### PR TITLE
Move flag-related function declarations out of pokemon.h

### DIFF
--- a/include/flags.h
+++ b/include/flags.h
@@ -1,0 +1,20 @@
+#ifndef POKEPLATINUM_FLAGS_H
+#define POKEPLATINUM_FLAGS_H
+
+/**
+ * @brief Gets a bitmask with a single bit set at the specified index.
+ * 
+ * @param index 
+ * @return A bitmask with a single bit set at the specified index.
+ */
+u32 FlagIndex(int index);
+
+/**
+ * @brief Gets the index of the lowest set bit of the given number
+ * 
+ * @param num 
+ * @return The index of the lowest set bit of the given number 
+ */
+int LowestBit(u32 num);
+
+#endif // POKEPLATINUM_FLAGS_H

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -847,22 +847,6 @@ void Pokemon_CalcAbility(Pokemon *mon);
 
 void sub_020780C4(Pokemon *mon, u32 monPersonality);
 
-/**
- * @brief Gets a bitmask with a single bit set at the specified index.
- * 
- * @param index 
- * @return A bitmask with a single bit set at the specified index.
- */
-u32 NumToFlag(int index);
-
-/**
- * @brief Gets the index of the lowest set bit of the given number
- * 
- * @param num 
- * @return The index of the lowest set bit of the given number 
- */
-int FlagToNum(u32 num);
-
 BOOL sub_02078804(u16 param0);
 u16 sub_02078824(u8 index);
 BOOL sub_02078838(Pokemon *mon);

--- a/src/overlay014/ov14_0221FC20.c
+++ b/src/overlay014/ov14_0221FC20.c
@@ -13,6 +13,7 @@
 #include "battle/ai_context.h"
 #include "battle/battle_context.h"
 
+#include "flags.h"
 #include "pokemon.h"
 #include "party.h"
 #include "overlay014/ov14_0221FC20.h"
