### PR TITLE
Hardcode -std=c++17 for knarc

### DIFF
--- a/tools/knarc/meson.build
+++ b/tools/knarc/meson.build
@@ -10,6 +10,7 @@ cpp_scrs = [
 ]
 
 knarc_exe = executable('knarc',
+    cpp_args: '-std=c++17',
     sources: [
         c_srcs,
         cpp_scrs


### PR DESCRIPTION
Needed to be able to build knarc with older versions of g++

Ideally, the standard should be set in default_options, but since knarc is not its own project, this would conflict with the c++ standard for game code (if and when we port the c++ libs). So for now we have to hardcode it in knarc's `cpp_args.`