### PR TITLE
Document + clean up enc_effects.c

### DIFF
--- a/include/enc_effects.h
+++ b/include/enc_effects.h
@@ -1,0 +1,27 @@
+#ifndef POKEPLATINUM_ENC_EFFECTS_H
+#define POKEPLATINUM_ENC_EFFECTS_H
+
+#include "overlay006/struct_ov6_02240D5C.h"
+
+/**
+ * Gets an identifier to be used for a particular cut-in effect applied to the
+ * game overlay whenever a battle starts. This effect is applied as a transition
+ * from the overworld view to the battle UI.
+ * 
+ * @param battleData
+ * @return An ID describing the graphical effect to apply as the battle starts.
+ */
+u32 EncEffects_GetCutInEffectForBattle(const UnkStruct_ov6_02240D5C * battleData);
+
+/**
+ * Gets an identifier pointing to a specific SEQ, which contains background
+ * music to be played whenever a battle is being conducted. This music
+ * starts playing after the battle begins, and will play during any
+ * graphical transition from the overworld view to the battle UI.
+ * 
+ * @param battleData 
+ * @return An ID pointing to a specific SEQ to be played during the battle.
+ */
+u32 EncEffects_GetBGMForBattle(const UnkStruct_ov6_02240D5C * battleData);
+
+#endif // POKEPLATINUM_ENC_EFFECTS_H

--- a/include/unk_02051B50.h
+++ b/include/unk_02051B50.h
@@ -1,9 +1,0 @@
-#ifndef POKEPLATINUM_UNK_02051B50_H
-#define POKEPLATINUM_UNK_02051B50_H
-
-#include "overlay006/struct_ov6_02240D5C.h"
-
-u32 sub_02051C00(const UnkStruct_ov6_02240D5C * param0);
-u32 sub_02051C10(const UnkStruct_ov6_02240D5C * param0);
-
-#endif // POKEPLATINUM_UNK_02051B50_H

--- a/main.lsf
+++ b/main.lsf
@@ -213,7 +213,7 @@ Static main
 	Object src/unk_020507CC.o
 	Object src/unk_020508D4.o
 	Object src/unk_02050A74.o
-	Object src/unk_02051B50.o
+	Object src/enc_effects.o
 	Object src/unk_02051D8C.o
 	Object src/unk_020528D0.o
 	Object src/unk_02052C6C.o

--- a/src/enc_effects.c
+++ b/src/enc_effects.c
@@ -326,9 +326,11 @@ static u32 EncEffects_GetEffectsForWildMon (Party * party, int zoneID)
     u32 monDexID = sub_02074470(enemyMon, 5, NULL);         // This gets the dex ID for a pokemon, 5 seems like a magic num?
 
     switch (monDexID) {
-        case 492:       return ENCFX_SHAYMIN;
-        case 488:       return ENCFX_CRESSELIA;
-        case 487:       return ENCFX_GIRATINA;
+        case 144:       // Articuno
+        case 145:       // Zapdos
+        case 146:       // Moltres
+            // Only use the special effects if this is outside the Pal Park
+            return (zoneID != PAL_PARK_ZONE_ID) ?  ENCFX_ARTICUNO_ZAPDOS_MOLTRES : ENCFX_GENERIC_POKEMON;
 
         case 377:       // Regirock
         case 378:       // Regice
@@ -336,28 +338,26 @@ static u32 EncEffects_GetEffectsForWildMon (Party * party, int zoneID)
             // Only use the special effects if this is outside the Pal Park
             return (zoneID != PAL_PARK_ZONE_ID) ? ENCFX_REGIROCK_REGICE_REGISTEEL : ENCFX_GENERIC_POKEMON;
         
-        case 486:       // Regigigas
-        case 485:       // Heatran
-        case 491:       // Darkrai
         case 479:       // Rotom
+        case 485:       // Heatran
+        case 486:       // Regigigas
+        case 491:       // Darkrai
             return ENCFX_REGIGIGAS_HEATRAN;
         
-        case 481:       return ENCFX_MESPRIT;
         case 480:       // Uxie
         case 482:       // Azelf
             return ENCFX_UXIE_AZELF;
+        case 481:       return ENCFX_MESPRIT;
+
         
         case 483:       // Dialga
         case 484:       // Palkia
             return ENCFX_DIALGA_PALKIA;
-        
-        case 493:       return ENCFX_ARCEUS;
 
-        case 144:       // Articuno
-        case 145:       // Zapdos
-        case 146:       // Moltres
-            // Only use the special effects if this is outside the Pal Park
-            return (zoneID != PAL_PARK_ZONE_ID) ?  ENCFX_ARTICUNO_ZAPDOS_MOLTRES : ENCFX_GENERIC_POKEMON;
+        case 487:       return ENCFX_GIRATINA;
+        case 488:       return ENCFX_CRESSELIA;
+        case 492:       return ENCFX_SHAYMIN;
+        case 493:       return ENCFX_ARCEUS;
         
         default:        return ENCFX_GENERIC_POKEMON;
     }