@@ -327,7 +328,7 @@ void ov14_0221FC20 (BattleSystem * param0, BattleContext * param1, u8 param2, u8
     v1 = BattleSystem_CheckStruggling(param0, param1, param2, 0, 0xffffffff);
 
     for (v0 = 0; v0 < LEARNED_MOVES_MAX; v0++) {
-        if (v1 & NumToFlag(v0)) {
+        if (v1 & FlagIndex(v0)) {
             param1->aiContext.moveCurPP[v0] = 0;
         }
 
@@ -2697,7 +2698,7 @@ static void ov14_022227A4 (BattleSystem * param0, BattleContext * param1)
 
     v2 = ov14_02222D34(param1, v0);
 
-    if (param1->battlersSwitchingMask & NumToFlag(v2)) {
+    if (param1->battlersSwitchingMask & FlagIndex(v2)) {
         ov14_02222D24(param1, v1);
     }
 }
@@ -2718,7 +2719,7 @@ static void ov14_022227F4 (BattleSystem * param0, BattleContext * param1)
 
     v2 = ov14_02222D34(param1, v0);
 
-    if ((param1->battlersSwitchingMask & NumToFlag(v2)) == 0) {
+    if ((param1->battlersSwitchingMask & FlagIndex(v2)) == 0) {
         ov14_02222D24(param1, v1);
     }
 }
@@ -3605,7 +3606,7 @@ static BOOL ov14_02223B34 (BattleSystem * param0, BattleContext * param1, int pa
     v3 = BattleSystem_BattlerSlot(param0, param2) ^ 1;
     v2 = ov16_0223E1C4(param0, v3);
 
-    if ((param1->battlersSwitchingMask & NumToFlag(v2)) == 0) {
+    if ((param1->battlersSwitchingMask & FlagIndex(v2)) == 0) {
         for (v0 = 0; v0 < 4; v0++) {
             v4 = param1->battleMons[param2].moves[v0];
             v5 = ov14_0222327C(param0, param1, param2, v4);
@@ -3633,7 +3634,7 @@ static BOOL ov14_02223B34 (BattleSystem * param0, BattleContext * param1, int pa
 
     v2 = BattleSystem_Partner(param0, v2);
 
-    if ((param1->battlersSwitchingMask & NumToFlag(v2)) == 0) {
+    if ((param1->battlersSwitchingMask & FlagIndex(v2)) == 0) {
         for (v0 = 0; v0 < 4; v0++) {
             v4 = param1->battleMons[param2].moves[v0];
             v5 = ov14_0222327C(param0, param1, param2, v4);
@@ -4019,37 +4020,37 @@ BOOL ov14_022244B0 (BattleSystem * param0, int param1)
                 }
             } else if (ov16_0225B0FC(v8, v2, 15)) {
                 if (v8->battleMons[param1].status & 0x7) {
-                    v8->aiContext.usedItemCondition[param1 >> 1] |= NumToFlag(5);
+                    v8->aiContext.usedItemCondition[param1 >> 1] |= FlagIndex(5);
                     v8->aiContext.usedItemType[param1 >> 1] = 2;
                     v4 = 1;
                 }
             } else if (ov16_0225B0FC(v8, v2, 16)) {
                 if ((v8->battleMons[param1].status & 0x8) || (v8->battleMons[param1].status & 0x80)) {
-                    v8->aiContext.usedItemCondition[param1 >> 1] |= NumToFlag(4);
+                    v8->aiContext.usedItemCondition[param1 >> 1] |= FlagIndex(4);
                     v8->aiContext.usedItemType[param1 >> 1] = 2;
                     v4 = 1;
                 }
             } else if (ov16_0225B0FC(v8, v2, 17)) {
                 if (v8->battleMons[param1].status & 0x10) {
-                    v8->aiContext.usedItemCondition[param1 >> 1] |= NumToFlag(3);
+                    v8->aiContext.usedItemCondition[param1 >> 1] |= FlagIndex(3);
                     v8->aiContext.usedItemType[param1 >> 1] = 2;
                     v4 = 1;
                 }
             } else if (ov16_0225B0FC(v8, v2, 18)) {
                 if (v8->battleMons[param1].status & 0x20) {
-                    v8->aiContext.usedItemCondition[param1 >> 1] |= NumToFlag(2);
+                    v8->aiContext.usedItemCondition[param1 >> 1] |= FlagIndex(2);
                     v8->aiContext.usedItemType[param1 >> 1] = 2;
                     v4 = 1;
                 }
             } else if (ov16_0225B0FC(v8, v2, 19)) {
                 if (v8->battleMons[param1].status & 0x40) {
-                    v8->aiContext.usedItemCondition[param1 >> 1] |= NumToFlag(1);
+                    v8->aiContext.usedItemCondition[param1 >> 1] |= FlagIndex(1);
                     v8->aiContext.usedItemType[param1 >> 1] = 2;
                     v4 = 1;
                 }
             } else if (ov16_0225B0FC(v8, v2, 20)) {
                 if (v8->battleMons[param1].statusVolatile & 0x7) {
-                    v8->aiContext.usedItemCondition[param1 >> 1] |= NumToFlag(0);
+                    v8->aiContext.usedItemCondition[param1 >> 1] |= FlagIndex(0);
                     v8->aiContext.usedItemType[param1 >> 1] = 2;
                     v4 = 1;
                 }

--- a/src/overlay016/battle_controller.c
+++ b/src/overlay016/battle_controller.c
@@ -40,6 +40,7 @@
 #include "party.h"
 #include "item.h"
 #include "unk_0207D3B8.h"
+#include "flags.h"
 #include "overlay016/ov16_0223B140.h"
 #include "overlay016/ov16_0223DF00.h"
 #include "overlay016/ov16_022405FC.h"
@@ -372,7 +373,7 @@ static void BattleController_CommandSelectionInput(BattleSystem *battleSys, Batt
                 break;
             }
 
-            if (battleCtx->battlersSwitchingMask & NumToFlag(i)) {
+            if (battleCtx->battlersSwitchingMask & FlagIndex(i)) {
                 battleCtx->curCommandState[i] = COMMAND_SELECTION_WAIT;
                 battleCtx->battlerActions[i][BATTLE_ACTION_PICK_COMMAND] = BATTLE_CONTROL_AFTER_MOVE;
                 break;
@@ -863,7 +864,7 @@ static void BattleController_CheckPreMoveActions(BattleSystem *battleSys, Battle
             while (battleCtx->turnStartCheckTemp < maxBattlers) {
                 battler = battleCtx->battlerActionOrder[battleCtx->turnStartCheckTemp];
 
-                if (battleCtx->battlersSwitchingMask & NumToFlag(battler)) {
+                if (battleCtx->battlersSwitchingMask & FlagIndex(battler)) {
                     battleCtx->turnStartCheckTemp++;
                     continue;
                 }
@@ -1352,7 +1353,7 @@ static void BattleController_CheckMonConditions(BattleSystem *battleSys, BattleC
     while (battleCtx->monConditionCheckTemp < maxBattlers) {
         battler = battleCtx->monSpeedOrder[battleCtx->monConditionCheckTemp];
 
-        if (battleCtx->battlersSwitchingMask & NumToFlag(battler)) {
+        if (battleCtx->battlersSwitchingMask & FlagIndex(battler)) {
             battleCtx->monConditionCheckTemp++;
             continue;
         }
@@ -1576,13 +1577,13 @@ static void BattleController_CheckMonConditions(BattleSystem *battleSys, BattleC
                 if (BattleContext_MoveFailed(battleCtx, battler)) {
                     i = BATTLE_SUBSEQ_UPROAR_END;
                     battleCtx->battleMons[battler].statusVolatile &= ~VOLATILE_CONDITION_UPROAR;
-                    battleCtx->fieldConditionsMask &= ((NumToFlag(battler) << FIELD_CONDITION_UPROAR_SHIFT) ^ 0xFFFFFFFF);
+                    battleCtx->fieldConditionsMask &= ((FlagIndex(battler) << FIELD_CONDITION_UPROAR_SHIFT) ^ 0xFFFFFFFF);
                 } else if (battleCtx->battleMons[battler].statusVolatile & VOLATILE_CONDITION_UPROAR) {
                     i = BATTLE_SUBSEQ_UPROAR_CONTINUES;
                 } else {
                     i = BATTLE_SUBSEQ_UPROAR_END;
                     battleCtx->battleMons[battler].statusVolatile &= ~VOLATILE_CONDITION_UPROAR;
-                    battleCtx->fieldConditionsMask &= ((NumToFlag(battler) << FIELD_CONDITION_UPROAR_SHIFT) ^ 0xFFFFFFFF);
+                    battleCtx->fieldConditionsMask &= ((FlagIndex(battler) << FIELD_CONDITION_UPROAR_SHIFT) ^ 0xFFFFFFFF);
                 }
 
                 battleCtx->msgBattlerTemp = battler;
@@ -1809,7 +1810,7 @@ static void BattleController_CheckSideConditions(BattleSystem *battleSys, Battle
     case SIDE_COND_CHECK_FUTURE_SIGHT:
         while (battleCtx->sideConditionCheckTemp < maxBattlers) {
             battler = battleCtx->monSpeedOrder[battleCtx->sideConditionCheckTemp];
-            if (battleCtx->battlersSwitchingMask & NumToFlag(battler)) {
+            if (battleCtx->battlersSwitchingMask & FlagIndex(battler)) {
                 battleCtx->sideConditionCheckTemp++;
                 continue;
             }
@@ -1840,7 +1841,7 @@ static void BattleController_CheckSideConditions(BattleSystem *battleSys, Battle
     case SIDE_COND_CHECK_PERISH_SONG:
         while (battleCtx->sideConditionCheckTemp < maxBattlers) {
             battler = battleCtx->monSpeedOrder[battleCtx->sideConditionCheckTemp];
-            if (battleCtx->battlersSwitchingMask & NumToFlag(battler)) {
+            if (battleCtx->battlersSwitchingMask & FlagIndex(battler)) {
                 battleCtx->sideConditionCheckTemp++;
                 continue;
             }
@@ -1968,7 +1969,7 @@ static void BattleController_ItemCommand(BattleSystem *battleSys, BattleContext 
                     && (battleCtx->aiContext.usedItemCondition[battleCtx->attacker >> 1] & ITEM_RECOVER_FULL)) {
                 battleCtx->msgTemp = 6;
             } else {
-                battleCtx->msgTemp = FlagToNum(battleCtx->aiContext.usedItemCondition[battleCtx->attacker >> 1]);
+                battleCtx->msgTemp = LowestBit(battleCtx->aiContext.usedItemCondition[battleCtx->attacker >> 1]);
             }
 
             nextScript = BATTLE_SUBSEQ_USE_STATUS_RECOVERY;
@@ -2203,7 +2204,7 @@ static int ov16_0224E13C (BattleSystem * param0, BattleContext * param1, int * p
     v0 = ((BattleSystem_RandNext(param0) & 0xff) * (param1->battleMons[param1->attacker].level + v3)) >> 8;
 
     if (v0 < v3) {
-        v0 = BattleSystem_CheckStruggling(param0, param1, param1->attacker, NumToFlag(param1->moveSlot[param1->attacker]), 0xffffffff);
+        v0 = BattleSystem_CheckStruggling(param0, param1, param1->attacker, FlagIndex(param1->moveSlot[param1->attacker]), 0xffffffff);
 
         if (v0 == 0xf) {
             param2[0] = (0 + 255);
@@ -2212,7 +2213,7 @@ static int ov16_0224E13C (BattleSystem * param0, BattleContext * param1, int * p
 
         do {
             v1 = BattleSystem_RandNext(param0) & 3;
-        } while (v0 & NumToFlag(v1));
+        } while (v0 & FlagIndex(v1));
 
         param1->moveSlot[param1->attacker] = v1;
         param1->moveTemp = param1->battleMons[param1->attacker].moves[param1->moveSlot[param1->attacker]];
@@ -2308,7 +2309,7 @@ static BOOL ov16_0224E458 (BattleSystem * param0, BattleContext * param1)
         } else {
             param1->moveStatusFlags |= 0x200;
         }
-    } else if ((param1->battleMons[param1->attacker].ppCur[v1] == 0) && ((param1->battleStatusMask & 0x200) == 0) && ((param1->battleMons[param1->attacker].statusVolatile & 0x1000) == 0) && ((param1->battleMons[param1->attacker].statusVolatile & 0xc00) == 0) && ((param1->fieldConditionsMask & (NumToFlag(param1->attacker) << 8)) == 0) && (v1 < 4)) {
+    } else if ((param1->battleMons[param1->attacker].ppCur[v1] == 0) && ((param1->battleStatusMask & 0x200) == 0) && ((param1->battleMons[param1->attacker].statusVolatile & 0x1000) == 0) && ((param1->battleMons[param1->attacker].statusVolatile & 0xc00) == 0) && ((param1->fieldConditionsMask & (FlagIndex(param1->attacker) << 8)) == 0) && (v1 < 4)) {
         param1->moveStatusFlags |= 0x200;
     }
 
@@ -2581,7 +2582,7 @@ static BOOL ov16_0224E784 (BattleSystem * param0, BattleContext * param1)
             break;
         case 13:
             if (param1->battleMons[param1->attacker].statusVolatile & 0xf0000) {
-                param1->msgBattlerTemp = FlagToNum((param1->battleMons[param1->attacker].statusVolatile & 0xf0000) >> 16);
+                param1->msgBattlerTemp = LowestBit((param1->battleMons[param1->attacker].statusVolatile & 0xf0000) >> 16);
 
                 if (BattleSystem_RandNext(param0) & 1) {
                     BattleSystem_LoadScript(param1, 1, (0 + 107));
@@ -3225,13 +3226,13 @@ static void ov16_0224F8EC (BattleSystem * param0, BattleContext * param1)
             if (param1->aiContext.moveTable[param1->moveCur].class == 0) {
                 param1->turnFlags[param1->defender].physicalDamageTakenFrom[param1->attacker] = param1->damage;
                 param1->turnFlags[param1->defender].physicalDamageLastAttacker = param1->attacker;
-                param1->turnFlags[param1->defender].physicalDamageAttackerMask |= NumToFlag(param1->attacker);
+                param1->turnFlags[param1->defender].physicalDamageAttackerMask |= FlagIndex(param1->attacker);
                 param1->selfTurnFlags[param1->defender].physicalDamageTaken = param1->damage;
                 param1->selfTurnFlags[param1->defender].physicalDamageLastAttacker = param1->attacker;
             } else if (param1->aiContext.moveTable[param1->moveCur].class == 1) {
                 param1->turnFlags[param1->defender].specialDamageTakenFrom[param1->attacker] = param1->damage;
                 param1->turnFlags[param1->defender].specialDamageLastAttacker = param1->attacker;
-                param1->turnFlags[param1->defender].specialDamageAttackerMask |= NumToFlag(param1->attacker);
+                param1->turnFlags[param1->defender].specialDamageAttackerMask |= FlagIndex(param1->attacker);
                 param1->selfTurnFlags[param1->defender].specialDamageTaken = param1->damage;
                 param1->selfTurnFlags[param1->defender].specialDamageLastAttacker = param1->attacker;
             }
@@ -3502,7 +3503,7 @@ static void ov16_0224FEE4 (BattleSystem * param0, BattleContext * param1)
         while (param1->afterMoveEffectTemp < BattleSystem_MaxBattlers(param0)) {
             v4 = param1->monSpeedOrder[param1->afterMoveEffectTemp];
 
-            if (param1->battlersSwitchingMask & NumToFlag(v4)) {
+            if (param1->battlersSwitchingMask & FlagIndex(v4)) {
                 param1->afterMoveEffectTemp++;
                 continue;
             }
@@ -3611,7 +3612,7 @@ static void ov16_02250298 (BattleSystem * param0, BattleContext * param1)
             do {
                 v0 = param1->monSpeedOrder[param1->battlerCounter++];
 
-                if (((param1->battlersSwitchingMask & NumToFlag(v0)) == 0) && (param1->battleMons[v0].curHP)) {
+                if (((param1->battlersSwitchingMask & FlagIndex(v0)) == 0) && (param1->battleMons[v0].curHP)) {
                     v2 = BattleSystem_BattlerData(param0, v0);
 
                     if (((v3 & 0x1) && ((ov16_02263AE4(v2) & 0x1) == 0)) || ((v3 & 0x1) == 0) && (ov16_02263AE4(v2) & 0x1)) {
@@ -3633,7 +3634,7 @@ static void ov16_02250298 (BattleSystem * param0, BattleContext * param1)
             do {
                 v4 = param1->monSpeedOrder[param1->battlerCounter++];
 
-                if (((param1->battlersSwitchingMask & NumToFlag(v4)) == 0) && (param1->battleMons[v4].curHP)) {
+                if (((param1->battlersSwitchingMask & FlagIndex(v4)) == 0) && (param1->battleMons[v4].curHP)) {
                     if (v4 != param1->attacker) {
                         ov16_02255F94(param0, param1);
                         param1->defender = v4;
@@ -3652,7 +3653,7 @@ static void ov16_02250298 (BattleSystem * param0, BattleContext * param1)
 static void ov16_02250438 (BattleSystem * param0, BattleContext * param1)
 {
     if (param1->battleStatusMask & 0xf0000000) {
-        param1->faintedMon = FlagToNum((param1->battleStatusMask & 0xf0000000) >> 28);
+        param1->faintedMon = LowestBit((param1->battleStatusMask & 0xf0000000) >> 28);
         param1->battleStatusMask &= (0xf0000000 ^ 0xffffffff);
 
         BattleSystem_LoadScript(param1, 1, (0 + 277));
@@ -3890,7 +3891,7 @@ static BOOL BattleController_CheckAnySwitches (BattleSystem * param0, BattleCont
                     }
 
                     if (v7 == 0) {
-                        param1->battlersSwitchingMask |= NumToFlag(v1);
+                        param1->battlersSwitchingMask |= FlagIndex(v1);
                         param1->selectedPartySlot[v1] = 6;
                     } else {
                         param1->commandNext = v4;
@@ -3920,7 +3921,7 @@ static BOOL BattleController_CheckAnySwitches (BattleSystem * param0, BattleCont
                     }
 
                     if (v13 == 0) {
-                        param1->battlersSwitchingMask |= NumToFlag(v1);
+                        param1->battlersSwitchingMask |= FlagIndex(v1);
                         param1->selectedPartySlot[v1] = 6;
                     } else {
                         param1->commandNext = v4;
@@ -4127,7 +4128,7 @@ static BOOL BattleController_CheckRange (BattleSystem *battleSys, BattleContext 
 
     if (battleType & 0x2) {
         if (*range == 0x100) {
-            if ((battleCtx->battlersSwitchingMask & NumToFlag(BattleSystem_Partner(battleSys, battler))) == 0) {
+            if ((battleCtx->battlersSwitchingMask & FlagIndex(BattleSystem_Partner(battleSys, battler))) == 0) {
                 return 1;
             } else {
                 return 0;
@@ -4168,16 +4169,16 @@ static BOOL BattleController_CheckAnyFainted (BattleContext * param0, int param1
     int v1;
 
     v0 = 0;
-    v1 = NumToFlag(param0->monSpeedOrder[v0]) << 24;
+    v1 = FlagIndex(param0->monSpeedOrder[v0]) << 24;
 
     if (param0->battleStatusMask & 0xf000000) {
         while ((param0->battleStatusMask & v1) == 0) {
             v0++;
-            v1 = NumToFlag(param0->monSpeedOrder[v0]) << 24;
+            v1 = FlagIndex(param0->monSpeedOrder[v0]) << 24;
         }
 
         param0->battleStatusMask &= (v1 ^ 0xffffffff);
-        param0->faintedMon = FlagToNum(v1 >> 24);
+        param0->faintedMon = LowestBit(v1 >> 24);
 
         if (param3 == 1) {
             BattleSystem_LoadScript(param0, 1, (0 + 6));
@@ -4209,7 +4210,7 @@ static BOOL BattleController_CheckExpPayout (BattleContext * param0, int param1,
             }
 
             param0->battleStatusMask2 &= (v0 ^ 0xffffffff);
-            param0->faintedMon = FlagToNum(v0 >> 28);
+            param0->faintedMon = LowestBit(v0 >> 28);
 
             BattleSystem_LoadScript(param0, 1, (0 + 276));
 

--- a/src/overlay016/ov16_0223B140.c
+++ b/src/overlay016/ov16_0223B140.c
@@ -81,6 +81,7 @@
 #include "unk_0207AE68.h"
 #include "unk_0207D3B8.h"
 #include "unk_0208C098.h"
+#include "flags.h"
 #include "overlay010/ov10_0221F800.h"
 #include "overlay011/ov11_0221F840.h"
 #include "overlay012/ov12_0221FC20.h"
@@ -1603,7 +1604,7 @@ static void ov16_0223CF8C (UnkStruct_0201CD38 * param0, void * param1)
 
             if (v2 != NULL) {
                 if (sub_0208C104(v2->unk_28, v2->unk_2C, (8 * 6)) == 1) {
-                    v5 |= NumToFlag(v3);
+                    v5 |= FlagIndex(v3);
                 }
             }
         }

--- a/src/overlay016/ov16_0223DF00.c
+++ b/src/overlay016/ov16_0223DF00.c
@@ -67,6 +67,7 @@
 #include "unk_02079170.h"
 #include "party.h"
 #include "item.h"
+#include "flags.h"
 #include "overlay016/ov16_0223DF00.h"
 #include "overlay016/ov16_0225177C.h"
 #include "overlay016/ov16_0225CBB8.h"
@@ -784,7 +785,7 @@ BOOL ov16_0223E30C (BattleSystem * param0, int param1, int param2, int param3, i
             Pokemon_IncreaseValue(v1, MON_DATA_MOVE1_CUR_PP + param3, v3);
 
             if ((v4 == param2) || (v5 == param2)) {
-                if (((ov16_02252060(v0, param1, 53, NULL) & 0x200000) == 0) && ((ov16_02252060(v0, param1, 75, NULL) & NumToFlag(param3)) == 0)) {
+                if (((ov16_02252060(v0, param1, 53, NULL) & 0x200000) == 0) && ((ov16_02252060(v0, param1, 75, NULL) & FlagIndex(param3)) == 0)) {
                     ov16_02252A14(v0, param1, 31 + param3, v3);
                 }
             }
@@ -801,7 +802,7 @@ BOOL ov16_0223E30C (BattleSystem * param0, int param1, int param2, int param3, i
                 Pokemon_IncreaseValue(v1, MON_DATA_MOVE1_CUR_PP + param3, v3);
 
                 if ((v4 == param2) || (v5 == param2)) {
-                    if (((ov16_02252060(v0, param1, 53, NULL) & 0x200000) == 0) && ((ov16_02252060(v0, param1, 75, NULL) & NumToFlag(param3)) == 0)) {
+                    if (((ov16_02252060(v0, param1, 53, NULL) & 0x200000) == 0) && ((ov16_02252060(v0, param1, 75, NULL) & FlagIndex(param3)) == 0)) {
                         ov16_02252A14(v0, param1, 31 + param3, v3);
                     }
                 }
@@ -957,13 +958,13 @@ u8 ov16_0223EC58 (BattleSystem * param0, int param1, u8 param2)
 
     if (((BattleSystem_BattlerSlot(param0, param1) == 4) && ((param0->battleType & 0x8) == 0))) {
         if (param0->battleType & 0x4) {
-            if ((param2 & NumToFlag(BattleSystem_Partner(param0, param1))) == 0) {
+            if ((param2 & FlagIndex(BattleSystem_Partner(param0, param1))) == 0) {
                 return 1;
             }
         } else {
             v0 = ov16_0225B45C(param0, param0->battleCtx, 12, 0) & 0xffff;
 
-            if (((ov16_0225B45C(param0, param0->battleCtx, 8, 0) == 14) && (v0 > 16)) || (param2 & NumToFlag(0))) {
+            if (((ov16_0225B45C(param0, param0->battleCtx, 8, 0) == 14) && (v0 > 16)) || (param2 & FlagIndex(0))) {
                 return 0;
             } else {
                 return 1;
@@ -987,8 +988,8 @@ u16 ov16_0223ECC4 (BattleParams * param0, int * param1, int * param2)
 
     while (param0->unk_150) {
         for (param1[0] = 0; param1[0] < 6; param1[0]++) {
-            if (param0->unk_150 & NumToFlag(param1[0])) {
-                param0->unk_150 &= (NumToFlag(param1[0]) ^ 0xffffffff);
+            if (param0->unk_150 & FlagIndex(param1[0])) {
+                param0->unk_150 &= (FlagIndex(param1[0]) ^ 0xffffffff);
                 break;
             }
         }
@@ -1089,7 +1090,7 @@ void ov16_0223EE70 (BattleSystem * param0)
         v2 = ov16_0223DFAC(param0, 0, v0);
         v3 = Pokemon_GetValue(v2, MON_DATA_SPECIES_EGG, NULL);
 
-        if ((v3 == 412) && (param0->unk_2414[0] & NumToFlag(v0))) {
+        if ((v3 == 412) && (param0->unk_2414[0] & FlagIndex(v0))) {
             switch (ov16_0223E22C(param0)) {
             default:
             case 2:
@@ -1126,7 +1127,7 @@ void ov16_0223EE70 (BattleSystem * param0)
 
 void ov16_0223EF2C (BattleSystem * param0, int param1, int param2)
 {
-    param0->unk_2414[param1] |= NumToFlag(param2);
+    param0->unk_2414[param1] |= FlagIndex(param2);
 }
 
 void ov16_0223EF48 (BattleSystem * param0, Pokemon * param1)

--- a/src/overlay016/ov16_022405FC.c
+++ b/src/overlay016/ov16_022405FC.c
@@ -78,6 +78,7 @@
 #include "item.h"
 #include "unk_0208694C.h"
 #include "unk_0208C098.h"
+#include "flags.h"
 #include "overlay012/ov12_02235E94.h"
 #include "overlay016/ov16_0223B140.h"
 #include "overlay016/ov16_0223DF00.h"
@@ -842,7 +843,7 @@ static BOOL ov16_02240A7C (BattleSystem * param0, BattleContext * param1)
         for (v0 = 0; v0 < v2; v0++) {
             v3 = BattleSystem_BattlerData(param0, v0);
 
-            if ((v3->unk_191 & 0x1) && ((param1->battlersSwitchingMask & NumToFlag(v0)) == 0)) {
+            if ((v3->unk_191 & 0x1) && ((param1->battlersSwitchingMask & FlagIndex(v0)) == 0)) {
                 ov16_02264EF8(param0, param1, v0);
             }
         }
@@ -1304,7 +1305,7 @@ static BOOL ov16_02241288 (BattleSystem * param0, BattleContext * param1)
         for (v0 = 0; v0 < v2; v0++) {
             v3 = BattleSystem_BattlerData(param0, v0);
 
-            if (((v3->unk_191 & 0x1) == 0) && ((param1->battlersSwitchingMask & NumToFlag(v0)) == 0)) {
+            if (((v3->unk_191 & 0x1) == 0) && ((param1->battlersSwitchingMask & FlagIndex(v0)) == 0)) {
                 ov16_02265314(param0, v0);
             }
         }
@@ -1616,7 +1617,7 @@ static BOOL ov16_022418C0 (BattleSystem * param0, BattleContext * param1)
 
     if (param1->battleMons[v1].curHP == 0) {
         param1->faintedMon = v1;
-        param1->battleStatusMask |= (NumToFlag(v1) << 24);
+        param1->battleStatusMask |= (FlagIndex(v1) << 24);
         param1->totalFainted[v1]++;
 
         ov16_0224B850(param0, param1, v1);
@@ -1630,8 +1631,8 @@ static BOOL ov16_02241924 (BattleSystem * param0, BattleContext * param1)
     ov16_02248AF0(param1, 1);
     ov16_02265D98(param0, param1, param1->faintedMon);
 
-    param1->battleStatusMask &= (NumToFlag(param1->faintedMon) << 24) ^ 0xffffffff;
-    param1->battleStatusMask2 |= NumToFlag(param1->faintedMon) << 28;
+    param1->battleStatusMask &= (FlagIndex(param1->faintedMon) << 24) ^ 0xffffffff;
+    param1->battleStatusMask2 |= FlagIndex(param1->faintedMon) << 28;
     param1->battlerActions[param1->faintedMon][0] = 39;
 
     ov16_02254744(param0, param1, param1->faintedMon);
@@ -1916,7 +1917,7 @@ static BOOL ov16_02241D34 (BattleSystem * param0, BattleContext * param1)
                 v10 = ov16_0223DFAC(param0, 0, v3);
 
                 if ((Pokemon_GetValue(v10, MON_DATA_SPECIES, NULL)) && (Pokemon_GetValue(v10, MON_DATA_CURRENT_HP, NULL))) {
-                    if (param1->monsGainingExp[(param1->faintedMon >> 1) & 1] & NumToFlag(v3)) {
+                    if (param1->monsGainingExp[(param1->faintedMon >> 1) & 1] & FlagIndex(v3)) {
                         v5++;
                     }
 
@@ -2011,7 +2012,7 @@ static BOOL ov16_02241F34 (BattleSystem * param0, BattleContext * param1)
 
     for (v0 = 0; v0 < v3; v0++) {
         if (param1->battlerStatusFlags[v0] & 0x1) {
-            v2 |= NumToFlag(v0);
+            v2 |= FlagIndex(v0);
             BattleIO_ShowPartyScreen(param0, param1, v0, 1, 0, 6);
         }
     }
@@ -2020,12 +2021,12 @@ static BOOL ov16_02241F34 (BattleSystem * param0, BattleContext * param1)
         if (BattleSystem_BattleType(param0) == ((0x4 | 0x1) | 0x2)) {
             v1 = BattleSystem_Partner(param0, v0);
 
-            if (((v2 & NumToFlag(v0)) == 0) && ((v2 & NumToFlag(v1)) == 0)) {
-                v2 |= NumToFlag(v0);
+            if (((v2 & FlagIndex(v0)) == 0) && ((v2 & FlagIndex(v1)) == 0)) {
+                v2 |= FlagIndex(v0);
                 BattleIO_LinkWaitMessage(param0, v0);
             }
         } else {
-            if ((v2 & NumToFlag(v0)) == 0) {
+            if ((v2 & FlagIndex(v0)) == 0) {
                 BattleIO_LinkWaitMessage(param0, v0);
             }
         }
@@ -2061,8 +2062,8 @@ static BOOL ov16_0224200C (BattleSystem * param0, BattleContext * param1)
             param1->switchedPartySlot[v0] = param1->ioBuffer[v0][0] - 1;
             v2--;
 
-            if ((param1->battleStatusMask2 & (NumToFlag(v0) << 24)) == 0) {
-                param1->battleStatusMask2 |= (NumToFlag(v0) << 24);
+            if ((param1->battleStatusMask2 & (FlagIndex(v0) << 24)) == 0) {
+                param1->battleStatusMask2 |= (FlagIndex(v0) << 24);
                 BattleIO_LinkWaitMessage(param0, v0);
             }
         }
@@ -2107,7 +2108,7 @@ static BOOL ov16_02242134 (BattleSystem * param0, BattleContext * param1)
     }
 
     param1->battlerStatusFlags[v0] &= 0x1 ^ 0xffffffff;
-    param1->battlersSwitchingMask &= (NumToFlag(v0) ^ 0xffffffff);
+    param1->battlersSwitchingMask &= (FlagIndex(v0) ^ 0xffffffff);
     param1->selectedPartySlot[v0] = param1->switchedPartySlot[v0];
     param1->switchedPartySlot[v0] = 6;
 
@@ -2249,7 +2250,7 @@ static BOOL ov16_0224230C (BattleSystem * param0, BattleContext * param1)
         v3[0] = v4;
         break;
     case ((6 + 1) + 9):
-        v3[0] = NumToFlag(v2);
+        v3[0] = FlagIndex(v2);
         break;
     case ((6 + 1) + 10):
         GF_ASSERT(0);
@@ -2514,7 +2515,7 @@ static BOOL ov16_02242A14 (BattleSystem * param0, BattleContext * param1)
         v5 = v6;
         break;
     case ((6 + 1) + 9):
-        v5 = NumToFlag(v3);
+        v5 = FlagIndex(v3);
         break;
     case ((6 + 1) + 10):
         GF_ASSERT(0);
@@ -2699,7 +2700,7 @@ static BOOL ov16_02242CA4 (BattleSystem * param0, BattleContext * param1)
         v3[0] = v5;
         break;
     case ((6 + 1) + 9):
-        v3[0] = NumToFlag(v4[0]);
+        v3[0] = FlagIndex(v4[0]);
         break;
     case ((6 + 1) + 10):
         v4[0] = v3[0];
@@ -2777,7 +2778,7 @@ static BOOL ov16_02242DBC (BattleSystem * param0, BattleContext * param1)
         v5 = v7;
         break;
     case ((6 + 1) + 9):
-        v5 = NumToFlag(v6[0]);
+        v5 = FlagIndex(v6[0]);
         break;
     case ((6 + 1) + 10):
         v6[0] = v5;
@@ -3763,7 +3764,7 @@ static BOOL ov16_02243DBC (BattleSystem * param0, BattleContext * param1)
                     param1->battleMons[param1->attacker].ppCur[v2] = 5;
                 }
 
-                param1->battleMons[param1->attacker].moveEffectsData.mimickedMoveSlot |= NumToFlag(v2);
+                param1->battleMons[param1->attacker].moveEffectsData.mimickedMoveSlot |= FlagIndex(v2);
 
                 if (param1->msgMoveTemp == 387) {
                     param1->battleMons[param1->attacker].moveEffectsData.lastResortCount = 0;
@@ -4043,7 +4044,7 @@ static BOOL ov16_022445D4 (BattleSystem * param0, BattleContext * param1)
 
     for (v0 = 0; v0 < 4; v0++) {
         if ((ov16_02255918(param1->battleMons[param1->attacker].moves[v0])) || (param1->battleMons[param1->attacker].moves[v0] == 264) || (param1->battleMons[param1->attacker].moves[v0] == 253) || (param1->battleMons[param1->attacker].moves[v0] == 448) || (ov16_0225582C(param1, param1->battleMons[param1->attacker].moves[v0]))) {
-            v1 |= NumToFlag(v0);
+            v1 |= FlagIndex(v0);
         }
     }
 
@@ -4054,7 +4055,7 @@ static BOOL ov16_022445D4 (BattleSystem * param0, BattleContext * param1)
     } else {
         do {
             v0 = BattleSystem_RandNext(param0) % 4;
-        } while ((v1 & NumToFlag(v0)));
+        } while ((v1 & FlagIndex(v0)));
 
         param1->msgMoveTemp = param1->battleMons[param1->attacker].moves[v0];
     }
@@ -4147,7 +4148,7 @@ static BOOL ov16_02244798 (BattleSystem * param0, BattleContext * param1)
         if (v0 & 0x2) {
             v1 = ov16_0224A984(param0, param1, 0x10);
 
-            if ((param1->battlersSwitchingMask & NumToFlag(v1)) == 0) {
+            if ((param1->battlersSwitchingMask & FlagIndex(v1)) == 0) {
                 if (ov16_02255AB4(param1, param1->attacker, v1, 43) == 0) {
                     param1->battleMons[v1].status = 0;
                     param1->battleMons[v1].statusVolatile &= (0x8000000 ^ 0xffffffff);
@@ -4166,7 +4167,7 @@ static BOOL ov16_02244798 (BattleSystem * param0, BattleContext * param1)
         if (v0 & 0x2) {
             v1 = ov16_0224A984(param0, param1, 0x10);
 
-            if ((param1->battlersSwitchingMask & NumToFlag(v1)) == 0) {
+            if ((param1->battlersSwitchingMask & FlagIndex(v1)) == 0) {
                 param1->battleMons[v1].status = 0;
                 param1->battleMons[v1].statusVolatile &= (0x8000000 ^ 0xffffffff);
             }
@@ -4196,7 +4197,7 @@ static BOOL ov16_022448E8 (BattleSystem * param0, BattleContext * param1)
 
     if ((Battler_Side(param0, param1->attacker)) && ((v2 & (0x4 | 0x80)) == 0)) {
         ov16_02248AF0(param1, v0);
-    } else if (param1->sideConditions[v3].knockedOffItemsMask & NumToFlag(param1->selectedPartySlot[param1->attacker])) {
+    } else if (param1->sideConditions[v3].knockedOffItemsMask & FlagIndex(param1->selectedPartySlot[param1->attacker])) {
         ov16_02248AF0(param1, v0);
     } else if ((Battler_Ability(param1, param1->attacker) == 121) || (Battler_Ability(param1, param1->defender) == 121)) {
         ov16_02248AF0(param1, v0);
@@ -4669,7 +4670,7 @@ static BOOL ov16_022455F8 (BattleSystem * param0, BattleContext * param1)
     if ((param1->battleMons[param1->msgBattlerTemp].gender == param1->battleMons[param1->sideEffectMon].gender) || (param1->battleMons[param1->sideEffectMon].statusVolatile & 0xf0000) || (param1->battleMons[param1->msgBattlerTemp].gender == 2) || (param1->battleMons[param1->sideEffectMon].gender == 2)) {
         ov16_02248AF0(param1, v0);
     } else {
-        param1->battleMons[param1->sideEffectMon].statusVolatile |= NumToFlag(param1->msgBattlerTemp) << 16;
+        param1->battleMons[param1->sideEffectMon].statusVolatile |= FlagIndex(param1->msgBattlerTemp) << 16;
     }
 
     return 0;
@@ -5060,7 +5061,7 @@ static BOOL ov16_02246004 (BattleSystem * param0, BattleContext * param1)
     if (v2 & 0x2) {
         v1 = ov16_0224A984(param0, param1, 0x10);
 
-        if (((param1->battlersSwitchingMask & NumToFlag(v1)) == 0) && (param1->battlerActions[v1][0] != 39) && (param1->battleMons[v1].curHP) && (param1->turnFlags[param1->attacker].helpingHand == 0) && (param1->turnFlags[v1].helpingHand == 0)) {
+        if (((param1->battlersSwitchingMask & FlagIndex(v1)) == 0) && (param1->battlerActions[v1][0] != 39) && (param1->battleMons[v1].curHP) && (param1->turnFlags[param1->attacker].helpingHand == 0) && (param1->turnFlags[v1].helpingHand == 0)) {
             param1->msgBattlerTemp = v1;
             param1->turnFlags[v1].helpingHand = 1;
         } else {
@@ -5091,7 +5092,7 @@ static BOOL ov16_022460A8 (BattleSystem * param0, BattleContext * param1)
 
     if ((Battler_Side(param0, param1->attacker)) && ((v2 & (0x4 | 0x80)) == 0)) {
         ov16_02248AF0(param1, v0);
-    } else if ((param1->sideConditions[v3].knockedOffItemsMask & NumToFlag(param1->selectedPartySlot[param1->attacker])) || (param1->sideConditions[v4].knockedOffItemsMask & NumToFlag(param1->selectedPartySlot[param1->defender]))) {
+    } else if ((param1->sideConditions[v3].knockedOffItemsMask & FlagIndex(param1->selectedPartySlot[param1->attacker])) || (param1->sideConditions[v4].knockedOffItemsMask & FlagIndex(param1->selectedPartySlot[param1->defender]))) {
         ov16_02248AF0(param1, v0);
     } else if (((param1->battleMons[param1->attacker].heldItem == 0) && (param1->battleMons[param1->defender].heldItem == 0)) || (ov16_022559DC(param1, param1->attacker) == 0) || (ov16_022559DC(param1, param1->defender) == 0)) {
         ov16_02248AF0(param1, v0);
@@ -5227,7 +5228,7 @@ static BOOL ov16_022463E8 (BattleSystem * param0, BattleContext * param1)
 {
     ov16_02248AF0(param1, 1);
 
-    if (((param1->turnFlags[param1->attacker].physicalDamageTakenFrom[param1->defender]) && (param1->turnFlags[param1->attacker].physicalDamageAttackerMask & NumToFlag(param1->defender))) || ((param1->turnFlags[param1->attacker].specialDamageTakenFrom[param1->defender]) && (param1->turnFlags[param1->attacker].specialDamageAttackerMask & NumToFlag(param1->defender)))) {
+    if (((param1->turnFlags[param1->attacker].physicalDamageTakenFrom[param1->defender]) && (param1->turnFlags[param1->attacker].physicalDamageAttackerMask & FlagIndex(param1->defender))) || ((param1->turnFlags[param1->attacker].specialDamageTakenFrom[param1->defender]) && (param1->turnFlags[param1->attacker].specialDamageAttackerMask & FlagIndex(param1->defender)))) {
         param1->powerMul = 20;
     } else {
         param1->powerMul = 10;
@@ -5298,7 +5299,7 @@ static BOOL ov16_0224650C (BattleSystem * param0, BattleContext * param1)
         param1->msgBuffer.params[1] = BattleSystem_NicknameTag(param1, param1->defender);
         param1->msgBuffer.params[2] = param1->battleMons[param1->defender].heldItem;
         param1->battleMons[param1->defender].heldItem = 0;
-        param1->sideConditions[v1].knockedOffItemsMask |= NumToFlag(param1->selectedPartySlot[param1->defender]);
+        param1->sideConditions[v1].knockedOffItemsMask |= FlagIndex(param1->selectedPartySlot[param1->defender]);
     } else {
         ov16_02248AF0(param1, v0);
     }
@@ -7664,7 +7665,7 @@ static void ov16_02248E74 (UnkStruct_0201CD38 * param0, void * param1)
         v9 = Pokemon_GetValue(v3, MON_DATA_HELD_ITEM, NULL);
         v10 = Item_LoadParam(v9, 1, 5);
 
-        if ((v10 == 51) || (v2->unk_04->monsGainingExp[v5] & NumToFlag(v1))) {
+        if ((v10 == 51) || (v2->unk_04->monsGainingExp[v5] & FlagIndex(v1))) {
             break;
         }
     }
@@ -7696,7 +7697,7 @@ static void ov16_02248E74 (UnkStruct_0201CD38 * param0, void * param1)
         v4.id = 1;
 
         if ((Pokemon_GetValue(v3, MON_DATA_CURRENT_HP, NULL)) && (Pokemon_GetValue(v3, MON_DATA_LEVEL, NULL) != 100)) {
-            if (v2->unk_04->monsGainingExp[v5] & NumToFlag(v1)) {
+            if (v2->unk_04->monsGainingExp[v5] & FlagIndex(v1)) {
                 v11 = v2->unk_04->gainedExp;
             }
 
@@ -7804,7 +7805,7 @@ static void ov16_02248E74 (UnkStruct_0201CD38 * param0, void * param1)
                     ov16_02251C94(v2->unk_00, v2->unk_04, v6, v2->unk_04->selectedPartySlot[v6]);
                 }
 
-                v2->unk_04->levelUpMons |= NumToFlag(v1);
+                v2->unk_04->levelUpMons |= FlagIndex(v1);
                 BattleIO_RefreshHPGauge(v2->unk_00, v2->unk_04, v6);
 
                 v4.id = 3;
@@ -8096,7 +8097,7 @@ static void ov16_02248E74 (UnkStruct_0201CD38 * param0, void * param1)
         }
         break;
     case 37:
-        v2->unk_04->monsGainingExp[v5] &= (NumToFlag(v1) ^ 0xffffffff);
+        v2->unk_04->monsGainingExp[v5] &= (FlagIndex(v1) ^ 0xffffffff);
         v2->unk_30[6] = v1 + 1;
         v2->unk_28 = 0;
         break;
@@ -8182,7 +8183,7 @@ static void ov16_022499C0 (Party * param0, int param1, int param2, int param3)
             break;
         }
 
-        if (sub_02077758(param0, NumToFlag(param1))) {
+        if (sub_02077758(param0, FlagIndex(param1))) {
             v1 = v1 * 2;
         }
 
@@ -8221,7 +8222,7 @@ static void ov16_02249B80 (UnkStruct_0201CD38 * param0, void * param1)
     v5 = ov16_0223E000(v2->unk_00);
     v1 = 1;
 
-    if (v2->unk_04->battlersSwitchingMask & NumToFlag(v1)) {
+    if (v2->unk_04->battlersSwitchingMask & FlagIndex(v1)) {
         v1 = 3;
     }
 

--- a/src/overlay016/ov16_0225177C.c
+++ b/src/overlay016/ov16_0225177C.c
@@ -27,6 +27,7 @@
 #include "unk_0208C098.h"
 #include "unk_02098700.h"
 #include "unk_02098988.h"
+#include "flags.h"
 #include "overlay016/ov16_0223DF00.h"
 #include "overlay016/ov16_0225177C.h"
 #include "overlay016/ov16_0225CBB8.h"
@@ -274,7 +275,7 @@ void BattleSystem_InitBattleMon (BattleSystem *battleSys, BattleContext *battleC
 
     v2 = Battler_Side(battleSys, battler);
 
-    if (battleCtx->sideConditions[v2].knockedOffItemsMask & NumToFlag(battleCtx->selectedPartySlot[battler])) {
+    if (battleCtx->sideConditions[v2].knockedOffItemsMask & FlagIndex(battleCtx->selectedPartySlot[battler])) {
         battleCtx->battleMons[battler].heldItem = 0;
         battleCtx->battleMons[battler].moveEffectsData.canUnburden = 0;
     } else {
@@ -302,7 +303,7 @@ void ov16_02251C94 (BattleSystem * param0, BattleContext * param1, int param2, i
 
     if ((param1->battleMons[param2].statusVolatile & 0x200000) == 0) {
         for (v1 = 0; v1 < 4; v1++) {
-            if ((param1->battleMons[param2].moveEffectsData.mimickedMoveSlot & NumToFlag(v1)) == 0) {
+            if ((param1->battleMons[param2].moveEffectsData.mimickedMoveSlot & FlagIndex(v1)) == 0) {
                 param1->battleMons[param2].moves[v1] = Pokemon_GetValue(v0, MON_DATA_MOVE1 + v1, 0);
                 param1->battleMons[param2].ppCur[v1] = Pokemon_GetValue(v0, MON_DATA_MOVE1_CUR_PP + v1, 0);
                 param1->battleMons[param2].ppUps[v1] = Pokemon_GetValue(v0, MON_DATA_MOVE1_PP_UPS + v1, 0);
@@ -1496,8 +1497,8 @@ void ov16_022535F0 (BattleSystem * param0, BattleContext * param1, int param2)
     v1 = BattleSystem_BattleType(param0);
 
     while (v0 <= 2) {
-        if (((param1->battlersSwitchingMask & NumToFlag(v0)) == 0) && ((param1->battlersSwitchingMask & NumToFlag(param2)) == 0) && (param1->battleMons[param2].curHP)) {
-            param1->monsGainingExp[(param2 >> 1) & 1] |= NumToFlag(param1->selectedPartySlot[v0]);
+        if (((param1->battlersSwitchingMask & FlagIndex(v0)) == 0) && ((param1->battlersSwitchingMask & FlagIndex(param2)) == 0) && (param1->battleMons[param2].curHP)) {
+            param1->monsGainingExp[(param2 >> 1) & 1] |= FlagIndex(param1->selectedPartySlot[v0]);
         }
 
         v0 += 2;
@@ -2089,8 +2090,8 @@ void BattleContext_InitCounters (BattleSystem * param0, BattleContext * param1)
     v0 = BattleSystem_BattleType(param0);
 
     if ((v0 & 0x2) == 0) {
-        param1->battlersSwitchingMask |= NumToFlag(2);
-        param1->battlersSwitchingMask |= NumToFlag(3);
+        param1->battlersSwitchingMask |= FlagIndex(2);
+        param1->battlersSwitchingMask |= FlagIndex(3);
     }
 
     param1->safariCatchCount = 6;
@@ -2138,8 +2139,8 @@ void ov16_0225433C (BattleSystem * param0, BattleContext * param1, int param2)
     }
 
     for (v0 = 0; v0 < v1; v0++) {
-        if (param1->battleMons[v0].statusVolatile & (NumToFlag(param2) << 16)) {
-            param1->battleMons[v0].statusVolatile &= ((NumToFlag(param2) << 16) ^ 0xffffffff);
+        if (param1->battleMons[v0].statusVolatile & (FlagIndex(param2) << 16)) {
+            param1->battleMons[v0].statusVolatile &= ((FlagIndex(param2) << 16) ^ 0xffffffff);
         }
 
         if ((param1->battleMons[v0].statusVolatile & 0xe000) && (param1->battleMons[v0].moveEffectsData.bindTarget == param2)) {
@@ -2181,7 +2182,7 @@ void ov16_0225433C (BattleSystem * param0, BattleContext * param1, int param2)
     param1->conversion2Battler[param2] = 0;
     param1->conversion2Type[param2] = 0;
     param1->metronomeMove[param2] = 0;
-    param1->fieldConditionsMask &= ((NumToFlag(param2) << 8) ^ 0xffffffff);
+    param1->fieldConditionsMask &= ((FlagIndex(param2) << 8) ^ 0xffffffff);
 
     if (param1->battleMons[param2].moveEffectsMask & 0x800000) {
         v0 = param1->battleMons[param2].attack;
@@ -2223,8 +2224,8 @@ void ov16_02254744 (BattleSystem * param0, BattleContext * param1, int param2)
             param1->battleMons[v0].statusVolatile &= (0x4000000 ^ 0xffffffff);
         }
 
-        if (param1->battleMons[v0].statusVolatile & (NumToFlag(param2) << 16)) {
-            param1->battleMons[v0].statusVolatile &= ((NumToFlag(param2) << 16) ^ 0xffffffff);
+        if (param1->battleMons[v0].statusVolatile & (FlagIndex(param2) << 16)) {
+            param1->battleMons[v0].statusVolatile &= ((FlagIndex(param2) << 16) ^ 0xffffffff);
         }
 
         if ((param1->battleMons[v0].statusVolatile & 0xe000) && (param1->battleMons[v0].moveEffectsData.bindTarget == param2)) {
@@ -2262,7 +2263,7 @@ void ov16_02254744 (BattleSystem * param0, BattleContext * param1, int param2)
     param1->conversion2Battler[param2] = 0;
     param1->conversion2Type[param2] = 0;
     param1->metronomeMove[param2] = 0;
-    param1->fieldConditionsMask &= ((NumToFlag(param2) << 8) ^ 0xffffffff);
+    param1->fieldConditionsMask &= ((FlagIndex(param2) << 8) ^ 0xffffffff);
 
     for (v0 = 0; v0 < v1; v0++) {
         if ((v0 != param2) && (Battler_Side(param0, v0) != Battler_Side(param0, param2))) {
@@ -2315,39 +2316,39 @@ int BattleSystem_CheckStruggling (BattleSystem *battleSys, BattleContext *battle
 
     for (v0 = 0; v0 < 4; v0++) {
         if ((battleCtx->battleMons[battler].moves[v0] == 0) && (struggleChecksMask & 0x1)) {
-            moveFlags |= NumToFlag(v0);
+            moveFlags |= FlagIndex(v0);
         }
 
         if ((battleCtx->battleMons[battler].ppCur[v0] == 0) && (struggleChecksMask & 0x2)) {
-            moveFlags |= NumToFlag(v0);
+            moveFlags |= FlagIndex(v0);
         }
 
         if ((battleCtx->battleMons[battler].moves[v0] == battleCtx->battleMons[battler].moveEffectsData.disabledMove) && (struggleChecksMask & 0x4)) {
-            moveFlags |= NumToFlag(v0);
+            moveFlags |= FlagIndex(v0);
         }
 
         if ((battleCtx->battleMons[battler].moves[v0] == battleCtx->movePrevByBattler[battler]) && (struggleChecksMask & 0x8) && (battleCtx->battleMons[battler].statusVolatile & 0x80000000)) {
-            moveFlags |= NumToFlag(v0);
+            moveFlags |= FlagIndex(v0);
         }
 
         if ((battleCtx->battleMons[battler].moveEffectsData.tauntedTurns) && (struggleChecksMask & 0x10) && (battleCtx->aiContext.moveTable[battleCtx->battleMons[battler].moves[v0]].power == 0)) {
-            moveFlags |= NumToFlag(v0);
+            moveFlags |= FlagIndex(v0);
         }
 
         if ((ov16_02255EF4(battleSys, battleCtx, battler, battleCtx->battleMons[battler].moves[v0])) && (struggleChecksMask & 0x20)) {
-            moveFlags |= NumToFlag(v0);
+            moveFlags |= FlagIndex(v0);
         }
 
         if ((ov16_02256044(battleSys, battleCtx, battler, battleCtx->battleMons[battler].moves[v0])) && (struggleChecksMask & 0x40)) {
-            moveFlags |= NumToFlag(v0);
+            moveFlags |= FlagIndex(v0);
         }
 
         if ((ov16_02256078(battleSys, battleCtx, battler, battleCtx->battleMons[battler].moves[v0])) && (struggleChecksMask & 0x80)) {
-            moveFlags |= NumToFlag(v0);
+            moveFlags |= FlagIndex(v0);
         }
 
         if ((battleCtx->battleMons[battler].moveEffectsData.encoredMove) && (battleCtx->battleMons[battler].moveEffectsData.encoredMove != battleCtx->battleMons[battler].moves[v0])) {
-            moveFlags |= NumToFlag(v0);
+            moveFlags |= FlagIndex(v0);
         }
 
         if (((v1 == 55) || (v1 == 115) || (v1 == 125)) && (struggleChecksMask & 0x200)) {
@@ -2355,7 +2356,7 @@ int BattleSystem_CheckStruggling (BattleSystem *battleSys, BattleContext *battle
                 battleCtx->battleMons[battler].moveEffectsData.choiceLockedMove = 0;
             } else {
                 if ((battleCtx->battleMons[battler].moveEffectsData.choiceLockedMove) && (battleCtx->battleMons[battler].moveEffectsData.choiceLockedMove != battleCtx->battleMons[battler].moves[v0])) {
-                    moveFlags |= NumToFlag(v0);
+                    moveFlags |= FlagIndex(v0);
                 }
             }
         }
@@ -2368,49 +2369,49 @@ BOOL BattleSystem_CanUseMove (BattleSystem *battleSys, BattleContext *battleCtx,
 {
     BOOL result = TRUE;
 
-    if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x4) & NumToFlag(moveSlot)) {
+    if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x4) & FlagIndex(moveSlot)) {
         msgOut->tags = 10;
         msgOut->id = 609;
         msgOut->params[0] = BattleSystem_NicknameTag(battleCtx, battler);
         msgOut->params[1] = battleCtx->battleMons[battler].moves[moveSlot];
         result = FALSE;
-    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x8) & NumToFlag(moveSlot)) {
+    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x8) & FlagIndex(moveSlot)) {
         msgOut->tags = 2;
         msgOut->id = 612;
         msgOut->params[0] = BattleSystem_NicknameTag(battleCtx, battler);
         result = FALSE;
-    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x10) & NumToFlag(moveSlot)) {
+    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x10) & FlagIndex(moveSlot)) {
         msgOut->tags = 10;
         msgOut->id = 613;
         msgOut->params[0] = BattleSystem_NicknameTag(battleCtx, battler);
         msgOut->params[1] = battleCtx->battleMons[battler].moves[moveSlot];
         result = FALSE;
-    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x20) & NumToFlag(moveSlot)) {
+    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x20) & FlagIndex(moveSlot)) {
         msgOut->tags = 10;
         msgOut->id = 616;
         msgOut->params[0] = BattleSystem_NicknameTag(battleCtx, battler);
         msgOut->params[1] = battleCtx->battleMons[battler].moves[moveSlot];
         result = FALSE;
-    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x40) & NumToFlag(moveSlot)) {
+    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x40) & FlagIndex(moveSlot)) {
         msgOut->tags = 10;
         msgOut->id = 1001;
         msgOut->params[0] = BattleSystem_NicknameTag(battleCtx, battler);
         msgOut->params[1] = battleCtx->battleMons[battler].moves[moveSlot];
         result = FALSE;
-    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x80) & NumToFlag(moveSlot)) {
+    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x80) & FlagIndex(moveSlot)) {
         msgOut->tags = 34;
         msgOut->id = 1057;
         msgOut->params[0] = BattleSystem_NicknameTag(battleCtx, battler);
         msgOut->params[1] = 377;
         msgOut->params[2] = battleCtx->battleMons[battler].moves[moveSlot];
         result = FALSE;
-    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x200) & NumToFlag(moveSlot)) {
+    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x200) & FlagIndex(moveSlot)) {
         msgOut->tags = 24;
         msgOut->id = 911;
         msgOut->params[0] = battleCtx->battleMons[battler].heldItem;
         msgOut->params[1] = battleCtx->battleMons[battler].moveEffectsData.choiceLockedMove;
         result = FALSE;
-    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x2) & NumToFlag(moveSlot)) {
+    } else if (BattleSystem_CheckStruggling(battleSys, battleCtx, battler, 0, 0x2) & FlagIndex(moveSlot)) {
         msgOut->tags = 0;
         msgOut->id = 823;
         result = FALSE;
@@ -2895,7 +2896,7 @@ int BattleSystem_CountAbility (BattleSystem * param0, BattleContext * param1, in
     case 4:
         for (v1 = 0; v1 < v2; v1++) {
             if ((Battler_Side(param0, v1) != Battler_Side(param0, param3)) && (param1->battleMons[v1].curHP) && (Battler_Ability(param1, v1) == param4)) {
-                v0 |= NumToFlag(v1);
+                v0 |= FlagIndex(v1);
             }
         }
         break;
@@ -3025,7 +3026,7 @@ BOOL ov16_02255980 (BattleSystem * param0, BattleContext * param1, int param2)
     v0 = 0;
     v1 = Battler_Side(param0, param2);
 
-    if ((param1->battleMons[param2].heldItem) && ((param1->sideConditions[v1].knockedOffItemsMask & NumToFlag(param1->selectedPartySlot[param2])) == 0) && (Item_IsMail(param1->battleMons[param2].heldItem) == 0)) {
+    if ((param1->battleMons[param2].heldItem) && ((param1->sideConditions[v1].knockedOffItemsMask & FlagIndex(param1->selectedPartySlot[param2])) == 0) && (Item_IsMail(param1->battleMons[param2].heldItem) == 0)) {
         v0 = 1;
     }
 
@@ -5200,7 +5201,7 @@ BOOL ov16_022588BC (BattleSystem * param0, BattleContext * param1, int * param2)
 
     switch (v2) {
     case 116:
-        if ((param1->battleMons[param1->attacker].curHP) && (param1->battleMons[param1->attacker].heldItem == 0) && ((param1->sideConditions[v4].knockedOffItemsMask & NumToFlag(param1->selectedPartySlot[param1->attacker])) == 0) && (param1->moveCur != 282) && ((param1->selfTurnFlags[param1->defender].physicalDamageTaken) || (param1->selfTurnFlags[param1->defender].specialDamageTaken)) && ((param1->battleStatusMask2 & 0x10) == 0) && (param1->aiContext.moveTable[param1->moveCur].flags & 0x1)) {
+        if ((param1->battleMons[param1->attacker].curHP) && (param1->battleMons[param1->attacker].heldItem == 0) && ((param1->sideConditions[v4].knockedOffItemsMask & FlagIndex(param1->selectedPartySlot[param1->attacker])) == 0) && (param1->moveCur != 282) && ((param1->selfTurnFlags[param1->defender].physicalDamageTaken) || (param1->selfTurnFlags[param1->defender].specialDamageTaken)) && ((param1->battleStatusMask2 & 0x10) == 0) && (param1->aiContext.moveTable[param1->moveCur].flags & 0x1)) {
             param2[0] = (0 + 216);
             v0 = 1;
         }
@@ -7079,7 +7080,7 @@ BOOL ov16_0225B228 (BattleSystem * param0, BattleContext * param1, int * param2)
         v0 = 1;
     }
 
-    if ((v4 == 116) && (param1->battleMons[param1->attacker].curHP) && (param1->battleMons[param1->attacker].heldItem == 0) && ((param1->sideConditions[v6].knockedOffItemsMask & NumToFlag(param1->selectedPartySlot[param1->attacker])) == 0) && ((param1->selfTurnFlags[param1->defender].physicalDamageTaken) || (param1->selfTurnFlags[param1->defender].specialDamageTaken)) && (param1->aiContext.moveTable[param1->moveCur].flags & 0x1)) {
+    if ((v4 == 116) && (param1->battleMons[param1->attacker].curHP) && (param1->battleMons[param1->attacker].heldItem == 0) && ((param1->sideConditions[v6].knockedOffItemsMask & FlagIndex(param1->selectedPartySlot[param1->attacker])) == 0) && ((param1->selfTurnFlags[param1->defender].physicalDamageTaken) || (param1->selfTurnFlags[param1->defender].specialDamageTaken)) && (param1->aiContext.moveTable[param1->moveCur].flags & 0x1)) {
         param2[0] = (0 + 216);
         v0 = 1;
     }
@@ -7691,7 +7692,7 @@ int ov16_0225BA88 (BattleSystem * param0, int param1)
             v19 = ov16_0223DFAC(param0, param1, v0);
             v7 = Pokemon_GetValue(v19, MON_DATA_SPECIES_EGG, NULL);
 
-            if ((v7 != 0) && (v7 != 494) && (Pokemon_GetValue(v19, MON_DATA_CURRENT_HP, NULL)) && ((v10 & NumToFlag(v0)) == 0) && (v20->selectedPartySlot[v14] != v0) && (v20->selectedPartySlot[v15] != v0) && (v0 != v20->aiSwitchedPartySlot[v14]) && (v0 != v20->aiSwitchedPartySlot[v15])) {
+            if ((v7 != 0) && (v7 != 494) && (Pokemon_GetValue(v19, MON_DATA_CURRENT_HP, NULL)) && ((v10 & FlagIndex(v0)) == 0) && (v20->selectedPartySlot[v14] != v0) && (v20->selectedPartySlot[v15] != v0) && (v0 != v20->aiSwitchedPartySlot[v14]) && (v0 != v20->aiSwitchedPartySlot[v15])) {
                 v3 = ov16_02252060(v20, v2, 27, NULL);
                 v4 = ov16_02252060(v20, v2, 28, NULL);
                 v5 = Pokemon_GetValue(v19, MON_DATA_177, NULL);
@@ -7704,7 +7705,7 @@ int ov16_0225BA88 (BattleSystem * param0, int param1)
                     v13 = v0;
                 }
             } else {
-                v10 |= NumToFlag(v0);
+                v10 |= FlagIndex(v0);
             }
         }
 
@@ -7726,7 +7727,7 @@ int ov16_0225BA88 (BattleSystem * param0, int param1)
             }
 
             if (v0 == 4) {
-                v10 |= NumToFlag(v13);
+                v10 |= FlagIndex(v13);
             } else {
                 return v13;
             }

--- a/src/overlay016/ov16_0225BFFC.c
+++ b/src/overlay016/ov16_0225BFFC.c
@@ -69,6 +69,7 @@
 #include "unk_02018340.h"
 #include "pokemon.h"
 #include "party.h"
+#include "flags.h"
 #include "overlay012/ov12_02235E94.h"
 #include "overlay012/ov12_022380BC.h"
 #include "overlay016/ov16_0223DF00.h"
@@ -611,14 +612,14 @@ static void ov16_0225C47C (BattleSystem * param0, UnkStruct_ov16_0225BFFC * para
 
     if ((v0->unk_18 & 0x200000) == 0) {
         for (v1 = 0; v1 < 4; v1++) {
-            if ((v0->unk_01_4 & NumToFlag(v1)) == 0) {
+            if ((v0->unk_01_4 & FlagIndex(v1)) == 0) {
                 Pokemon_SetValue(v2, 54 + v1, (u8 *)&v0->unk_0E[v1]);
                 Pokemon_SetValue(v2, 58 + v1, (u8 *)&v0->unk_12[v1]);
             }
         }
     }
 
-    if ((v0->unk_08 & NumToFlag(v0->unk_01_0)) == 0) {
+    if ((v0->unk_08 & FlagIndex(v0->unk_01_0)) == 0) {
         Pokemon_SetValue(v2, 6, (u8 *)&v0->unk_0C);
     }
 

--- a/src/overlay016/ov16_0225CBB8.c
+++ b/src/overlay016/ov16_0225CBB8.c
@@ -136,6 +136,8 @@
 #include "move_table.h"
 #include "party.h"
 #include "item.h"
+#include "flags.h"
+#include "flags.h"
 #include "overlay012/ov12_0221FC20.h"
 #include "overlay012/ov12_02235E94.h"
 #include "overlay012/ov12_02237EFC.h"
@@ -3402,7 +3404,7 @@ static void ov16_02260DB0 (UnkStruct_0201CD38 * param0, void * param1)
             v6 = 0;
 
             for (v4 = 0; v4 < 4; v4++) {
-                if ((v0->unk_22 & NumToFlag(v4)) == 0) {
+                if ((v0->unk_22 & FlagIndex(v4)) == 0) {
                     v5[v6] = v4 + 1;
                     v6++;
                 }
@@ -4348,7 +4350,7 @@ static void ov16_02261E8C (UnkStruct_0201CD38 * param0, void * param1)
                 v0->unk_04->unk_28 = v0->unk_09;
                 v0->unk_04->unk_32 = v0->unk_17;
 
-                if ((v0->unk_18 & NumToFlag(v0->unk_09)) == 0) {
+                if ((v0->unk_18 & FlagIndex(v0->unk_09)) == 0) {
                     v0->unk_04->unk_14 = v0->unk_0C[v0->unk_09];
                 } else {
                     v0->unk_04->unk_14 = 6;
@@ -4356,7 +4358,7 @@ static void ov16_02261E8C (UnkStruct_0201CD38 * param0, void * param1)
 
                 if (BattleSystem_BattleType(v0->unk_00) & 0x8) {
                     v0->unk_04->unk_15 = 6;
-                } else if ((v0->unk_18 & NumToFlag(BattleSystem_Partner(v0->unk_00, v0->unk_09))) == 0) {
+                } else if ((v0->unk_18 & FlagIndex(BattleSystem_Partner(v0->unk_00, v0->unk_09))) == 0) {
                     v0->unk_04->unk_15 = v0->unk_0C[BattleSystem_Partner(v0->unk_00, v0->unk_09)];
                 } else {
                     v0->unk_04->unk_15 = 6;
@@ -6158,7 +6160,7 @@ static void ov16_02264270 (BattleSystem * param0, UnkStruct_ov16_0225BFFC * para
     int v2 = 0;
 
     for (v0 = 0; v0 < BattleSystem_MaxBattlers(param0); v0++) {
-        if (param2->unk_01 & NumToFlag(v0)) {
+        if (param2->unk_01 & FlagIndex(v0)) {
             if (Battler_Side(param0, v0)) {
                 v2++;
             } else {

--- a/src/overlay016/ov16_0226485C.c
+++ b/src/overlay016/ov16_0226485C.c
@@ -63,6 +63,7 @@
 #include "pokemon.h"
 #include "move_table.h"
 #include "party.h"
+#include "flags.h"
 #include "unk_0207A6DC.h"
 #include "overlay016/ov16_0223DF00.h"
 #include "overlay016/ov16_0225177C.h"
@@ -596,7 +597,7 @@ void BattleIO_SetCommandSelection (BattleSystem *battleSys, BattleContext *battl
 
     for (v1 = 0; v1 < BattleSystem_MaxBattlers(battleSys); v1++) {
         if (BattleSystem_CanPickCommand(battleCtx, v1) == 0) {
-            v10 |= NumToFlag(v1);
+            v10 |= FlagIndex(v1);
         }
     }
 
@@ -844,11 +845,11 @@ void BattleIO_ShowBagScreen (BattleSystem *battleSys, BattleContext *battleCtx, 
     }
 
     if (BattleSystem_BattleType(battleSys) == (0x2 | 0x8 | 0x40)) {
-        if (((battleCtx->battlersSwitchingMask & NumToFlag(1)) == 0) && ((battleCtx->battlersSwitchingMask & NumToFlag(3)) == 0)) {
+        if (((battleCtx->battlersSwitchingMask & FlagIndex(1)) == 0) && ((battleCtx->battlersSwitchingMask & FlagIndex(3)) == 0)) {
             v0.unk_01 = 1;
             v0.unk_02 = 0;
             v0.unk_03 = 0;
-        } else if ((battleCtx->battlersSwitchingMask & NumToFlag(1)) == 0) {
+        } else if ((battleCtx->battlersSwitchingMask & FlagIndex(1)) == 0) {
             v0.unk_01 = 0;
 
             if (battleCtx->battleMons[1].moveEffectsMask & (0x40 | 0x80 | 0x40000 | 0x20000000)) {
@@ -1505,7 +1506,7 @@ void ov16_0226683C (BattleSystem * param0, BattleContext * param1)
 
     for (v1 = 0; v1 < BattleSystem_MaxBattlers(param0); v1++) {
         if (param1->battlerActions[v1][0] == 16) {
-            v0.unk_01 |= NumToFlag(v1);
+            v0.unk_01 |= FlagIndex(v1);
         }
     }
 

--- a/src/overlay104/ov104_0222DCE0.c
+++ b/src/overlay104/ov104_0222DCE0.c
@@ -38,6 +38,7 @@
 #include "party.h"
 #include "unk_0208C098.h"
 #include "unk_02092494.h"
+#include "flags.h"
 #include "overlay104/ov104_0222DCE0.h"
 
 void ov104_0222E1C0(UnkStruct_021C0794 * param0, Party * param1, Pokemon * param2);
@@ -215,7 +216,7 @@ u32 ov104_0222DD6C (UnkStruct_ov104_0223A348_sub2 * param0, u16 param1, u32 para
     v1 = 0;
 
     for (v0 = 0; v0 < 6; v0++) {
-        if (v4.unk_0A & NumToFlag(v0)) {
+        if (v4.unk_0A & FlagIndex(v0)) {
             v1++;
         }
     }
@@ -227,7 +228,7 @@ u32 ov104_0222DD6C (UnkStruct_ov104_0223A348_sub2 * param0, u16 param1, u32 para
     }
 
     for (v0 = 0; v0 < 6; v0++) {
-        if (v4.unk_0A & NumToFlag(v0)) {
+        if (v4.unk_0A & FlagIndex(v0)) {
             param0->unk_18_val2[v0] = v1;
         }
     }

--- a/src/overlay104/ov104_0223A0C4.c
+++ b/src/overlay104/ov104_0223A0C4.c
@@ -24,6 +24,7 @@
 #include "unk_02051D8C.h"
 #include "pokemon.h"
 #include "party.h"
+#include "flags.h"
 #include "overlay104/ov104_0222DCE0.h"
 #include "overlay104/ov104_0223A0C4.h"
 
@@ -860,7 +861,7 @@ static u32 ov104_0223A3A8 (UnkStruct_0204AFC4 * param0, UnkStruct_ov104_0223A348
     v1 = 0;
 
     for (v0 = 0; v0 < 6; v0++) {
-        if (v4.unk_0A & NumToFlag(v0)) {
+        if (v4.unk_0A & FlagIndex(v0)) {
             v1++;
         }
     }
@@ -872,7 +873,7 @@ static u32 ov104_0223A3A8 (UnkStruct_0204AFC4 * param0, UnkStruct_ov104_0223A348
     }
 
     for (v0 = 0; v0 < 6; v0++) {
-        if (v4.unk_0A & NumToFlag(v0)) {
+        if (v4.unk_0A & FlagIndex(v0)) {
             param1->unk_18_val2[v0] = v1;
         }
     }

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -47,6 +47,7 @@
 #include "party.h"
 #include "item.h"
 #include "unk_02092494.h"
+#include "flags.h"
 
 #include "constants/pokemon.h"
 #include "constants/species.h"
@@ -2326,16 +2327,16 @@ u32 sub_02075E64(u32 param0)
     u16 v3 = LCRNG_Next() & 0x7;
 
     for (i = 0; i < 13; i++) {
-        if (param0 & NumToFlag(i)) {
+        if (param0 & FlagIndex(i)) {
             if (LCRNG_Next() & 1) {
-                v2 |= NumToFlag(i + 3);
+                v2 |= FlagIndex(i + 3);
             } else {
-                v3 |= NumToFlag(i + 3);
+                v3 |= FlagIndex(i + 3);
             }
         } else {
             if (LCRNG_Next() & 1) {
-                v2 |= NumToFlag(i + 3);
-                v3 |= NumToFlag(i + 3);
+                v2 |= FlagIndex(i + 3);
+                v3 |= FlagIndex(i + 3);
             }
         }
     }
@@ -3656,7 +3657,7 @@ void sub_020776B0(Party *party)
             }
         } while (partySlot == currentPartyCount);
 
-        if (sub_02077758(party, NumToFlag(partySlot)) == 0) {
+        if (sub_02077758(party, FlagIndex(partySlot)) == 0) {
             u8 monPokerus;
             do {
                 monPokerus = LCRNG_Next() & 0xff;
@@ -4466,7 +4467,7 @@ static int Pokemon_GetFormNarcIndex(int monSpecies, int monForm)
     return monSpecies;
 }
 
-u32 NumToFlag(int num)
+u32 FlagIndex(int num)
 {
     int i;
     u32 flag = 1;
@@ -4480,7 +4481,7 @@ u32 NumToFlag(int num)
     return flag;
 }
 
-int FlagToNum(u32 flag)
+int LowestBit(u32 flag)
 {
     int i;
     u32 mask = 1;

--- a/src/unk_0204AEE8.c
+++ b/src/unk_0204AEE8.c
@@ -34,6 +34,7 @@
 #include "unk_0204AEE8.h"
 #include "pokemon.h"
 #include "party.h"
+#include "flags.h"
 
 static BOOL sub_0204B470(UnkStruct_0204AFC4 * param0, UnkStruct_0204B184 * param1, u16 param2, UnkStruct_ov104_0223A348_sub2 * param3, u8 param4, u16 * param5, u16 * param6, UnkStruct_0204B404 * param7, int param8);
 static void * sub_0204B630(u16 param0, int param1);
@@ -363,7 +364,7 @@ static u32 sub_0204B1E8 (UnkStruct_0204AFC4 * param0, UnkStruct_ov104_0223A348_s
     v1 = 0;
 
     for (v0 = 0; v0 < 6; v0++) {
-        if (v4.unk_0A & NumToFlag(v0)) {
+        if (v4.unk_0A & FlagIndex(v0)) {
             v1++;
         }
     }
@@ -375,7 +376,7 @@ static u32 sub_0204B1E8 (UnkStruct_0204AFC4 * param0, UnkStruct_ov104_0223A348_s
     }
 
     for (v0 = 0; v0 < 6; v0++) {
-        if (v4.unk_0A & NumToFlag(v0)) {
+        if (v4.unk_0A & FlagIndex(v0)) {
             param1->unk_18_val2[v0] = v1;
         }
     }


### PR DESCRIPTION
These functions really shouldn't be declared in `pokemon.h`, since they're not related to anything about the `pokemon` concept. While we can't move the code, we can at least change the declaration to make more sense.