### PR TITLE
Reorganize rsf asset listing

### DIFF
--- a/platinum.us/rom.rsf
+++ b/platinum.us/rom.rsf
@@ -216,7 +216,13 @@ RomSpec
 	File wazaeffect/effectclact/wecellanm.narc
 	File wazaeffect/effectclact/wechar.narc
 	File wazaeffect/effectclact/wepltt.narc
-	File poketool/waza/pl_waza_tbl.narc
+
+	Root /poketool/waza
+	HostRoot res/moves
+	File pl_waza_tbl.narc
+
+	Root /
+	HostRoot res
 	File poketool/waza/waza_tbl.narc
 	File fielddata/script/scr_seq.narc
 	File graphic/bag_gra.narc

--- a/res/moves/meson.build
+++ b/res/moves/meson.build
@@ -484,7 +484,7 @@ pl_waza_tbl_narc = custom_target('pl_waza_tbl.narc',
         movedata_py,
         '--knarc', knarc_exe,
         '--source-dir', '@CURRENT_SOURCE_DIR@',
-        '--output-dir', '@BUILD_ROOT@' / 'res' / 'poketool' / 'waza',
+        '--output-dir', '@OUTDIR@',
     ]
 )
 


### PR DESCRIPTION
Meson expects the output of a build target to be in the same directory layout as its source files, relative to the build directory.  However, #46 outputs `pl_waza_tbl.narc` in the path that mirrors the one in the final ROM, causing it to get rebuilt on every run as the build system does not find it.

This PR builds `pl_waza_tbl.narc`  in the correct directory, and uses the rsf file to specify its path in the ROM. The aim is also to reorganize the whole files section in the rsf for clarity.