--- a/src/enc_effects.c
+++ b/src/enc_effects.c
@@ -170,7 +170,7 @@ static const EncEffectsDataPair ENCOUNTER_EFFECTS[ENCFX_NUM_ENTRIES] = {
 static u32 EncEffects_GetEffectsForTrainerClass(u32 param0);
 static u32 EncEffects_GetEffectsForWildMon(Party * param0, int param1);
 static u32 EncEffects_GetEffectsForBattle(const UnkStruct_ov6_02240D5C * param0);
-static u32 EncEffects_GetCutinFromEffects(u32 param0, const UnkStruct_ov6_02240D5C * param1);
+static u32 EncEffects_GetCutInFromEffects(u32 param0, const UnkStruct_ov6_02240D5C * param1);
 static u32 EncEffects_GetBGMFromEffects(u32 param0, const UnkStruct_ov6_02240D5C * param1);
 
 

--- a/src/enc_effects.c
+++ b/src/enc_effects.c
@@ -213,7 +213,9 @@ static u32 EncEffects_GetEffectsForBattle (const UnkStruct_ov6_02240D5C * battle
         // Checking for a double battle here introduces a bug: it implicitly
         // overrides the behavior for any given Special Trainer.
         // Suppose, for example, that the Gym Leader fight against Roark was
-        // a Double Battle. 
+        // a Double Battle. This check would catch that fight, and then the
+        // returned effect would be ENCFX_DOUBLE_BATTLE_TRAINER, instead
+        // of ENCFX_OREBURGH_GYM_LEADER.
         if (fightType & FIGHT_TYPE_DOUBLE) {
             if (encEffects == ENCFX_SUNYSHORE_GYM_LEADER) {
                 return ENCFX_DOUBLE_BATTLE_GYM_LEADER;

--- a/src/unk_02050A74.c
+++ b/src/unk_02050A74.c
@@ -31,7 +31,7 @@
 #include "unk_020507CC.h"
 #include "unk_020508D4.h"
 #include "unk_02050A74.h"
-#include "unk_02051B50.h"
+#include "enc_effects.h"
 #include "unk_02051D8C.h"
 #include "unk_020528D0.h"
 #include "unk_020530C8.h"
@@ -341,12 +341,12 @@ void sub_02050E10 (UnkStruct_0203CDB0 * param0, UnkStruct_ov6_02240D5C * param1)
     if (sub_0206AE5C(sub_020507E4(param0->unk_0C))) {
         UnkStruct_02050ACC * v0;
 
-        v0 = sub_02050ACC(param1, sub_02051C00(param1), sub_02051C10(param1), NULL);
+        v0 = sub_02050ACC(param1, EncEffects_GetCutInEffectForBattle(param1), EncEffects_GetBGMForBattle(param1), NULL);
         sub_02050904(param0, sub_02051074, v0);
     } else {
         UnkStruct_02050DD4 * v1;
 
-        v1 = sub_02050DD4(param1, sub_02051C00(param1), sub_02051C10(param1), NULL);
+        v1 = sub_02050DD4(param1, EncEffects_GetCutInEffectForBattle(param1), EncEffects_GetBGMForBattle(param1), NULL);
         sub_02050904(param0, sub_02050EE0, v1);
     }
 }
@@ -356,12 +356,12 @@ void sub_02050E78 (UnkStruct_0203CDB0 * param0, UnkStruct_020508D4 * param1, Unk
     if (sub_0206AE5C(sub_020507E4(param0->unk_0C))) {
         UnkStruct_02050ACC * v0;
 
-        v0 = sub_02050ACC(param2, sub_02051C00(param2), sub_02051C10(param2), NULL);
+        v0 = sub_02050ACC(param2, EncEffects_GetCutInEffectForBattle(param2), EncEffects_GetBGMForBattle(param2), NULL);
         sub_02050924(param1, sub_02051074, v0);
     } else {
         UnkStruct_02050DD4 * v1;
 
-        v1 = sub_02050DD4(param2, sub_02051C00(param2), sub_02051C10(param2), NULL);
+        v1 = sub_02050DD4(param2, EncEffects_GetCutInEffectForBattle(param2), EncEffects_GetBGMForBattle(param2), NULL);
         sub_02050924(param1, sub_02050EE0, v1);
     }
 }
@@ -548,7 +548,7 @@ void sub_0205120C (UnkStruct_020508D4 * param0, int * param1)
     ov6_02242034(v2, v1);
 
     sub_0202CF28(sub_0202CD88(v2->unk_0C), (1 + 6));
-    sub_02050C4C(param0, v1, sub_02051C00(v1), sub_02051C10(v1), param1);
+    sub_02050C4C(param0, v1, EncEffects_GetCutInEffectForBattle(v1), EncEffects_GetBGMForBattle(v1), param1);
 }
 
 void sub_02051270 (UnkStruct_020508D4 * param0, u16 param1, u8 param2, int * param3, BOOL param4)
@@ -570,7 +570,7 @@ void sub_02051270 (UnkStruct_020508D4 * param0, u16 param1, u8 param2, int * par
     }
 
     sub_0202CF28(sub_0202CD88(v2->unk_0C), (1 + 6));
-    sub_02050C4C(param0, v1, sub_02051C00(v1), sub_02051C10(v1), param3);
+    sub_02050C4C(param0, v1, EncEffects_GetCutInEffectForBattle(v1), EncEffects_GetBGMForBattle(v1), param3);
 }
 
 void sub_020512E4 (UnkStruct_020508D4 * param0, u16 param1, u8 param2, int * param3, BOOL param4)
@@ -599,7 +599,7 @@ void sub_020512E4 (UnkStruct_020508D4 * param0, u16 param1, u8 param2, int * par
     }
 
     sub_0202CF28(sub_0202CD88(v2->unk_0C), (1 + 6));
-    sub_02050C4C(param0, v1, sub_02051C00(v1), sub_02051C10(v1), param3);
+    sub_02050C4C(param0, v1, EncEffects_GetCutInEffectForBattle(v1), EncEffects_GetBGMForBattle(v1), param3);
 }
 
 static BOOL sub_0205136C (UnkStruct_020508D4 * param0)
@@ -661,7 +661,7 @@ void sub_02051450 (UnkStruct_0203CDB0 * param0, UnkStruct_ov6_02240D5C * param1)
 {
     UnkStruct_02050ACC * v0;
 
-    v0 = sub_02050ACC(param1, sub_02051C00(param1), sub_02051C10(param1), NULL);
+    v0 = sub_02050ACC(param1, EncEffects_GetCutInEffectForBattle(param1), EncEffects_GetBGMForBattle(param1), NULL);
     sub_02050904(param0, sub_0205136C, v0);
 }
 
@@ -683,7 +683,7 @@ void sub_02051480 (UnkStruct_020508D4 * param0, int param1, int param2, int * pa
 
     sub_02079170(v1, v2->unk_0C, param2);
     sub_0202CF28(sub_0202CD88(v2->unk_0C), (1 + 7));
-    sub_02050C4C(param0, v1, sub_02051C00(v1), sub_02051C10(v1), param3);
+    sub_02050C4C(param0, v1, EncEffects_GetCutInEffectForBattle(v1), EncEffects_GetBGMForBattle(v1), param3);
 }
 
 static BOOL sub_020514E8 (UnkStruct_020508D4 * param0)
@@ -734,7 +734,7 @@ void sub_02051590 (UnkStruct_020508D4 * param0)
     UnkStruct_0203CDB0 * v2 = sub_02050A60(param0);
 
     v1 = sub_02051F4C(11, v2);
-    v0 = sub_02050ACC(v1, sub_02051C00(v1), sub_02051C10(v1), NULL);
+    v0 = sub_02050ACC(v1, EncEffects_GetCutInEffectForBattle(v1), EncEffects_GetBGMForBattle(v1), NULL);
 
     sub_02050944(param0, sub_020514E8, v0);
 }
@@ -774,7 +774,7 @@ void sub_020515CC (UnkStruct_020508D4 * param0, int param1, int param2, int para
 
     sub_02079170(v2, v3->unk_0C, param4);
     sub_0202CF28(sub_0202CD88(v3->unk_0C), (1 + 7));
-    sub_02050C4C(param0, v2, sub_02051C00(v2), sub_02051C10(v2), param5);
+    sub_02050C4C(param0, v2, EncEffects_GetCutInEffectForBattle(v2), EncEffects_GetBGMForBattle(v2), param5);
 }
 
 void sub_0205167C (UnkStruct_020508D4 * param0, const u8 * param1, int param2)
@@ -786,7 +786,7 @@ void sub_0205167C (UnkStruct_020508D4 * param0, const u8 * param1, int param2)
     v2 = sub_02051D8C(11, param2);
     sub_020526CC(v2, v0, param1);
 
-    v1 = sub_02050ACC(v2, sub_02051C00(v2), sub_02051C10(v2), NULL);
+    v1 = sub_02050ACC(v2, EncEffects_GetCutInEffectForBattle(v2), EncEffects_GetBGMForBattle(v2), NULL);
     sub_02050944(param0, sub_02050CA8, v1);
 }
 
@@ -844,7 +844,7 @@ void sub_020516F4 (UnkStruct_020508D4 * param0, int param1, int param2, int para
 
     v2->unk_18A = v5;
 
-    v1 = sub_02050ACC(v2, sub_02051C00(v2), sub_02051C10(v2), NULL);
+    v1 = sub_02050ACC(v2, EncEffects_GetCutInEffectForBattle(v2), EncEffects_GetBGMForBattle(v2), NULL);
     v1->unk_0C = param1;
 
     sub_02050944(param0, sub_02050D4C, v1);
@@ -885,7 +885,7 @@ void sub_020517E8 (UnkStruct_0203CDB0 * param0, const u8 * param1, int param2)
     sub_0202F1F8(param0->unk_0C, 11, &v2);
 
     v1->unk_18A = sub_020516C8(param0->unk_B0, param2);
-    v0 = sub_02050ACC(v1, sub_02051C00(v1), sub_02051C10(v1), NULL);
+    v0 = sub_02050ACC(v1, EncEffects_GetCutInEffectForBattle(v1), EncEffects_GetBGMForBattle(v1), NULL);
 
     sub_02050904(param0, sub_02051790, v0);
 }
@@ -902,7 +902,7 @@ void sub_0205184C (UnkStruct_0203CDB0 * param0, const Party * param1, int param2
     sub_0202F1F8(param0->unk_0C, 11, &v2);
 
     v1->unk_18A = sub_020516C8(param0->unk_B0, param2);
-    v0 = sub_02050ACC(v1, sub_02051C00(v1), sub_02051C10(v1), NULL);
+    v0 = sub_02050ACC(v1, EncEffects_GetCutInEffectForBattle(v1), EncEffects_GetBGMForBattle(v1), NULL);
 
     sub_02050904(param0, sub_02051790, v0);
 }
@@ -1026,5 +1026,5 @@ void sub_02051ABC (UnkStruct_020508D4 * param0, u16 param1, u8 param2, int * par
     v1->unk_12C = 23;
 
     sub_0202CF28(sub_0202CD88(v2->unk_0C), (1 + 6));
-    sub_02050C4C(param0, v1, sub_02051C00(v1), sub_02051C10(v1), param3);
+    sub_02050C4C(param0, v1, EncEffects_GetCutInEffectForBattle(v1), EncEffects_GetBGMForBattle(v1), param3);
 }

--- a/src/unk_02051B50.c
+++ b/src/unk_02051B50.c
@@ -11,106 +11,232 @@
 #include "unk_02073C2C.h"
 #include "overlay005/ov5_021DDBE8.h"
 
-typedef struct {
-    u16 unk_00;
-    u16 unk_02;
-} UnkStruct_020EC208;
+// These should absolutely live somewhere else (eventually), but they're here for now
+// to reduce overall refactoring load and establish baseline readability.
+#define SEQ_BA_POKE         1116        // Battle Wild Pokemon
+#define SEQ_BA_GYM          1117        // Battle Gym Leader
+#define SEQ_BA_DPOKE1       1118        // Battle Lake Guardians (Uxie / Mesprit / Azelf)
+#define SEQ_BA_TRAIN        1119        // Battle Trainer
+#define SEQ_BA_AKAGI        1120        // Battle Cyrus
+#define SEQ_BA_DPOKE2       1121        // Battle Dialga / Palkia
+#define SEQ_BA_CHANP        1122        // Battle Champion
+#define SEQ_BA_GINGA        1123        // Battle Galactic Grunt
+#define SEQ_BA_RIVAL        1124        // Battle Rival
+#define SEQ_BA_SECRET1      1125        // Batlte Arceus
+#define SEQ_BA_SECRET2      1126        // Battle Legendary Birds, Rotom, Heatran, Regigigas, Darkrai
+#define SEQ_BA_GINGA3       1133        // Battle Galactic Commander
+#define SEQ_BA_TENNO        1136        // Battle Elite Four
+#define SEQ_PL_BA_GIRA      1201        // Battle Giratina
+#define SEQ_PL_BA_BRAIN     1202        // Battle Frontier Brain
+#define SEQ_PL_BA_REGI      1204        // Battle Regi trio (not Regigigas)
 
-static const UnkStruct_020EC208 Unk_020EC208[35] = {
-    {0xC, 0x45D},
-    {0xD, 0x45D},
-    {0xE, 0x45D},
-    {0xF, 0x45D},
-    {0x10, 0x45D},
-    {0x11, 0x45D},
-    {0x12, 0x45D},
-    {0x13, 0x45D},
-    {0x14, 0x470},
-    {0x15, 0x470},
-    {0x16, 0x470},
-    {0x17, 0x470},
-    {0x18, 0x462},
-    {0xffff, 0x464},
-    {0x19, 0x45C},
-    {0x1A, 0x461},
-    {0x1A, 0x45E},
-    {0xffff, 0x45E},
-    {0x1A, 0x465},
-    {0x19, 0x466},
-    {0xffff, 0x45C},
-    {0xffff, 0x466},
-    {0x19, 0x4B1},
-    {0x19, 0x4B4},
-    {0x1B, 0x463},
-    {0x1C, 0x46E},
-    {0x1C, 0x460},
-    {0x1D, 0x45F},
-    {0x1D, 0x45F},
-    {0x1E, 0x45F},
-    {0x1E, 0x45C},
-    {0x1D, 0x4B2},
-    {0x1E, 0x45D},
-    {0xffff, 0x45F},
-    {0xffff, 0x45C}
+// need to research why these start at 0x000C
+#define OREBURGH_GYM_ENC        0x000C      // Roark
+#define ETERNA_GYM_ENC          0x000D      // Gardenia
+#define PASTORIA_GYM_ENC        0x000E      // Crasher Wake
+#define VEILSTONE_GYM_ENC       0x000F      // Maylene
+#define HEARTHOME_GYM_ENC       0x0010      // Fantina
+#define SNOWPOINT_GYM_ENC       0x0011      // Candice
+#define CANALAVE_GYM_ENC        0x0012      // Byron
+#define SUNYSHORE_GYM_ENC       0x0013      // Volkner
+#define ELITE_FOUR_ENC_1        0x0014      // Aaron
+#define ELITE_FOUR_ENC_2        0x0015      // Bertha
+#define ELITE_FOUR_ENC_3        0x0016      // Flint
+#define ELITE_FOUR_ENC_4        0x0017      // Lucian
+#define CHAMPION_ENC            0x0018      // Cynthia
+#define LEGENDARY_POKE_ENC_1    0x0019      // Roamers, Heatran, Regigigas, Darkrai, Shaymin
+#define LEGENDARY_POKE_ENC_2    0x001A      // Dialga, Palkia, Lake Guardians, Arceus
+#define GALACTIC_GRUNT_ENC      0x001B      // Grunts
+#define GALACTIC_LEADER_ENC     0x001C      // Mars, Jupiter, Saturn, Cyrus
+#define FRONTIER_ENC            0x001D      // Frontier / Wi-Fi Battles
+#define DOUBLE_ENC              0x001E      // 2v2s, wild battles with partner
+#define CATCHALL_ENC            0xFFFF      // catch-all?
+
+typedef struct {
+    u16 cutinVFX;
+    u16 bgmSEQID;
+} EncEffectsDataPair;
+
+enum {
+    // Gym Leaders
+    ENCFX_OREBURGH_GYM_LEADER,
+    ENCFX_ETERNA_GYM_LEADER,
+    ENCFX_PASTORIA_GYM_LEADER,
+    ENCFX_VEILSTONE_GYM_LEADER,
+    ENCFX_HEARTHOME_GYM_LEADER,
+    ENCFX_SNOWPOINT_GYM_LEADER,
+    ENCFX_CANALAVE_GYM_LEADER,
+    ENCFX_SUNYSHORE_GYM_LEADER,
+
+    // Elite Four
+    ENCFX_ELITE_FOUR_1,
+    ENCFX_ELITE_FOUR_2,
+    ENCFX_ELITE_FOUR_3,
+    ENCFX_ELITE_FOUR_4,
+
+    // Champion
+    ENCFX_CHAMPION,
+
+    // Rival
+    ENCFX_RIVAL,
+
+    // Legendary Pokemon
+    ENCFX_SHAYMIN,
+    ENCFX_DIALGA_PALKIA,
+    ENCFX_UXIE_AZELF,
+    ENCFX_MESPRIT,
+    ENCFX_ARCEUS,
+    ENCFX_REGIGIGAS_HEATRAN,
+    ENCFX_CRESSELIA,
+    ENCFX_ARTICUNO_ZAPDOS_MOLTRES,
+    ENCFX_GIRATINA,
+    ENCFX_REGIROCK_REGICE_REGISTEEL,
+
+    // Team Galactic
+    ENCFX_GALACTIC_GRUNT,
+    ENCFX_GALACTIC_COMMANDER,
+    ENCFX_GALACTIC_LEADER,
+
+    // Other Special Trainers
+    ENCFX_FRONTIER_TRAINER,
+    ENCFX_LINK_WIFI_BATTLE,
+    ENCFX_DOUBLE_BATTLE_TRAINER,
+    ENCFX_DOUBLE_BATTLE_POKEMON,
+    ENCFX_FRONTIER_BRAIN,
+    ENCFX_DOUBLE_BATTLE_GYM_LEADER,
+
+    // Generic Trainers and Pokemon
+    ENCFX_GENERIC_TRAINER,
+    ENCFX_GENERIC_POKEMON,
+
+    ENCFX_NUM_ENTRIES
 };
 
-static u32 sub_02051C20(u32 param0);
-static u32 sub_02051CD0(Party * param0, int param1);
-static u32 sub_02051B50(const UnkStruct_ov6_02240D5C * param0);
+static const EncEffectsPair Unk_020EC208[ENCFX_NUM_ENTRIES] = {
+    // Gym leaders
+    {OREBURGH_GYM_ENC,      SEQ_BA_GYM},            // Roark
+    {ETERNA_GYM_ENC,        SEQ_BA_GYM},            // Gardenia
+    {PASTORIA_GYM_ENC,      SEQ_BA_GYM},            // Crasher Wake
+    {VEILSTONE_GYM_ENC,     SEQ_BA_GYM},            // Maylene
+    {HEARTHOME_GYM_ENC,     SEQ_BA_GYM},            // Fantina
+    {SNOWPOINT_GYM_ENC,     SEQ_BA_GYM},            // Candice
+    {CANALAVE_GYM_ENC,      SEQ_BA_GYM},            // Byron
+    {SUNYSHORE_GYM_ENC,     SEQ_BA_GYM},            // Volkner
+
+    // Elite four
+    {ELITE_FOUR_ENC_1,      SEQ_BA_TENNO},          // Aaron
+    {ELITE_FOUR_ENC_2,      SEQ_BA_TENNO},          // Bertha
+    {ELITE_FOUR_ENC_3,      SEQ_BA_TENNO},          // Flint
+    {ELITE_FOUR_ENC_4,      SEQ_BA_TENNO},          // Lucian
+
+    // Champion
+    {CHAMPION_ENC,          SEQ_BA_CHANP},          // Champion (Cynthia)
+
+    // Rival
+    {CATCHALL_ENC,          SEQ_BA_RIVAL},          // Rival (Barry/Cedric)
+    
+    // Legendary Pokemon
+    {LEGENDARY_POKE_ENC_1,  SEQ_BA_POKE},           // Shaymin
+    {LEGENDARY_POKE_ENC_2,  SEQ_BA_DPOKE2},         // Dialga, Palkia
+    {LEGENDARY_POKE_ENC_2,  SEQ_BA_DPOKE1},         // Uxie, Azelf
+    {CATCHALL_ENC,          SEQ_BA_DPOKE1},         // Mesprit (roaming)
+    {LEGENDARY_POKE_ENC_2,  SEQ_BA_SECRET1},        // Arceus
+    {LEGENDARY_POKE_ENC_1,  SEQ_BA_SECRET2},        // Regigigas, Heatran
+    {CATCHALL_ENC,          SEQ_BA_POKE},           // Cresselia (roaming)
+    {CATCHALL_ENC,          SEQ_BA_SECRET2},        // Articuno, Zapdos, Moltres (roaming)
+    {LEGENDARY_POKE_ENC_1,  SEQ_PL_BA_GIRA},        // Giratina
+    {LEGENDARY_POKE_ENC_1,  SEQ_PL_BA_REGI},        // Regirock, Regice, Registeel
+
+    // Team Galactic
+    {GALACTIC_GRUNT_ENC,    SEQ_BA_GINGA},          // Grunts
+    {GALACTIC_LEADER_ENC,   SEQ_BA_GINGA3},         // Commanders (Mars, Jupiter, Saturn)
+    {GALACTIC_LEADER_ENC,   SEQ_BA_AKAGI},          // Cyrus
+
+    // Other special encounter types
+    {FRONTIER_ENC,          SEQ_BA_TRAIN},          // Frontier trainers
+    {FRONTIER_ENC,          SEQ_BA_TRAIN},          // Link/Wi-Fi battles
+    {DOUBLE_ENC,            SEQ_BA_TRAIN},          // Double-battle against a trainer
+    {DOUBLE_ENC,            SEQ_BA_POKE},           // Wild encounters with a partner NPC
+    {FRONTIER_ENC,          SEQ_PL_BA_BRAIN},       // Frontier Brains (Palmer, Thorton, Argenta, Dahlia, Darach)
+    {DOUBLE_ENC,            SEQ_BA_GYM},            // Double-battle against a gym leader (Volkner+Flint, specifically)
+
+    // All other encounters
+    {CATCHALL_ENC,          SEQ_BA_TRAIN},          // Generic trainer
+    {CATCHALL_ENC,          SEQ_BA_POKE}            // Generic wild Pokemon
+};
+
+static u32 EncEffects_GetEffectsForTrainerClass(u32 param0);
+static u32 EncEffects_GetEffectsForWildMon(Party * param0, int param1);
+static u32 EncEffects_GetEffectsForBattle(const UnkStruct_ov6_02240D5C * param0);
 static u32 sub_02051BBC(u32 param0, const UnkStruct_ov6_02240D5C * param1);
 static u32 sub_02051BE8(u32 param0, const UnkStruct_ov6_02240D5C * param1);
 
-static u32 sub_02051B50 (const UnkStruct_ov6_02240D5C * param0)
+
+// Fight type flag definitions
+// The fight type structure is a sequence of bits that tell us stuff
+// about the encounter
+#define FIGHT_TYPE_POKEMON           0      // bit 1 off -> this is a fight against a Pokemon
+#define FIGHT_TYPE_TRAINER           1      // bit 1 on -> this is a fight against a trainer
+#define FIGHT_TYPE_DOUBLE       1 << 1      // bit 2 on -> this is a 2vs2 battle
+#define FIGHT_TYPE_LINK         1 << 2      // bit 3 on -> this is a link battle (or a wi-fi battle)
+#define FIGHT_TYPE_FRONTIER     1 << 7      // bit 8 on -> this is a fight in the battle frontier
+
+static u32 EncEffects_GetEffectsForBattle (const UnkStruct_ov6_02240D5C * battleData)
 {
-    u32 v0 = param0->unk_00;
-    u32 v1;
-    u32 v2;
+    u32 fightType = battleData->unk_00;
+    u32 encEffects;
 
-    if ((v0 & 0x1)) {
-        v1 = sub_02051C20(param0->unk_28[1].unk_01);
+    if (fightType & FIGHT_TYPE_TRAINER) {
+        encEffects = EncEffects_GetEffectsForTrainerClass(battleData->unk_28[1].unk_01);
 
-        if (v0 & 0x80) {
-            if (v1 == 31) {
-                return v1;
+        if (fightType & FIGHT_TYPE_FRONTIER) {
+            if (encEffects == ENCFX_FRONTIER_BRAIN) {
+                return encEffects;
             }
 
-            if (v0 & 0x2) {
-                return 29;
+            if (fightType & FIGHT_TYPE_DOUBLE) {
+                return ENCFX_DOUBLE_BATTLE_TRAINER;
             }
 
-            return 27;
+            return ENCFX_FRONTIER_TRAINER;
         }
 
-        if ((v1 == 24) || (v1 == 25) || (v1 == 26)) {
-            return v1;
+        if ((encEffects == ENCFX_GALACTIC_GRUNT) || 
+            (encEffects == ENCFX_GALACTIC_COMMANDER) || 
+            (encEffects == ENCFX_GALACTIC_LEADER)  ) {
+            return encEffects;
         }
 
-        if (v0 & 0x2) {
-            if (v1 == 7) {
-                return 32;
+        // Checking for a double battle here introduces a bug: it implicitly
+        // overrides the behavior for any given Special Trainer.
+        // Suppose, for example, that the Gym Leader fight against Roark was
+        // a Double Battle. 
+        if (fightType & FIGHT_TYPE_DOUBLE) {
+            if (encEffects == ENCFX_SUNYSHORE_GYM_LEADER) {
+                return ENCFX_DOUBLE_BATTLE_GYM_LEADER;
             }
 
-            return 29;
+            return ENCFX_DOUBLE_BATTLE_TRAINER;
         }
 
-        if (v0 & 0x4) {
-            return 28;
+        if (fightType & FIGHT_TYPE_LINK) {
+            return ENCFX_LINK_WIFI_BATTLE;
         }
 
-        return v1;
+        return encEffects;
     }
 
-    v2 = sub_02051CD0(param0->unk_04[1], param0->unk_134);
+    encEffects = EncEffects_GetEffectsForWildMon(battleData->unk_04[1], battleData->unk_134);
 
-    if (v2 < 34) {
-        return v2;
+    if (encEffects < 34) {
+        return encEffects;
     }
 
     if (v0 & 0x2) {
         return 30;
     }
 
-    return v2;
+    return encEffects;
 }
 
 static u32 sub_02051BBC (u32 param0, const UnkStruct_ov6_02240D5C * param1)
@@ -134,7 +260,7 @@ u32 sub_02051C00 (const UnkStruct_ov6_02240D5C * param0)
 {
     u32 v0;
 
-    v0 = sub_02051B50(param0);
+    v0 = EncEffects_GetEffectsForBattle(param0);
     return sub_02051BBC(v0, param0);
 }
 
@@ -142,84 +268,56 @@ u32 sub_02051C10 (const UnkStruct_ov6_02240D5C * param0)
 {
     u32 v0;
 
-    v0 = sub_02051B50(param0);
+    v0 = EncEffects_GetEffectsForBattle(param0);
     return sub_02051BE8(v0, param0);
 }
 
-static u32 sub_02051C20 (u32 param0)
+static u32 EncEffects_GetEffectsForTrainerClass (u32 trainerClass)
 {
-    u32 v0 = 33;
+    switch (trainerClass) {
+        // Gym leaders
+        case 62:    return ENCFX_OREBURGH_GYM_LEADER;   // Roark
+        case 74:    return ENCFX_ETERNA_GYM_LEADER;     // Gardenia      
+        case 75:    return ENCFX_PASTORIA_GYM_LEADER;   // Crasher Wake
+        case 76:    return ENCFX_VEILSTONE_GYM_LEADER;  // Maylene
+        case 77:    return ENCFX_HEARTHOME_GYM_LEADER;  // Fantina
+        case 78:    return ENCFX_SNOWPOINT_GYM_LEADER;  // Candice
+        case 64:    return ENCFX_CANALAVE_GYM_LEADER;   // Byron
+        case 79:    return ENCFX_SUNYSHORE_GYM_LEADER;  // Volkner
 
-    switch (param0) {
-    case 62:
-        v0 = 0;
-        break;
-    case 74:
-        v0 = 1;
-        break;
-    case 75:
-        v0 = 2;
-        break;
-    case 76:
-        v0 = 3;
-        break;
-    case 77:
-        v0 = 4;
-        break;
-    case 78:
-        v0 = 5;
-        break;
-    case 64:
-        v0 = 6;
-        break;
-    case 79:
-        v0 = 7;
-        break;
-    case 65:
-        v0 = 8;
-        break;
-    case 66:
-        v0 = 9;
-        break;
-    case 67:
-        v0 = 10;
-        break;
-    case 68:
-        v0 = 11;
-        break;
-    case 69:
-        v0 = 12;
-        break;
-    case 63:
-        v0 = 13;
-        break;
-    case 86:
-        v0 = 26;
-        break;
-    case 72:
-    case 87:
-    case 88:
-        v0 = 25;
-        break;
-    case 73:
-    case 89:
-        v0 = 24;
-        break;
-    case 97:
-    case 99:
-    case 100:
-    case 101:
-    case 102:
-        v0 = 31;
-        break;
-    default:
-        break;
+        // Elite Four
+        case 65:    return ENCFX_ELITE_FOUR_1;          // Aaron
+        case 66:    return ENCFX_ELITE_FOUR_2;          // Bertha
+        case 67:    return ENCFX_ELITE_FOUR_3;          // Flint
+        case 68:    return ENCFX_ELITE_FOUR_4;          // Lucian
+
+        // Champion
+        case 69:    return ENCFX_CHAMPION;              // Cynthia
+
+        // Rival
+        case 63:    return ENCFX_RIVAL;                 // Barry/Cedric
+
+        // Team Galactic
+        case 73:    return ENCFX_GALACTIC_GRUNT;        // Grunt (Male)
+        case 89:    return ENCFX_GALACTIC_GRUNT;        // Grunt (Female)
+        case 72:    return ENCFX_GALACTIC_COMMANDER;    // Mars
+        case 87:    return ENCFX_GALACTIC_COMMANDER;    // Jupiter
+        case 88:    return ENCFX_GALACTIC_COMMANDER;    // Saturn
+        case 86:    return ENCFX_GALACTIC_LEADER;       // Cyrus
+
+        // Frontier Brains
+        case 97:    return ENCFX_FRONTIER_BRAIN;        // Palmer
+        case 99:    return ENCFX_FRONTIER_BRAIN;        // Argenta
+        case 100:   return ENCFX_FRONTIER_BRAIN;        // Thorton
+        case 101:   return ENCFX_FRONTIER_BRAIN;        // Dahlia
+        case 102:   return ENCFX_FRONTIER_BRAIN;        // Darach
+
+        // All other trainers
+        default:    return ENCFX_GENERIC_TRAINER;
     }
-
-    return v0;
 }
 
-static u32 sub_02051CD0 (Party * param0, int param1)
+static u32 EncEffects_GetEffectsForWildMon (Party * param0, int param1)
 {
     UnkStruct_02073C74 * v0;
     u32 v1;


### PR DESCRIPTION
[External research](https://gist.github.com/lhearachel/ade4bad51d4836247b9310f137a56abd) (tooting my own horn a bit)

## Renamed Files

* `include/unk_02051B50.h` -> `include/enc_effects.h`
* `src/unk_02051B50.c` -> `src/enc_effects.c`

## Renamed Structs and Fields

* `UnkStruct_020EC208` -> `EncEffectsDataPair`
* `UnkStruct_020EC208::unk_00` -> `EncEffectsDataPair::cutinVFX`
* `UnkStruct_020EC208::unk_02` -> `EncEffectsDataPair::bgmSEQID`

## Renamed Functions

* `sub_02051C00` -> `EncEffects_GetCutInEffectForBattle`
* `sub_02051C10` -> `EncEffects_GetBGMForBattle`
* `sub_02051C20` -> `EncEffects_GetEffectsForTrainerClass`
* `sub_02051CD0` -> `EncEffects_GetEffectsForWildMon`
* `sub_02051B50` -> `EncEffects_GetEffectsForBattle`
* `sub_02051BBC` -> `EncEffects_GetCutinFromEffects`
* `sub_02051BE8` -> `EncEffects_GetBGMFromEffects`

## New Enums and Typedefs

None named/exported.