### PR TITLE
Document battle commands 0x34 - 0x43

### DIFF
--- a/include/battle/battle_mon.h
+++ b/include/battle/battle_mon.h
@@ -110,7 +110,7 @@ typedef struct BattleMon {
     u16 OTName[TRAINER_NAME_LEN + 1];
 
     u32 exp;
-    u32 pid;
+    u32 personality;
     u32 status;
     u32 statusVolatile;
     u32 OTId;

--- a/include/battle/btlcmd.h
+++ b/include/battle/btlcmd.h
@@ -124,6 +124,11 @@ enum OpCode {
     VALOP_AND,
 };
 
+enum CheckAbilityOp {
+    CHECK_ABILITY_HAVE,
+    CHECK_ABILITY_NONE,
+};
+
 enum StatusEffect {
     STATUS_EFFECT_LEVEL_UP = 8,
 

--- a/include/battle/common.h
+++ b/include/battle/common.h
@@ -43,7 +43,7 @@
 #define NO_TARGET_MULTI_TURN    (battleCtx->defender == BATTLER_NONE \
                                 && BattleMove_IsMultiTurn(battleCtx, battleCtx->moveCur) == TRUE \
                                 && ( \
-                                    (ATTACKING_MON.statusVolatile & VOLATILE_CONDITION_CHARGE_TURN) \
+                                    (ATTACKING_MON.statusVolatile & VOLATILE_CONDITION_MOVE_LOCKED) \
                                     || (battleCtx->battleStatusMask & SYSCTL_LAST_OF_MULTI_TURN) \
                                 ))
 #define NO_TARGET               (NO_TARGET_SINGLE_TURN || NO_TARGET_MULTI_TURN)

--- a/include/constants/battle/condition.h
+++ b/include/constants/battle/condition.h
@@ -24,7 +24,7 @@
 // unused flag: 1 << 7
 #define VOLATILE_CONDITION_BIDE         ((1 << 8) | (1 << 9)) // counter for the number of Bide turns remaining
 #define VOLATILE_CONDITION_THRASH       ((1 << 10) | (1 << 11)) // counter for the number of Thrash turns remaining
-#define VOLATILE_CONDITION_CHARGE_TURN  (1 << 12)
+#define VOLATILE_CONDITION_MOVE_LOCKED  (1 << 12)
 #define VOLATILE_CONDITION_BIND         ((1 << 13) | (1 << 14) | (1 << 15)) // counter for the number of Bind turns remaining
 #define VOLATILE_CONDITION_ATTRACT      ((1 << 16) | (1 << 17) | (1 << 18) | (1 << 19)) // each bit here defines which battlers the mon is infatuated with
 #define VOLATILE_CONDITION_FOCUS_ENERGY (1 << 20)

--- a/include/overlay016/ov16_0225177C.h
+++ b/include/overlay016/ov16_0225177C.h
@@ -227,7 +227,16 @@ void BattleIO_ClearBuffer(BattleContext *battleCtx, int battler);
  * presented via outBuf
  */
 int BattleMon_Get(BattleContext *battleCtx, int battler, enum BattleMonParam paramID, void *buf);
-void ov16_022523E8(BattleContext * param0, int param1, int param2, const void * param3);
+
+/**
+ * @brief Set a data field value for a given battler.
+ * 
+ * @param battleCtx 
+ * @param battler       The requested battler
+ * @param paramID       ID of the field to retrieve from the battler
+ * @param buf           Buffer input for the value to be set
+ */
+void BattleMon_Set(BattleContext *battleCtx, int battler, enum BattleMonParam paramID, const void *buf);
 void ov16_02252A14(BattleContext * param0, int param1, int param2, int param3);
 void ov16_02252A2C(BattleMon * param0, int param1, int param2);
 u8 BattleSystem_CompareBattlerSpeed(BattleSystem * param0, BattleContext * param1, int param2, int param3, int param4);

--- a/include/overlay016/ov16_0225177C.h
+++ b/include/overlay016/ov16_0225177C.h
@@ -267,8 +267,27 @@ int BattleSystem_Defender(BattleSystem *battleSys, BattleContext *battleCtx, int
 void BattleSystem_RedirectTarget(BattleSystem * param0, BattleContext * param1, int param2, u16 param3);
 BOOL BattleMove_TriggerRedirectionAbilities(BattleSystem * param0, BattleContext * param1);
 void BattleMon_CopyToParty(BattleSystem * param0, BattleContext * param1, int param2);
-void ov16_02253EF0(BattleSystem * param0, BattleContext * param1, int param2);
-void BattleSystem_BreakMultiTurn(BattleSystem * param0, BattleContext * param1, int param2);
+
+/**
+ * @brief Locks the battler into their current move.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @param battler 
+ */
+void Battler_LockMoveChoice(BattleSystem *battleSys, BattleContext *battleCtx, int battler);
+
+/**
+ * @brief Unlocks the battler's future move choices.
+ * 
+ * This will also, as a convenience, toggle off the flags for Bide and semi-
+ * invulnerable moves and reset the counters for Rollout and Fury Cutter.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @param battler 
+ */
+void Battler_UnlockMoveChoice(BattleSystem *battleSys, BattleContext *battleCtx, int battler);
 int ov16_02253F7C(BattleContext * param0, int param1);
 BOOL BattleSystem_CheckTrainerMessage(BattleSystem * param0, BattleContext * param1);
 void BattleContext_Init(BattleContext * param0);
@@ -540,7 +559,15 @@ int BattleSystem_CalcDamageVariance(BattleSystem *battleSys, BattleContext *batt
 int BattleSystem_CalcCriticalMulti(BattleSystem *battleSys, BattleContext *battleCtx, int attacker, int defender, int criticalStage, u32 sideConditions);
 BOOL ov16_0225AFF4(u16 param0);
 BOOL ov16_0225B02C(BattleSystem * param0, BattleContext * param1, int param2, u16 param3);
-BOOL ov16_0225B084(BattleContext * param0, u16 param1);
+
+/**
+ * @brief Check if a given move can be Encored.
+ * 
+ * @param battleCtx 
+ * @param move 
+ * @return TRUE if the move can be Encored, FALSE otherwise.
+ */
+BOOL BattleSystem_CanEncoreMove(BattleContext *battleCtx, u16 move);
 BOOL ov16_0225B0C0(BattleContext * param0, u16 param1);
 
 /**

--- a/include/overlay016/ov16_0226485C.h
+++ b/include/overlay016/ov16_0226485C.h
@@ -42,9 +42,9 @@ void BattleIO_UpdateExpGauge(BattleSystem * param0, BattleContext * param1, int 
 void BattleIO_PlayFaintingSequence(BattleSystem * param0, BattleContext * param1, int param2);
 void BattleIO_PlaySound(BattleSystem * param0, BattleContext * param1, int param2, int param3);
 void BattleIO_FadeOut(BattleSystem * param0, BattleContext * param1);
-void ov16_02265EE8(BattleSystem * param0, int param1, int param2);
-void ov16_02265FB8(BattleSystem * param0, int param1, int param2);
-void ov16_02265FD8(BattleSystem * param0, int param1, int param2);
+void BattleIO_ToggleVanish(BattleSystem * param0, int param1, int param2);
+void BattleIO_SetStatusIcon(BattleSystem * param0, int param1, int param2);
+void BattleIO_TrainerMessage(BattleSystem * param0, int param1, int param2);
 void BattleIO_PlayStatusEffect(BattleSystem * param0, BattleContext * param1, int param2, int param3);
 void ov16_02266028(BattleSystem * param0, BattleContext * param1, int param2, int param3, int param4);
 void ov16_02266058(BattleSystem * param0, BattleContext * param1, int param2, int param3);

--- a/src/overlay016/battle_controller.c
+++ b/src/overlay016/battle_controller.c
@@ -2328,7 +2328,7 @@ static BOOL BattleController_DecrementPP(BattleSystem *battleSys, BattleContext 
         }
     } else if (ATTACKING_MON.ppCur[moveSlot] == 0
             && (battleCtx->battleStatusMask & SYSCTL_LAST_OF_MULTI_TURN) == FALSE
-            && (ATTACKING_MON.statusVolatile & VOLATILE_CONDITION_CHARGE_TURN) == FALSE
+            && (ATTACKING_MON.statusVolatile & VOLATILE_CONDITION_MOVE_LOCKED) == FALSE
             && (ATTACKING_MON.statusVolatile & VOLATILE_CONDITION_THRASH) == FALSE
             && MON_IS_UPROARING(battleCtx->attacker) == FALSE
             && moveSlot < LEARNED_MOVES_MAX) {
@@ -2371,7 +2371,7 @@ static BOOL BattleController_HasNoTarget(BattleSystem *battleSys, BattleContext 
             && result == FALSE
             && solarMove == FALSE
             && Battler_HeldItemEffect(battleCtx, battleCtx->attacker) != HOLD_EFFECT_CHARGE_SKIP
-            && (ATTACKING_MON.statusVolatile & VOLATILE_CONDITION_CHARGE_TURN) == FALSE) {
+            && (ATTACKING_MON.statusVolatile & VOLATILE_CONDITION_MOVE_LOCKED) == FALSE) {
         battleCtx->defender = battleCtx->attacker;
     }
 
@@ -3051,7 +3051,7 @@ static int BattleController_CheckMoveHitOverrides(BattleSystem *battleSys, Battl
             && (MOVE_DATA(move).flags & MOVE_FLAG_CAN_PROTECT)
             && (move != MOVE_CURSE || BattleSystem_IsGhostCurse(battleCtx, move, attacker) == TRUE) // Ghost-Curse can be Protected
             && (BattleMove_IsMultiTurn(battleCtx, move) == FALSE || (battleCtx->battleStatusMask & SYSCTL_LAST_OF_MULTI_TURN))) {
-        BattleSystem_BreakMultiTurn(battleSys, battleCtx, attacker);
+        Battler_UnlockMoveChoice(battleSys, battleCtx, attacker);
         battleCtx->moveStatusFlags |= MOVE_STATUS_PROTECTED;
         return 0;
     }

--- a/src/overlay016/battle_script.c
+++ b/src/overlay016/battle_script.c
@@ -3257,7 +3257,7 @@ static BOOL ov16_02242A14 (BattleSystem * param0, BattleContext * param1)
         BattleAI_SetAbility(param1, v4, v5);
     }
 
-    ov16_022523E8(param1, v4, v2, (u8 *)&v5);
+    BattleMon_Set(param1, v4, v2, (u8 *)&v5);
     BattleMon_CopyToParty(param0, param1, v4);
 
     return 0;
@@ -3521,7 +3521,7 @@ static BOOL ov16_02242DBC (BattleSystem * param0, BattleContext * param1)
             BattleAI_SetAbility(param1, v4, v5);
         }
 
-        ov16_022523E8(param1, v4, v2, (u8 *)&v5);
+        BattleMon_Set(param1, v4, v2, (u8 *)&v5);
         BattleMon_CopyToParty(param0, param1, v4);
     }
 

--- a/src/overlay016/battle_script.c
+++ b/src/overlay016/battle_script.c
@@ -3292,7 +3292,7 @@ static BOOL ov16_02242B74 (BattleSystem * param0, BattleContext * param1)
     v1 = BattleScript_Read(param1);
     v2 = BattleScript_Battler(param0, param1, v0);
 
-    ov16_02265EE8(param0, v2, v1);
+    BattleIO_ToggleVanish(param0, v2, v1);
 
     return 0;
 }
@@ -3672,7 +3672,7 @@ static BOOL ov16_0224314C (BattleSystem * param0, BattleContext * param1)
     v1 = BattleScript_Read(param1);
     v2 = BattleScript_Battler(param0, param1, v0);
 
-    ov16_02265FB8(param0, v2, v1);
+    BattleIO_SetStatusIcon(param0, v2, v1);
 
     return 0;
 }
@@ -3689,7 +3689,7 @@ static BOOL ov16_02243184 (BattleSystem * param0, BattleContext * param1)
     v1 = BattleScript_Read(param1);
     v2 = BattleScript_Battler(param0, param1, v0);
 
-    ov16_02265FD8(param0, v2, v1);
+    BattleIO_TrainerMessage(param0, v2, v1);
 
     return 0;
 }
@@ -4032,7 +4032,7 @@ static BOOL ov16_0224355C (BattleSystem * param0, BattleContext * param1)
     v0 = BattleScript_Read(param1);
     v1 = BattleScript_Battler(param0, param1, v0);
 
-    ov16_02265FD8(param0, v1, param1->msgTemp);
+    BattleIO_TrainerMessage(param0, v1, param1->msgTemp);
 
     return 0;
 }

--- a/src/overlay016/battle_script.c
+++ b/src/overlay016/battle_script.c
@@ -3589,7 +3589,7 @@ static BOOL ov16_02242F8C (BattleSystem * param0, BattleContext * param1)
         }
     }
 
-    if ((v1) && (ov16_0225B084(param1, v1) == 1)) {
+    if ((v1) && (BattleSystem_CanEncoreMove(param1, v1) == 1)) {
         param1->battleStatusMask &= (0x1 ^ 0xffffffff);
         param1->battleStatusMask &= (0x4000 ^ 0xffffffff);
         param1->moveCur = v1;
@@ -3640,7 +3640,7 @@ static BOOL ov16_022430F4 (BattleSystem * param0, BattleContext * param1)
     v0 = BattleScript_Read(param1);
     v1 = BattleScript_Battler(param0, param1, v0);
 
-    ov16_02253EF0(param0, param1, v1);
+    Battler_LockMoveChoice(param0, param1, v1);
 
     return 0;
 }
@@ -3655,7 +3655,7 @@ static BOOL ov16_02243120 (BattleSystem * param0, BattleContext * param1)
     v0 = BattleScript_Read(param1);
     v1 = BattleScript_Battler(param0, param1, v0);
 
-    BattleSystem_BreakMultiTurn(param0, param1, v1);
+    Battler_UnlockMoveChoice(param0, param1, v1);
 
     return 0;
 }
@@ -4631,7 +4631,7 @@ static BOOL ov16_02244208 (BattleSystem * param0, BattleContext * param1)
     v0 = BattleScript_Read(param1);
     v1 = Battler_SlotForMove(&param1->battleMons[param1->defender], param1->movePrevByBattler[param1->defender]);
 
-    if (ov16_0225B084(param1, param1->movePrevByBattler[param1->defender]) == 0) {
+    if (BattleSystem_CanEncoreMove(param1, param1->movePrevByBattler[param1->defender]) == 0) {
         v1 = 4;
     }
 
@@ -5332,12 +5332,12 @@ static BOOL ov16_0224544C (BattleSystem * param0, BattleContext * param1)
     param1->selfTurnFlags[param1->attacker].repeatedMoveCount = param1->battleMons[param1->attacker].moveEffectsData.rolloutCount;
 
     if ((param1->battleMons[param1->attacker].statusVolatile & 0x1000) == 0) {
-        ov16_02253EF0(param0, param1, param1->attacker);
+        Battler_LockMoveChoice(param0, param1, param1->attacker);
         param1->battleMons[param1->attacker].moveEffectsData.rolloutCount = 5;
     }
 
     if (--param1->battleMons[param1->attacker].moveEffectsData.rolloutCount == 0) {
-        BattleSystem_BreakMultiTurn(param0, param1, param1->attacker);
+        Battler_UnlockMoveChoice(param0, param1, param1->attacker);
     }
 
     param1->movePower = param1->aiContext.moveTable[param1->moveCur].power;

--- a/src/overlay016/battle_script.c
+++ b/src/overlay016/battle_script.c
@@ -9,6 +9,7 @@
 #include "constants/sdat.h"
 #include "constants/battle/condition.h"
 #include "constants/battle/message_tags.h"
+#include "constants/battle/moves.h"
 #include "constants/battle/side_effects.h"
 #include "constants/battle/system_control.h"
 #include "constants/battle/terrain.h"
@@ -157,22 +158,22 @@ static BOOL ov16_0224226C(BattleSystem * param0, BattleContext * param1);
 static BOOL BtlCmd_SetupMultiHit(BattleSystem *battleSys, BattleContext *battleCtx);
 static BOOL BtlCmd_SetVarValue(BattleSystem *battleSys, BattleContext *battleCtx);
 static BOOL BtlCmd_ChangeStatStage(BattleSystem *battleSys, BattleContext *battleCtx);
-static BOOL ov16_02242A14(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_02242B38(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_02242B74(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_02242BAC(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_02242C6C(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_02242CA4(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_02242DBC(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_02242F1C(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_02242F3C(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_02242F5C(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_02242F8C(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_022430A4(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_022430F4(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_02243120(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_0224314C(BattleSystem * param0, BattleContext * param1);
-static BOOL ov16_02243184(BattleSystem * param0, BattleContext * param1);
+static BOOL BtlCmd_SetMonDataValue(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_ClearVolatileStatus(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_ToggleVanish(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_CheckAbility(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_Random(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_SetVarFromVar(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_SetMonDataFromVar(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_Jump(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_CallSub(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_CallSubFromVar(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_SetMirrorMove(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_ResetStatChanges(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_LockMoveChoice(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_UnlockMoveChoice(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_SetStatusIcon(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_TrainerMessage(BattleSystem *battleSys, BattleContext *battleCtx);
 static BOOL ov16_022432B4(BattleSystem * param0, BattleContext * param1);
 static BOOL ov16_02243334(BattleSystem * param0, BattleContext * param1);
 static BOOL ov16_02243398(BattleSystem * param0, BattleContext * param1);
@@ -417,22 +418,22 @@ static const BtlCmd sBattleCommands[] = {
     BtlCmd_SetupMultiHit,
     BtlCmd_SetVarValue,
     BtlCmd_ChangeStatStage,
-    ov16_02242A14,
-    ov16_02242B38,
-    ov16_02242B74,
-    ov16_02242BAC,
-    ov16_02242C6C,
-    ov16_02242CA4,
-    ov16_02242DBC,
-    ov16_02242F1C,
-    ov16_02242F3C,
-    ov16_02242F5C,
-    ov16_02242F8C,
-    ov16_022430A4,
-    ov16_022430F4,
-    ov16_02243120,
-    ov16_0224314C,
-    ov16_02243184,
+    BtlCmd_SetMonDataValue,
+    BtlCmd_ClearVolatileStatus,
+    BtlCmd_ToggleVanish,
+    BtlCmd_CheckAbility,
+    BtlCmd_Random,
+    BtlCmd_SetVarFromVar,
+    BtlCmd_SetMonDataFromVar,
+    BtlCmd_Jump,
+    BtlCmd_CallSub,
+    BtlCmd_CallSubFromVar,
+    BtlCmd_SetMirrorMove,
+    BtlCmd_ResetStatChanges,
+    BtlCmd_LockMoveChoice,
+    BtlCmd_UnlockMoveChoice,
+    BtlCmd_SetStatusIcon,
+    BtlCmd_TrainerMessage,
     ov16_022432B4,
     ov16_02243334,
     ov16_02243398,
@@ -3180,518 +3181,670 @@ static BOOL BtlCmd_ChangeStatStage(BattleSystem *battleSys, BattleContext *battl
     return FALSE;
 }
 
-static BOOL ov16_02242A14 (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Update the value of a battler's data field using an operation applied
+ * to itself and a static source value.
+ * 
+ * Inputs:
+ * 1. The operation to apply; see enum OpCode for possible values.
+ * 2. ID of the battler to target as a source operand and the destination.
+ * 3. ID of the battler's data field to target as a source operand and
+ * the destination.
+ * 4. A static source value to use as the second operand.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE 
+ */
+static BOOL BtlCmd_SetMonDataValue(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int v1;
-    int v2;
-    int v3;
-    int v4;
-    int v5;
-    u32 v6;
+    BattleScript_Iter(battleCtx, 1);
+    int op = BattleScript_Read(battleCtx);
+    int inBattler = BattleScript_Read(battleCtx);
+    int paramID = BattleScript_Read(battleCtx);
+    int srcVal = BattleScript_Read(battleCtx);
 
-    BattleScript_Iter(param1, 1);
+    int battler = BattleScript_Battler(battleSys, battleCtx, inBattler);
+    int monData = BattleMon_Get(battleCtx, battler, paramID, NULL);
 
-    v0 = BattleScript_Read(param1);
-    v1 = BattleScript_Read(param1);
-    v2 = BattleScript_Read(param1);
-    v3 = BattleScript_Read(param1);
-    v4 = BattleScript_Battler(param0, param1, v1);
-    v5 = BattleMon_Get(param1, v4, v2, NULL);
+    switch (op) {
+    case VALOP_SET:
+        monData = srcVal;
+        break;
 
-    switch (v0) {
-    case ((6 + 1) + 0):
-        v5 = v3;
+    case VALOP_ADD:
+        monData += srcVal;
         break;
-    case ((6 + 1) + 1):
-        v5 += v3;
-        break;
-    case ((6 + 1) + 2):
-        v5 -= v3;
-        break;
-    case ((6 + 1) + 3):
-        v5 |= v3;
-        break;
-    case ((6 + 1) + 4):
-        v5 &= (v3 ^ 0xffffffff);
-        break;
-    case ((6 + 1) + 5):
-        v5 *= v3;
-        break;
-    case ((6 + 1) + 6):
-        v5 /= v3;
-        break;
-    case ((6 + 1) + 7):
-        v5 = v5 << v3;
-        break;
-    case ((6 + 1) + 8):
-        v6 = v5;
-        v6 = v6 >> v3;
-        v5 = v6;
-        break;
-    case ((6 + 1) + 9):
-        v5 = FlagIndex(v3);
-        break;
-    case ((6 + 1) + 10):
-        GF_ASSERT(0);
-        break;
-    case ((6 + 1) + 11):
-        v5 -= v3;
 
-        if (v5 < 0) {
-            v5 = 0;
+    case VALOP_SUB:
+        monData -= srcVal;
+        break;
+
+    case VALOP_FLAG_ON:
+        monData |= srcVal;
+        break;
+
+    case VALOP_FLAG_OFF:
+        monData &= FLAG_NEGATE(srcVal);
+        break;
+
+    case VALOP_MUL:
+        monData *= srcVal;
+        break;
+
+    case VALOP_DIV:
+        monData /= srcVal;
+        break;
+
+    case VALOP_LSH:
+        monData = monData << srcVal;
+        break;
+
+    case VALOP_RSH:
+        u32 mask = monData;
+        mask = mask >> srcVal;
+        monData = mask;
+        break;
+
+    case VALOP_FLAG_INDEX:
+        monData = FlagIndex(srcVal);
+        break;
+
+    case VALOP_GET:
+        GF_ASSERT(FALSE);
+        break;
+
+    case VALOP_SUB_TO_ZERO:
+        monData -= srcVal;
+
+        if (monData < 0) {
+            monData = 0;
         }
         break;
-    case ((6 + 1) + 12):
-        v5 ^= v3;
+
+    case VALOP_XOR:
+        monData ^= srcVal;
         break;
-    case ((6 + 1) + 13):
-        v5 &= v3;
+
+    case VALOP_AND:
+        monData &= srcVal;
         break;
+
     default:
-        GF_ASSERT(0);
+        GF_ASSERT(FALSE);
         break;
     }
 
-    if (v2 == 26) {
-        BattleAI_SetAbility(param1, v4, v5);
+    if (paramID == BATTLEMON_ABILITY) {
+        BattleAI_SetAbility(battleCtx, battler, monData);
     }
 
-    BattleMon_Set(param1, v4, v2, (u8 *)&v5);
-    BattleMon_CopyToParty(param0, param1, v4);
+    BattleMon_Set(battleCtx, battler, paramID, &monData);
+    BattleMon_CopyToParty(battleSys, battleCtx, battler);
 
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_02242B38 (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Clear a particular volatile status for a battler.
+ * 
+ * Inputs:
+ * 1. The battler whose volatile status should be cleared.
+ * 2. Bitmask of the volatile status condition(s) to be cleared.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE
+ */
+static BOOL BtlCmd_ClearVolatileStatus(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int v1;
-    int v2;
+    BattleScript_Iter(battleCtx, 1);
+    int inBattler = BattleScript_Read(battleCtx);
+    int volStatus = BattleScript_Read(battleCtx);
 
-    BattleScript_Iter(param1, 1);
+    int battler = BattleScript_Battler(battleSys, battleCtx, inBattler);
+    battleCtx->clearVolatileStatus[battler] |= volStatus;
 
-    v1 = BattleScript_Read(param1);
-    v2 = BattleScript_Read(param1);
-    v0 = BattleScript_Battler(param0, param1, v1);
-
-    param1->clearVolatileStatus[v0] |= v2;
-
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_02242B74 (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Toggle the "vanished" flag for a battler.
+ * 
+ * This flag controls whether or not the battler's sprite is visible, e.g.,
+ * during a multi-turn move like Bounce or Dig.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE
+ */
+static BOOL BtlCmd_ToggleVanish(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int v1;
-    int v2;
+    BattleScript_Iter(battleCtx, 1);
+    int inBattler = BattleScript_Read(battleCtx);
+    int toggle = BattleScript_Read(battleCtx);
 
-    BattleScript_Iter(param1, 1);
+    int battler = BattleScript_Battler(battleSys, battleCtx, inBattler);
+    BattleIO_ToggleVanish(battleSys, battler, toggle);
 
-    v0 = BattleScript_Read(param1);
-    v1 = BattleScript_Read(param1);
-    v2 = BattleScript_Battler(param0, param1, v0);
-
-    BattleIO_ToggleVanish(param0, v2, v1);
-
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_02242BAC (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Check the ability of a battler or set of battlers.
+ * 
+ * Inputs:
+ * 1. Op-code which controls the behavior. See enum CheckAbilityOp
+ * 2. Input battler (or set of battlers) whose ability should be checked
+ * 3. The ability to check for any battler to have (or not have)
+ * 4. Jump distance if a battler in the input set meets the criteria
+ * 
+ * Side effects:
+ * - If any battler matches the criteria, battleCtx->abilityMon will be set
+ * to their identifier.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE 
+ */
+static BOOL BtlCmd_CheckAbility(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int v1;
-    int v2;
-    int v3;
-    int v4;
 
-    BattleScript_Iter(param1, 1);
+    BattleScript_Iter(battleCtx, 1);
+    int op = BattleScript_Read(battleCtx);
+    int inBattler = BattleScript_Read(battleCtx);
+    int ability = BattleScript_Read(battleCtx);
+    int jump = BattleScript_Read(battleCtx);
 
-    v0 = BattleScript_Read(param1);
-    v1 = BattleScript_Read(param1);
-    v2 = BattleScript_Read(param1);
-    v3 = BattleScript_Read(param1);
+    int battler;
+    if (inBattler == BTLSCR_ALL_BATTLERS) {
+        int maxBattlers = BattleSystem_MaxBattlers(battleSys);
 
-    if (v1 == 0x0) {
-        {
-            int v5;
-
-            v5 = BattleSystem_MaxBattlers(param0);
-
-            for (v4 = 0; v4 < v5; v4++) {
-                if (v0 == 0) {
-                    if (Battler_Ability(param1, v4) == v2) {
-                        BattleScript_Iter(param1, v3);
-                        param1->abilityMon = v4;
-                        break;
-                    }
-                } else {
-                    if (Battler_Ability(param1, v4) == v2) {
-                        break;
-                    }
+        for (battler = 0; battler < maxBattlers; battler++) {
+            if (op == CHECK_ABILITY_HAVE) {
+                if (Battler_Ability(battleCtx, battler) == ability) {
+                    BattleScript_Iter(battleCtx, jump);
+                    battleCtx->abilityMon = battler;
+                    break;
                 }
+            } else if (Battler_Ability(battleCtx, battler) == ability) {
+                break;
             }
         }
     } else {
-        v4 = BattleScript_Battler(param0, param1, v1);
+        battler = BattleScript_Battler(battleSys, battleCtx, inBattler);
 
-        if (v0 == 0) {
-            if (Battler_Ability(param1, v4) == v2) {
-                BattleScript_Iter(param1, v3);
-                param1->abilityMon = v4;
+        if (op == CHECK_ABILITY_HAVE) {
+            if (Battler_Ability(battleCtx, battler) == ability) {
+                BattleScript_Iter(battleCtx, jump);
+                battleCtx->abilityMon = battler;
             }
-        } else {
-            if (Battler_Ability(param1, v4) != v2) {
-                BattleScript_Iter(param1, v3);
-                param1->abilityMon = v4;
-            }
+        } else if (Battler_Ability(battleCtx, battler) != ability) {
+            BattleScript_Iter(battleCtx, jump);
+            battleCtx->abilityMon = battler;
         }
     }
 
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_02242C6C (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Generate a random value in the specified range, inclusive on both
+ * ends, and offseting the result by a static value.
+ * 
+ * Inputs:
+ * 1. The maximum value R of the range [0, R]
+ * 2. The value by which to offset the generated random value
+ * 
+ * Side effects:
+ * - battleCtx->calcTemp will be set to the result value
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE
+ */
+static BOOL BtlCmd_Random(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int v1;
+    BattleScript_Iter(battleCtx, 1);
+    int range = BattleScript_Read(battleCtx);
+    range += 1;
+    int offset = BattleScript_Read(battleCtx);
 
-    BattleScript_Iter(param1, 1);
+    battleCtx->calcTemp = (BattleSystem_RandNext(battleSys) % range) + offset;
 
-    v0 = BattleScript_Read(param1);
-    v0 += 1;
-    v1 = BattleScript_Read(param1);
-
-    param1->calcTemp = (BattleSystem_RandNext(param0) % v0) + v1;
-
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_02242CA4 (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Update the value of a variable using an operation applied to itself
+ * and the value of another variable.
+ * 
+ * Inputs:
+ * 1. The operation to apply; see enum OpCode for possible values.
+ * 2. ID of the variable to target as a source operand and the destination.
+ * 3. ID of the variable to use as the second operand.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE
+ */
+static BOOL BtlCmd_SetVarFromVar(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int v1;
-    int v2;
-    int * v3;
-    int * v4;
-    u32 v5;
+    BattleScript_Iter(battleCtx, 1);
+    int op = BattleScript_Read(battleCtx);
+    int dstVar = BattleScript_Read(battleCtx);
+    int srcVar = BattleScript_Read(battleCtx);
 
-    BattleScript_Iter(param1, 1);
+    int *dstData = BattleScript_VarAddress(battleSys, battleCtx, dstVar);
+    int *srcData = BattleScript_VarAddress(battleSys, battleCtx, srcVar);
 
-    v0 = BattleScript_Read(param1);
-    v1 = BattleScript_Read(param1);
-    v2 = BattleScript_Read(param1);
-    v3 = BattleScript_VarAddress(param0, param1, v1);
-    v4 = BattleScript_VarAddress(param0, param1, v2);
+    switch (op) {
+    case VALOP_SET:
+        *dstData = *srcData;
+        break;
 
-    switch (v0) {
-    case ((6 + 1) + 0):
-        v3[0] = v4[0];
+    case VALOP_ADD:
+        *dstData += *srcData;
         break;
-    case ((6 + 1) + 1):
-        v3[0] += v4[0];
-        break;
-    case ((6 + 1) + 2):
-        v3[0] -= v4[0];
-        break;
-    case ((6 + 1) + 3):
-        v3[0] |= v4[0];
-        break;
-    case ((6 + 1) + 4):
-        v3[0] &= (v4[0] ^ 0xffffffff);
-        break;
-    case ((6 + 1) + 5):
-        v3[0] *= v4[0];
-        break;
-    case ((6 + 1) + 6):
-        v3[0] /= v4[0];
-        break;
-    case ((6 + 1) + 7):
-        v3[0] = v3[0] << v4[0];
-        break;
-    case ((6 + 1) + 8):
-        v5 = v3[0];
-        v5 = v5 >> v4[0];
-        v3[0] = v5;
-        break;
-    case ((6 + 1) + 9):
-        v3[0] = FlagIndex(v4[0]);
-        break;
-    case ((6 + 1) + 10):
-        v4[0] = v3[0];
-        break;
-    case ((6 + 1) + 11):
-        v3[0] -= v4[0];
 
-        if (v3[0] < 0) {
-            v3[0] = 0;
+    case VALOP_SUB:
+        *dstData -= *srcData;
+        break;
+
+    case VALOP_FLAG_ON:
+        *dstData |= *srcData;
+        break;
+
+    case VALOP_FLAG_OFF:
+        *dstData &= FLAG_NEGATE(*srcData);
+        break;
+
+    case VALOP_MUL:
+        *dstData *= *srcData;
+        break;
+
+    case VALOP_DIV:
+        *dstData /= *srcData;
+        break;
+
+    case VALOP_LSH:
+        *dstData = *dstData << *srcData;
+        break;
+
+    case VALOP_RSH:
+        u32 tmp = *dstData;
+        tmp = tmp >> *srcData;
+        *dstData = tmp;
+        break;
+
+    case VALOP_FLAG_INDEX:
+        *dstData = FlagIndex(*srcData);
+        break;
+
+    case VALOP_GET:
+        *srcData = *dstData;
+        break;
+
+    case VALOP_SUB_TO_ZERO:
+        *dstData -= *srcData;
+
+        if (*dstData < 0) {
+            *dstData = 0;
         }
         break;
-    case ((6 + 1) + 12):
-        v3[0] ^= v4[0];
+
+    case VALOP_XOR:
+        *dstData ^= *srcData;
         break;
-    case ((6 + 1) + 13):
-        v3[0] &= v4[0];
+
+    case VALOP_AND:
+        *dstData &= *srcData;
         break;
+
     default:
-        GF_ASSERT(0);
+        GF_ASSERT(FALSE);
         break;
     }
 
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_02242DBC (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Update the value of a battler's data field using an operation applied
+ * to itself and the value of a variable.
+ * 
+ * Inputs:
+ * 1. The operation to apply; see enum OpCode for possible values.
+ * 2. ID of the battler to target as a source operand and the destination.
+ * 3. ID of the battler's data field to target as a source operand and
+ * the destination.
+ * 4. ID of the variable to use as the second operand.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE
+ */
+static BOOL BtlCmd_SetMonDataFromVar(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int v1;
-    int v2;
-    int v3;
-    int v4;
-    int v5;
-    int * v6;
-    u32 v7;
+    BattleScript_Iter(battleCtx, 1);
+    int op = BattleScript_Read(battleCtx);
+    int inBattler = BattleScript_Read(battleCtx);
+    int paramID = BattleScript_Read(battleCtx);
+    int var = BattleScript_Read(battleCtx);
 
-    BattleScript_Iter(param1, 1);
+    int battler = BattleScript_Battler(battleSys, battleCtx, inBattler);
+    int monData = BattleMon_Get(battleCtx, battler, paramID, NULL);
+    int *varData = BattleScript_VarAddress(battleSys, battleCtx, var);
 
-    v0 = BattleScript_Read(param1);
-    v1 = BattleScript_Read(param1);
-    v2 = BattleScript_Read(param1);
-    v3 = BattleScript_Read(param1);
-    v4 = BattleScript_Battler(param0, param1, v1);
-    v5 = BattleMon_Get(param1, v4, v2, NULL);
-    v6 = BattleScript_VarAddress(param0, param1, v3);
+    switch (op) {
+    case VALOP_SET:
+        monData = *varData;
+        break;
 
-    switch (v0) {
-    case ((6 + 1) + 0):
-        v5 = v6[0];
+    case VALOP_ADD:
+        monData += *varData;
         break;
-    case ((6 + 1) + 1):
-        v5 += v6[0];
-        break;
-    case ((6 + 1) + 2):
-        v5 -= v6[0];
-        break;
-    case ((6 + 1) + 3):
-        v5 |= v6[0];
-        break;
-    case ((6 + 1) + 4):
-        v5 &= (v6[0] ^ 0xffffffff);
-        break;
-    case ((6 + 1) + 5):
-        v5 *= v6[0];
-        break;
-    case ((6 + 1) + 6):
-        v5 /= v6[0];
-        break;
-    case ((6 + 1) + 7):
-        v5 = v5 << v6[0];
-        break;
-    case ((6 + 1) + 8):
-        v7 = v5;
-        v7 = v7 >> v6[0];
-        v5 = v7;
-        break;
-    case ((6 + 1) + 9):
-        v5 = FlagIndex(v6[0]);
-        break;
-    case ((6 + 1) + 10):
-        v6[0] = v5;
-        break;
-    case ((6 + 1) + 11):
-        v5 -= v6[0];
 
-        if (v5 < 0) {
-            v5 = 0;
+    case VALOP_SUB:
+        monData -= *varData;
+        break;
+
+    case VALOP_FLAG_ON:
+        monData |= *varData;
+        break;
+
+    case VALOP_FLAG_OFF:
+        monData &= FLAG_NEGATE(*varData);
+        break;
+
+    case VALOP_MUL:
+        monData *= *varData;
+        break;
+
+    case VALOP_DIV:
+        monData /= *varData;
+        break;
+
+    case VALOP_LSH:
+        monData = monData << *varData;
+        break;
+
+    case VALOP_RSH:
+        u32 mask = monData;
+        mask = mask >> *varData;
+        monData = mask;
+        break;
+
+    case VALOP_FLAG_INDEX:
+        monData = FlagIndex(*varData);
+        break;
+
+    case VALOP_GET:
+        *varData = monData;
+        break;
+
+    case VALOP_SUB_TO_ZERO:
+        monData -= *varData;
+
+        if (monData < 0) {
+            monData = 0;
         }
         break;
-    case ((6 + 1) + 12):
-        v5 ^= v6[0];
+
+    case VALOP_XOR:
+        monData ^= *varData;
         break;
-    case ((6 + 1) + 13):
-        v5 &= v6[0];
+
+    case VALOP_AND:
+        monData &= *varData;
         break;
+
     default:
-        GF_ASSERT(0);
+        GF_ASSERT(FALSE);
         break;
     }
 
-    if (v0 != ((6 + 1) + 10)) {
-        if (v2 == 26) {
-            BattleAI_SetAbility(param1, v4, v5);
+    if (op != VALOP_GET) {
+        if (paramID == BATTLEMON_ABILITY) {
+            BattleAI_SetAbility(battleCtx, battler, monData);
         }
 
-        BattleMon_Set(param1, v4, v2, (u8 *)&v5);
-        BattleMon_CopyToParty(param0, param1, v4);
+        BattleMon_Set(battleCtx, battler, paramID, &monData);
+        BattleMon_CopyToParty(battleSys, battleCtx, battler);
     }
 
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_02242F1C (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Jump ahead a certain distance.
+ * 
+ * Inputs:
+ * 1. The distance to jump forward in words.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE 
+ */
+static BOOL BtlCmd_Jump(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
+    BattleScript_Iter(battleCtx, 1);
+    int jump = BattleScript_Read(battleCtx);
 
-    BattleScript_Iter(param1, 1);
-    v0 = BattleScript_Read(param1);
-    BattleScript_Iter(param1, v0);
+    BattleScript_Iter(battleCtx, jump);
 
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_02242F3C (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Call a given subroutine sequence, returning to the current routine
+ * point finished.
+ * 
+ * Inputs:
+ * 1. ID of the subroutine sequence to call.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE 
+ */
+static BOOL BtlCmd_CallSub(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
+    BattleScript_Iter(battleCtx, 1);
+    int subseq = BattleScript_Read(battleCtx);
 
-    BattleScript_Iter(param1, 1);
-    v0 = BattleScript_Read(param1);
-    BattleScript_Call(param1, 1, v0);
+    BattleScript_Call(battleCtx, NARC_INDEX_BATTLE__SKILL__SUB_SEQ, subseq);
 
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_02242F5C (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Call a given subroutine sequence from the value of a variable,
+ * returning to the current routine point finished.
+ * 
+ * Inputs:
+ * 1. Variable containing the ID of the subroutine sequence to call.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE 
+ */
+static BOOL BtlCmd_CallSubFromVar(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int * v1;
+    BattleScript_Iter(battleCtx, 1);
+    int var = BattleScript_Read(battleCtx);
 
-    BattleScript_Iter(param1, 1);
+    int *subseq = BattleScript_VarAddress(battleSys, battleCtx, var);
+    BattleScript_Call(battleCtx, NARC_INDEX_BATTLE__SKILL__SUB_SEQ, *subseq);
 
-    v0 = BattleScript_Read(param1);
-    v1 = BattleScript_VarAddress(param0, param1, v0);
-
-    BattleScript_Call(param1, 1, v1[0]);
-
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_02242F8C (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Set the move to be copied by Mirror Move.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE
+ */
+static BOOL BtlCmd_SetMirrorMove(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int v1;
+    int move = MOVE_NONE;
+    int battleType = BattleSystem_BattleType(battleSys);
 
-    v1 = 0;
-    v0 = BattleSystem_BattleType(param0);
+    BattleScript_Iter(battleCtx, 1);
 
-    BattleScript_Iter(param1, 1);
+    if (battleCtx->moveCopied[battleCtx->attacker]) {
+        move = battleCtx->moveCopied[battleCtx->attacker];
+    } else if (battleType & BATTLE_TYPE_DOUBLES) {
+        // In double battles, choose randomly.
+        move = battleCtx->moveCopiedHit[battleCtx->attacker][0]
+            + battleCtx->moveCopiedHit[battleCtx->attacker][1]
+            + battleCtx->moveCopiedHit[battleCtx->attacker][2]
+            + battleCtx->moveCopiedHit[battleCtx->attacker][3];
 
-    if (param1->moveCopied[param1->attacker]) {
-        v1 = param1->moveCopied[param1->attacker];
-    } else {
-        if (v0 & 0x2) {
-            v1 = param1->moveCopiedHit[param1->attacker][0] + param1->moveCopiedHit[param1->attacker][1] + param1->moveCopiedHit[param1->attacker][2] + param1->moveCopiedHit[param1->attacker][3];
-
-            if (v1) {
-                do {
-                    v1 = param1->moveCopiedHit[param1->attacker][BattleSystem_RandNext(param0) % 4];
-                } while (v1 == 0);
-            }
+        if (move) {
+            do {
+                move = battleCtx->moveCopiedHit[battleCtx->attacker][BattleSystem_RandNext(battleSys) % 4];
+            } while (move == MOVE_NONE);
         }
     }
 
-    if ((v1) && (BattleSystem_CanEncoreMove(param1, v1) == 1)) {
-        param1->battleStatusMask &= (0x1 ^ 0xffffffff);
-        param1->battleStatusMask &= (0x4000 ^ 0xffffffff);
-        param1->moveCur = v1;
-        param1->defender = BattleSystem_Defender(param0, param1, param1->attacker, v1, 1, 0);
+    if (move && BattleSystem_CanEncoreMove(battleCtx, move) == TRUE) {
+        battleCtx->battleStatusMask &= ~SYSCTL_SKIP_ATTACK_MESSAGE;
+        battleCtx->battleStatusMask &= ~SYSCTL_PLAYED_MOVE_ANIMATION;
+        battleCtx->moveCur = move;
+        battleCtx->defender = BattleSystem_Defender(battleSys, battleCtx, battleCtx->attacker, move, TRUE, RANGE_SINGLE_TARGET);
 
-        if (param1->defender == 0xff) {
-            param1->commandNext = 38;
-            BattleScript_Jump(param1, 1, (0 + 281));
+        if (battleCtx->defender == BATTLER_NONE) {
+            battleCtx->commandNext = BATTLE_CONTROL_UPDATE_MOVE_BUFFERS;
+            BattleScript_Jump(battleCtx, NARC_INDEX_BATTLE__SKILL__SUB_SEQ, BATTLE_SUBSEQ_NO_TARGET);
         } else {
-            param1->battlerActions[param1->attacker][1] = param1->defender;
-            BattleScript_Jump(param1, 0, v1);
+            battleCtx->battlerActions[battleCtx->attacker][1] = battleCtx->defender;
+            BattleScript_Jump(battleCtx, NARC_INDEX_BATTLE__SKILL__WAZA_SEQ, move);
         }
     } else {
-        param1->selfTurnFlags[param1->attacker].skipPressureCheck = 1;
+        battleCtx->selfTurnFlags[battleCtx->attacker].skipPressureCheck = TRUE;
     }
 
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_022430A4 (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Reset all stat changes for all active battlers.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE
+ */
+static BOOL BtlCmd_ResetStatChanges(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int v1;
-    int v2;
+    BattleScript_Iter(battleCtx, 1);
 
-    BattleScript_Iter(param1, 1);
-
-    v2 = BattleSystem_MaxBattlers(param0);
-
-    for (v1 = 0; v1 < v2; v1++) {
-        for (v0 = 0x0; v0 < 0x8; v0++) {
-            param1->battleMons[v1].statBoosts[v0] = 6;
+    int maxBattlers = BattleSystem_MaxBattlers(battleSys);
+    for (int i = 0; i < maxBattlers; i++) {
+        for (int j = BATTLE_STAT_HP; j < BATTLE_STAT_MAX; j++) {
+            battleCtx->battleMons[i].statBoosts[j] = 6;
         }
 
-        param1->battleMons[v1].statusVolatile &= (0x100000 ^ 0xffffffff);
+        battleCtx->battleMons[i].statusVolatile &= ~VOLATILE_CONDITION_FOCUS_ENERGY;
     }
 
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_022430F4 (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Locks the given battler into their current move.
+ * 
+ * This is used by moves such as Thrash and Outrage to force the user to keep
+ * using them over multiple turns.
+ * 
+ * Inputs:
+ * 1. The battler whose move choice should be locked.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE
+ */
+static BOOL BtlCmd_LockMoveChoice(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int v1;
+    BattleScript_Iter(battleCtx, 1);
+    int inBattler = BattleScript_Read(battleCtx);
+    
+    int battler = BattleScript_Battler(battleSys, battleCtx, inBattler);
+    Battler_LockMoveChoice(battleSys, battleCtx, battler);
 
-    BattleScript_Iter(param1, 1);
-
-    v0 = BattleScript_Read(param1);
-    v1 = BattleScript_Battler(param0, param1, v0);
-
-    Battler_LockMoveChoice(param0, param1, v1);
-
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_02243120 (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Unlocks the given battler's move choices.
+ * 
+ * This is invoked at the end of moves such as Thrash and Outrage to permit the
+ * user to choose a different move after their effect ends.
+ * 
+ * Inputs:
+ * 1. The battler whose move choice should be unlocked.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE
+ */
+static BOOL BtlCmd_UnlockMoveChoice(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int v1;
+    BattleScript_Iter(battleCtx, 1);
+    int inBattler = BattleScript_Read(battleCtx);
 
-    BattleScript_Iter(param1, 1);
+    int battler = BattleScript_Battler(battleSys, battleCtx, inBattler);
+    Battler_UnlockMoveChoice(battleSys, battleCtx, battler);
 
-    v0 = BattleScript_Read(param1);
-    v1 = BattleScript_Battler(param0, param1, v0);
-
-    Battler_UnlockMoveChoice(param0, param1, v1);
-
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_0224314C (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Set the status icon on a battler's HP gauge.
+ * 
+ * Inputs:
+ * 1. The battler whose HP gauge should be updated.
+ * 2. The status icon to apply to the HP gauge.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return BOOL 
+ */
+static BOOL BtlCmd_SetStatusIcon(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int v1;
-    int v2;
 
-    BattleScript_Iter(param1, 1);
+    BattleScript_Iter(battleCtx, 1);
+    int inBattler = BattleScript_Read(battleCtx);
+    int status = BattleScript_Read(battleCtx);
+    
+    int battler = BattleScript_Battler(battleSys, battleCtx, inBattler);
+    BattleIO_SetStatusIcon(battleSys, battler, status);
 
-    v0 = BattleScript_Read(param1);
-    v1 = BattleScript_Read(param1);
-    v2 = BattleScript_Battler(param0, param1, v0);
-
-    BattleIO_SetStatusIcon(param0, v2, v1);
-
-    return 0;
+    return FALSE;
 }
 
-static BOOL ov16_02243184 (BattleSystem * param0, BattleContext * param1)
+/**
+ * @brief Shows a trainer message of a particular type.
+ * 
+ * Inputs:
+ * 1. The battler whose trainer message should be shown.
+ * 2. The type of trainer message to display.
+ * 
+ * @param battleSys 
+ * @param battleCtx 
+ * @return FALSE
+ */
+static BOOL BtlCmd_TrainerMessage(BattleSystem *battleSys, BattleContext *battleCtx)
 {
-    int v0;
-    int v1;
-    int v2;
+    BattleScript_Iter(battleCtx, 1);
+    int inBattler = BattleScript_Read(battleCtx);
+    int msgType = BattleScript_Read(battleCtx);
 
-    BattleScript_Iter(param1, 1);
+    int battler = BattleScript_Battler(battleSys, battleCtx, inBattler);
+    BattleIO_TrainerMessage(battleSys, battler, msgType);
 
-    v0 = BattleScript_Read(param1);
-    v1 = BattleScript_Read(param1);
-    v2 = BattleScript_Battler(param0, param1, v0);
-
-    BattleIO_TrainerMessage(param0, v2, v1);
-
-    return 0;
+    return FALSE;
 }
 
 static u8 Unk_ov16_02270B20[] = {

--- a/src/overlay016/battle_script.c
+++ b/src/overlay016/battle_script.c
@@ -5093,7 +5093,7 @@ static BOOL ov16_02244D60 (BattleSystem * param0, BattleContext * param1)
     param1->battleMons[param1->attacker].statusVolatile |= 0x200000;
     param1->battleMons[param1->attacker].moveEffectsData.disabledMove = 0;
     param1->battleMons[param1->attacker].moveEffectsData.disabledTurns = 0;
-    param1->battleMons[param1->attacker].moveEffectsData.transformedPID = param1->battleMons[param1->defender].pid;
+    param1->battleMons[param1->attacker].moveEffectsData.transformedPID = param1->battleMons[param1->defender].personality;
     param1->battleMons[param1->attacker].moveEffectsData.transformedGender = param1->battleMons[param1->defender].gender;
     param1->battleMons[param1->attacker].moveEffectsData.mimickedMoveSlot = 0;
     param1->battleMons[param1->attacker].moveEffectsData.lastResortCount = 0;

--- a/src/overlay016/ov16_0223DF00.c
+++ b/src/overlay016/ov16_0223DF00.c
@@ -602,10 +602,10 @@ BOOL ov16_0223E30C (BattleSystem * param0, int param1, int param2, int param3, i
             if ((v4 == param2) || (v5 == param2)) {
                 v3 = BattleMon_Get(v0, param1, 52, NULL);
                 v3 &= (0x7 ^ 0xffffffff);
-                ov16_022523E8(v0, param1, 52, &v3);
+                BattleMon_Set(v0, param1, 52, &v3);
                 v3 = BattleMon_Get(v0, param1, 53, NULL);
                 v3 &= (0x8000000 ^ 0xffffffff);
-                ov16_022523E8(v0, param1, 53, &v3);
+                BattleMon_Set(v0, param1, 53, &v3);
             }
 
             v2 = 1;
@@ -622,7 +622,7 @@ BOOL ov16_0223E30C (BattleSystem * param0, int param1, int param2, int param3, i
             if ((v4 == param2) || (v5 == param2)) {
                 v3 = BattleMon_Get(v0, param1, 52, NULL);
                 v3 &= ((0x8 | 0x80 | 0xf00) ^ 0xffffffff);
-                ov16_022523E8(v0, param1, 52, &v3);
+                BattleMon_Set(v0, param1, 52, &v3);
             }
 
             v2 = 1;
@@ -639,7 +639,7 @@ BOOL ov16_0223E30C (BattleSystem * param0, int param1, int param2, int param3, i
             if ((v4 == param2) || (v5 == param2)) {
                 v3 = BattleMon_Get(v0, param1, 52, NULL);
                 v3 &= (0x10 ^ 0xffffffff);
-                ov16_022523E8(v0, param1, 52, &v3);
+                BattleMon_Set(v0, param1, 52, &v3);
             }
 
             v2 = 1;
@@ -656,7 +656,7 @@ BOOL ov16_0223E30C (BattleSystem * param0, int param1, int param2, int param3, i
             if ((v4 == param2) || (v5 == param2)) {
                 v3 = BattleMon_Get(v0, param1, 52, NULL);
                 v3 &= (0x20 ^ 0xffffffff);
-                ov16_022523E8(v0, param1, 52, &v3);
+                BattleMon_Set(v0, param1, 52, &v3);
             }
 
             v2 = 1;
@@ -673,7 +673,7 @@ BOOL ov16_0223E30C (BattleSystem * param0, int param1, int param2, int param3, i
             if ((v4 == param2) || (v5 == param2)) {
                 v3 = BattleMon_Get(v0, param1, 52, NULL);
                 v3 &= (0x40 ^ 0xffffffff);
-                ov16_022523E8(v0, param1, 52, &v3);
+                BattleMon_Set(v0, param1, 52, &v3);
             }
 
             v2 = 1;
@@ -686,7 +686,7 @@ BOOL ov16_0223E30C (BattleSystem * param0, int param1, int param2, int param3, i
 
             if (v3 & 0x7) {
                 v3 &= (0x7 ^ 0xffffffff);
-                ov16_022523E8(v0, param1, 53, &v3);
+                BattleMon_Set(v0, param1, 53, &v3);
                 v2 = 1;
             }
         }
@@ -698,7 +698,7 @@ BOOL ov16_0223E30C (BattleSystem * param0, int param1, int param2, int param3, i
 
             if (v3 & 0xf0000) {
                 v3 &= (0xf0000 ^ 0xffffffff);
-                ov16_022523E8(v0, param1, 53, &v3);
+                BattleMon_Set(v0, param1, 53, &v3);
                 v2 = 1;
             }
         }
@@ -776,7 +776,7 @@ BOOL ov16_0223E30C (BattleSystem * param0, int param1, int param2, int param3, i
 
             if ((v3 & 0x100000) == 0) {
                 v3 |= 0x100000;
-                ov16_022523E8(v0, param1, 53, &v3);
+                BattleMon_Set(v0, param1, 53, &v3);
                 v2 = 1;
             }
         }
@@ -856,7 +856,7 @@ BOOL ov16_0223E30C (BattleSystem * param0, int param1, int param2, int param3, i
 
             if (!Item_LoadParam(param4, 23, 5)) {
                 if (Battler_Side(param0, param1)) {
-                    ov16_022523E8(v0, param1, 95, &v3);
+                    BattleMon_Set(v0, param1, 95, &v3);
                 } else {
                     if ((v4 == param2) || (v5 == param2)) {
                         ov16_02252A14(v0, param1, 47, v3);

--- a/src/overlay016/ov16_0225177C.c
+++ b/src/overlay016/ov16_0225177C.c
@@ -253,7 +253,7 @@ void BattleSystem_InitBattleMon(BattleSystem *battleSys, BattleContext *battleCt
     battleCtx->battleMons[battler].curHP = Pokemon_GetValue(mon, MON_DATA_CURRENT_HP, NULL);
     battleCtx->battleMons[battler].maxHP = Pokemon_GetValue(mon, MON_DATA_MAX_HP, NULL);
     battleCtx->battleMons[battler].exp = Pokemon_GetValue(mon, MON_DATA_EXP, NULL);
-    battleCtx->battleMons[battler].pid = Pokemon_GetValue(mon, MON_DATA_PERSONALITY, NULL);
+    battleCtx->battleMons[battler].personality = Pokemon_GetValue(mon, MON_DATA_PERSONALITY, NULL);
     battleCtx->battleMons[battler].OTId = Pokemon_GetValue(mon, MON_DATA_OT_ID, NULL);
     battleCtx->battleMons[battler].OTGender = Pokemon_GetValue(mon, MON_DATA_OT_GENDER, NULL);
     battleCtx->battleMons[battler].capturedBall = Pokemon_GetValue(mon, MON_DATA_POKEBALL, NULL);
@@ -549,7 +549,7 @@ int BattleMon_Get(BattleContext *battleCtx, int battler, enum BattleMonParam par
         return battleMon->exp;
 
     case BATTLEMON_PERSONALITY:
-        return battleMon->pid;
+        return battleMon->personality;
 
     case BATTLEMON_STATUS:
         return battleMon->status;
@@ -839,7 +839,7 @@ void ov16_022523E8 (BattleContext * param0, int param1, int param2, const void *
         v6->exp = v1[0];
         break;
     case 51:
-        v6->pid = v1[0];
+        v6->personality = v1[0];
         break;
     case 52:
         v6->status = v1[0];
@@ -1106,7 +1106,7 @@ void ov16_02252A2C (BattleMon * param0, int param1, int param2)
         param0->exp += param2;
         break;
     case 51:
-        param0->pid += param2;
+        param0->personality += param2;
         break;
     case 61:
         param0->moveEffectsData.disabledTurns += param2;
@@ -4608,7 +4608,7 @@ BOOL BattleSystem_TriggerHeldItem (BattleSystem * param0, BattleContext * param1
                 param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param2].maxHP, v3);
                 param1->msgTemp = 0;
 
-                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].pid, 0) == -1) {
+                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].personality, 0) == -1) {
                     v1 = (0 + 207);
                 } else {
                     v1 = (0 + 198);
@@ -4622,7 +4622,7 @@ BOOL BattleSystem_TriggerHeldItem (BattleSystem * param0, BattleContext * param1
                 param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param2].maxHP, v3);
                 param1->msgTemp = 1;
 
-                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].pid, 1) == -1) {
+                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].personality, 1) == -1) {
                     v1 = (0 + 207);
                 } else {
                     v1 = (0 + 198);
@@ -4636,7 +4636,7 @@ BOOL BattleSystem_TriggerHeldItem (BattleSystem * param0, BattleContext * param1
                 param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param2].maxHP, v3);
                 param1->msgTemp = 2;
 
-                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].pid, 2) == -1) {
+                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].personality, 2) == -1) {
                     v1 = (0 + 207);
                 } else {
                     v1 = (0 + 198);
@@ -4650,7 +4650,7 @@ BOOL BattleSystem_TriggerHeldItem (BattleSystem * param0, BattleContext * param1
                 param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param2].maxHP, v3);
                 param1->msgTemp = 3;
 
-                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].pid, 3) == -1) {
+                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].personality, 3) == -1) {
                     v1 = (0 + 207);
                 } else {
                     v1 = (0 + 198);
@@ -4664,7 +4664,7 @@ BOOL BattleSystem_TriggerHeldItem (BattleSystem * param0, BattleContext * param1
                 param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param2].maxHP, v3);
                 param1->msgTemp = 4;
 
-                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].pid, 4) == -1) {
+                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].personality, 4) == -1) {
                     v1 = (0 + 207);
                 } else {
                     v1 = (0 + 198);
@@ -5017,7 +5017,7 @@ BOOL BattleSystem_TriggerHeldItemOnStatus (BattleSystem * param0, BattleContext 
                 param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param2].maxHP, v3);
                 param1->msgTemp = 0;
 
-                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].pid, 0) == -1) {
+                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].personality, 0) == -1) {
                     param3[0] = (0 + 207);
                 } else {
                     param3[0] = (0 + 198);
@@ -5031,7 +5031,7 @@ BOOL BattleSystem_TriggerHeldItemOnStatus (BattleSystem * param0, BattleContext 
                 param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param2].maxHP, v3);
                 param1->msgTemp = 1;
 
-                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].pid, 1) == -1) {
+                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].personality, 1) == -1) {
                     param3[0] = (0 + 207);
                 } else {
                     param3[0] = (0 + 198);
@@ -5045,7 +5045,7 @@ BOOL BattleSystem_TriggerHeldItemOnStatus (BattleSystem * param0, BattleContext 
                 param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param2].maxHP, v3);
                 param1->msgTemp = 2;
 
-                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].pid, 2) == -1) {
+                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].personality, 2) == -1) {
                     param3[0] = (0 + 207);
                 } else {
                     param3[0] = (0 + 198);
@@ -5059,7 +5059,7 @@ BOOL BattleSystem_TriggerHeldItemOnStatus (BattleSystem * param0, BattleContext 
                 param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param2].maxHP, v3);
                 param1->msgTemp = 3;
 
-                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].pid, 3) == -1) {
+                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].personality, 3) == -1) {
                     param3[0] = (0 + 207);
                 } else {
                     param3[0] = (0 + 198);
@@ -5073,7 +5073,7 @@ BOOL BattleSystem_TriggerHeldItemOnStatus (BattleSystem * param0, BattleContext 
                 param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param2].maxHP, v3);
                 param1->msgTemp = 4;
 
-                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].pid, 4) == -1) {
+                if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param2].personality, 4) == -1) {
                     param3[0] = (0 + 207);
                 } else {
                     param3[0] = (0 + 198);
@@ -5559,7 +5559,7 @@ BOOL ov16_02258CB4 (BattleSystem * param0, BattleContext * param1, int param2)
             param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param1->attacker].maxHP, v3);
             param1->msgTemp = 0;
 
-            if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->attacker].pid, 0) == -1) {
+            if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->attacker].personality, 0) == -1) {
                 v1 = (0 + 207);
             } else {
                 v1 = (0 + 198);
@@ -5573,7 +5573,7 @@ BOOL ov16_02258CB4 (BattleSystem * param0, BattleContext * param1, int param2)
             param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param1->attacker].maxHP, v3);
             param1->msgTemp = 1;
 
-            if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->attacker].pid, 1) == -1) {
+            if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->attacker].personality, 1) == -1) {
                 v1 = (0 + 207);
             } else {
                 v1 = (0 + 198);
@@ -5587,7 +5587,7 @@ BOOL ov16_02258CB4 (BattleSystem * param0, BattleContext * param1, int param2)
             param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param1->attacker].maxHP, v3);
             param1->msgTemp = 2;
 
-            if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->attacker].pid, 2) == -1) {
+            if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->attacker].personality, 2) == -1) {
                 v1 = (0 + 207);
             } else {
                 v1 = (0 + 198);
@@ -5601,7 +5601,7 @@ BOOL ov16_02258CB4 (BattleSystem * param0, BattleContext * param1, int param2)
             param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param1->attacker].maxHP, v3);
             param1->msgTemp = 3;
 
-            if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->attacker].pid, 3) == -1) {
+            if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->attacker].personality, 3) == -1) {
                 v1 = (0 + 207);
             } else {
                 v1 = (0 + 198);
@@ -5615,7 +5615,7 @@ BOOL ov16_02258CB4 (BattleSystem * param0, BattleContext * param1, int param2)
             param1->hpCalcTemp = BattleSystem_Divide(param1->battleMons[param1->attacker].maxHP, v3);
             param1->msgTemp = 4;
 
-            if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->attacker].pid, 4) == -1) {
+            if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->attacker].personality, 4) == -1) {
                 v1 = (0 + 207);
             } else {
                 v1 = (0 + 198);
@@ -5838,7 +5838,7 @@ BOOL ov16_02259204 (BattleSystem * param0, BattleContext * param1, int param2)
         param1->flingTemp = BattleSystem_Divide(param1->battleMons[param1->defender].maxHP, v2);
         param1->msgTemp = 0;
 
-        if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->defender].pid, 0) == -1) {
+        if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->defender].personality, 0) == -1) {
             param1->flingScript = (0 + 207);
         } else {
             param1->flingScript = (0 + 198);
@@ -5848,7 +5848,7 @@ BOOL ov16_02259204 (BattleSystem * param0, BattleContext * param1, int param2)
         param1->flingTemp = BattleSystem_Divide(param1->battleMons[param1->defender].maxHP, v2);
         param1->msgTemp = 1;
 
-        if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->defender].pid, 1) == -1) {
+        if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->defender].personality, 1) == -1) {
             param1->flingScript = (0 + 207);
         } else {
             param1->flingScript = (0 + 198);
@@ -5858,7 +5858,7 @@ BOOL ov16_02259204 (BattleSystem * param0, BattleContext * param1, int param2)
         param1->flingTemp = BattleSystem_Divide(param1->battleMons[param1->defender].maxHP, v2);
         param1->msgTemp = 2;
 
-        if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->defender].pid, 2) == -1) {
+        if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->defender].personality, 2) == -1) {
             param1->flingScript = (0 + 207);
         } else {
             param1->flingScript = (0 + 198);
@@ -5868,7 +5868,7 @@ BOOL ov16_02259204 (BattleSystem * param0, BattleContext * param1, int param2)
         param1->flingTemp = BattleSystem_Divide(param1->battleMons[param1->defender].maxHP, v2);
         param1->msgTemp = 3;
 
-        if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->defender].pid, 3) == -1) {
+        if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->defender].personality, 3) == -1) {
             param1->flingScript = (0 + 207);
         } else {
             param1->flingScript = (0 + 198);
@@ -5878,7 +5878,7 @@ BOOL ov16_02259204 (BattleSystem * param0, BattleContext * param1, int param2)
         param1->flingTemp = BattleSystem_Divide(param1->battleMons[param1->defender].maxHP, v2);
         param1->msgTemp = 4;
 
-        if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->defender].pid, 4) == -1) {
+        if (Pokemon_GetFlavorAffinityOf(param1->battleMons[param1->defender].personality, 4) == -1) {
             param1->flingScript = (0 + 207);
         } else {
             param1->flingScript = (0 + 198);

--- a/src/overlay016/ov16_0225177C.c
+++ b/src/overlay016/ov16_0225177C.c
@@ -57,7 +57,7 @@ BOOL BattleIO_QueueIsEmpty(BattleContext *battleCtx);
 void BattleIO_UpdateTimeout(BattleContext *battleCtx);
 void BattleIO_ClearBuffer(BattleContext *battleCtx, int battler);
 int BattleMon_Get(BattleContext *battleCtx, int battler, enum BattleMonParam paramID, void *buf);
-void ov16_022523E8(BattleContext * param0, int param1, int param2, const void * param3);
+void BattleMon_Set(BattleContext *battleCtx, int battler, enum BattleMonParam param, const void *buf);
 void ov16_02252A14(BattleContext * param0, int param1, int param2, int param3);
 void ov16_02252A2C(BattleMon * param0, int param1, int param2);
 u8 BattleSystem_CompareBattlerSpeed(BattleSystem * param0, BattleContext * param1, int param2, int param3, int param4);
@@ -703,290 +703,355 @@ int BattleMon_Get(BattleContext *battleCtx, int battler, enum BattleMonParam par
     return 0;
 }
 
-void ov16_022523E8 (BattleContext * param0, int param1, int param2, const void * param3)
+void BattleMon_Set(BattleContext *battleCtx, int battler, enum BattleMonParam paramID, const void *buf)
 {
-    int v0;
-    u32 * v1 = (u32 *)param3;
-    u16 * v2 = (u16 *)param3;
-    s16 * v3 = (s16 *)param3;
-    u8 * v4 = (u8 *)param3;
-    s8 * v5 = (s8 *)param3;
-    BattleMon * v6 = &param0->battleMons[param1];
+    BattleMon *mon = &battleCtx->battleMons[battler];
 
-    switch (param2) {
-    case 0:
-        v6->species = v2[0];
+    switch (paramID) {
+    case BATTLEMON_SPECIES:
+        mon->species = *(u16 *)buf;
         break;
-    case 1:
-        v6->attack = v2[0];
-        break;
-    case 2:
-        v6->defense = v2[0];
-        break;
-    case 3:
-        v6->speed = v2[0];
-        break;
-    case 4:
-        v6->spAttack = v2[0];
-        break;
-    case 5:
-        v6->spDefense = v2[0];
-        break;
-    case 6:
-    case 7:
-    case 8:
-    case 9:
-        v6->moves[param2 - 6] = v2[0];
-        break;
-    case 10:
-        v6->hpIV = v4[0];
-        break;
-    case 11:
-        v6->attackIV = v4[0];
-        break;
-    case 12:
-        v6->defenseIV = v4[0];
-        break;
-    case 13:
-        v6->speedIV = v4[0];
-        break;
-    case 14:
-        v6->spAttackIV = v4[0];
-        break;
-    case 15:
-        v6->spDefenseIV = v4[0];
-        break;
-    case 16:
-        v6->isEgg = v4[0];
-        break;
-    case 17:
-        v6->hasNickname = v4[0];
-        break;
-    case 18:
-    case 19:
-    case 20:
-    case 21:
-    case 22:
-    case 23:
-    case 24:
-    case 25:
-        v6->statBoosts[param2 - 18] = v5[0];
-        break;
-    case 26:
-        v6->ability = v4[0];
-        break;
-    case 27:
-        v6->type1 = v4[0];
-        break;
-    case 28:
-        v6->type2 = v4[0];
-        break;
-    case 29:
-        v6->gender = v4[0];
-        break;
-    case 30:
-        v6->isShiny = v4[0];
-        break;
-    case 31:
-    case 32:
-    case 33:
-    case 34:
-        v6->ppCur[param2 - 31] = v4[0];
-        break;
-    case 35:
-    case 36:
-    case 37:
-    case 38:
-        v6->ppUps[param2 - 35] = v4[0];
-        break;
-    case 39:
-    case 40:
-    case 41:
-    case 42:
-        GF_ASSERT(0);
-        break;
-    case 43:
-        v6->level = v4[0];
-        break;
-    case 44:
-        v6->friendship = v4[0];
-        break;
-    case 45:
-    {
-        int v7;
 
-        for (v7 = 0; v7 < 10 + 1; v7++) {
-            v6->nickname[v7] = v2[v7];
+    case BATTLEMON_ATTACK:
+        mon->attack = *(u16 *)buf;
+        break;
+
+    case BATTLEMON_DEFENSE:
+        mon->defense = *(u16 *)buf;
+        break;
+
+    case BATTLEMON_SPEED:
+        mon->speed = *(u16 *)buf;
+        break;
+
+    case BATTLEMON_SP_ATTACK:
+        mon->spAttack = *(u16 *)buf;
+        break;
+
+    case BATTLEMON_SP_DEFENSE:
+        mon->spDefense = *(u16 *)buf;
+        break;
+
+    case BATTLEMON_MOVE_1:
+    case BATTLEMON_MOVE_2:
+    case BATTLEMON_MOVE_3:
+    case BATTLEMON_MOVE_4:
+        mon->moves[paramID - BATTLEMON_MOVE_1] = *(u16 *)buf;
+        break;
+
+    case BATTLEMON_HP_IV:
+        mon->hpIV = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_ATTACK_IV:
+        mon->attackIV = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_DEFENSE_IV:
+        mon->defenseIV = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_SPEED_IV:
+        mon->speedIV = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_SP_ATTACK_IV:
+        mon->spAttackIV = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_SP_DEFENSE_IV:
+        mon->spDefenseIV = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_IS_EGG:
+        mon->isEgg = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_HAS_NICKNAME:
+        mon->hasNickname = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_HP_STAGE:
+    case BATTLEMON_ATTACK_STAGE:
+    case BATTLEMON_DEFENSE_STAGE:
+    case BATTLEMON_SPEED_STAGE:
+    case BATTLEMON_SP_ATTACK_STAGE:
+    case BATTLEMON_SP_DEFENSE_STAGE:
+    case BATTLEMON_ACCURACY_STAGE:
+    case BATTLEMON_EVASION_STAGE:
+        mon->statBoosts[paramID - BATTLEMON_HP_STAGE] = *(s8 *)buf;
+        break;
+
+    case BATTLEMON_ABILITY:
+        mon->ability = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_TYPE_1:
+        mon->type1 = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_TYPE_2:
+        mon->type2 = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_GENDER:
+        mon->gender = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_IS_SHINY:
+        mon->isShiny = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_CUR_PP_1:
+    case BATTLEMON_CUR_PP_2:
+    case BATTLEMON_CUR_PP_3:
+    case BATTLEMON_CUR_PP_4:
+        mon->ppCur[paramID - BATTLEMON_CUR_PP_1] = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_PP_UPS_1:
+    case BATTLEMON_PP_UPS_2:
+    case BATTLEMON_PP_UPS_3:
+    case BATTLEMON_PP_UPS_4:
+        mon->ppUps[paramID - BATTLEMON_PP_UPS_1] = *(u8 *)buf;
+        break;
+        
+    case BATTLEMON_MAX_PP_1:
+    case BATTLEMON_MAX_PP_2:
+    case BATTLEMON_MAX_PP_3:
+    case BATTLEMON_MAX_PP_4:
+        GF_ASSERT(FALSE);
+        break;
+
+    case BATTLEMON_LEVEL:
+        mon->level = *(u8 *)buf;
+        break;
+
+    case BATTLEMON_FRIENDSHIP:
+        mon->friendship = *(u8 *)buf;
+        break;
+        
+    case BATTLEMON_NICKNAME:
+        for (int i = 0; i < MON_NAME_LEN + 1; i++) {
+            mon->nickname[i] = ((u16 *)buf)[i];
         }
-    }
-    break;
-    case 47:
-        v6->curHP = v3[0];
         break;
-    case 48:
-        v6->maxHP = v2[0];
-        break;
-    case 49:
-    {
-        int v8;
 
-        for (v8 = 0; v8 < 10 + 1; v8++) {
-            v6->OTName[v8] = v2[v8];
+    case BATTLEMON_CUR_HP:
+        mon->curHP = *(s16 *)buf;
+        break;
+
+    case BATTLEMON_MAX_HP:
+        mon->maxHP = *(u16 *)buf;
+        break;
+
+    case BATTLEMON_OT_NAME:
+        for (int i = 0; i < MON_NAME_LEN + 1; i++) {
+            mon->OTName[i] = ((u16 *)buf)[i];
         }
-    }
-    break;
-    case 50:
-        v6->exp = v1[0];
         break;
-    case 51:
-        v6->personality = v1[0];
+
+    case BATTLEMON_EXP:
+        mon->exp = *(u32 *)buf;
         break;
-    case 52:
-        v6->status = v1[0];
+
+    case BATTLEMON_PERSONALITY:
+        mon->personality = *(u32 *)buf;
         break;
-    case 53:
-        v6->statusVolatile = v1[0];
+    
+    case BATTLEMON_STATUS:
+        mon->status = *(u32 *)buf;
         break;
-    case 54:
-        v6->OTId = v1[0];
+
+    case BATTLEMON_VOLATILE_STATUS:
+        mon->statusVolatile = *(u32 *)buf;
         break;
-    case 55:
-        v6->heldItem = v2[0];
+
+    case BATTLEMON_OT_ID:
+        mon->OTId = *(u32 *)buf;
         break;
-    case 56:
-        v6->timesDamaged = v4[0];
+
+    case BATTLEMON_HELD_ITEM:
+        mon->heldItem = *(u16 *)buf;
         break;
-    case 57:
-        v6->trainerMessageFlags = v4[0];
+
+    case BATTLEMON_TIMES_DAMAGED:
+        mon->timesDamaged = *(u8 *)buf;
         break;
-    case 58:
-        v6->OTGender = v4[0];
+
+    case BATTLEMON_TRAINER_MESSAGE_FLAGS:
+        mon->trainerMessageFlags = *(u8 *)buf;
         break;
-    case 59:
-        v6->moveEffectsMask = v1[0];
+
+    case BATTLEMON_OT_GENDER:
+        mon->OTGender = *(u8 *)buf;
         break;
-    case 60:
-        v6->moveEffectsTemp = v1[0];
+    case BATTLEMON_MOVE_EFFECTS_MASK:
+        mon->moveEffectsMask = *(u32 *)buf;
         break;
-    case 61:
-        v6->moveEffectsData.disabledTurns = v4[0];
+
+    case BATTLEMON_MOVE_EFFECTS_TEMP:
+        mon->moveEffectsTemp = *(u32 *)buf;
         break;
-    case 62:
-        v6->moveEffectsData.encoredTurns = v4[0];
+
+    case BATTLEMON_DISABLED_TURNS:
+        mon->moveEffectsData.disabledTurns = *(u8 *)buf;
         break;
-    case 63:
-        v6->moveEffectsData.chargedTurns = v4[0];
+
+    case BATTLEMON_ENCORED_TURNS:
+        mon->moveEffectsData.encoredTurns = *(u8 *)buf;
         break;
-    case 64:
-        v6->moveEffectsData.tauntedTurns = v4[0];
+
+    case BATTLEMON_CHARGED_TURNS:
+        mon->moveEffectsData.chargedTurns = *(u8 *)buf;
         break;
-    case 65:
-        v6->moveEffectsData.protectSuccessTurns = v4[0];
+
+    case BATTLEMON_TAUNTED_TURNS:
+        mon->moveEffectsData.tauntedTurns = *(u8 *)buf;
         break;
-    case 66:
-        v6->moveEffectsData.perishSongTurns = v4[0];
+
+    case BATTLEMON_SUCCESSFUL_PROTECT_TURNS:
+        mon->moveEffectsData.protectSuccessTurns = *(u8 *)buf;
         break;
-    case 67:
-        v6->moveEffectsData.rolloutCount = v4[0];
+
+    case BATTLEMON_PERISH_SONG_TURNS:
+        mon->moveEffectsData.perishSongTurns = *(u8 *)buf;
         break;
-    case 68:
-        v6->moveEffectsData.furyCutterCount = v4[0];
+
+    case BATTLEMON_ROLLOUT_COUNT:
+        mon->moveEffectsData.rolloutCount = *(u8 *)buf;
         break;
-    case 69:
-        v6->moveEffectsData.stockpileCount = v4[0];
+
+    case BATTLEMON_FURY_CUTTER_COUNT:
+        mon->moveEffectsData.furyCutterCount = *(u8 *)buf;
         break;
-    case 70:
-        v6->moveEffectsData.stockpileDefBoosts = v4[0];
+
+    case BATTLEMON_STOCKPILE_COUNT:
+        mon->moveEffectsData.stockpileCount = *(u8 *)buf;
         break;
-    case 71:
-        v6->moveEffectsData.stockpileSpDefBoosts = v4[0];
+
+    case BATTLEMON_STOCKPILE_DEF_BOOSTS:
+        mon->moveEffectsData.stockpileDefBoosts = *(u8 *)buf;
         break;
-    case 72:
-        v6->moveEffectsData.truant = v4[0];
+
+    case BATTLEMON_STOCKPILE_SPDEF_BOOSTS:
+        mon->moveEffectsData.stockpileSpDefBoosts = *(u8 *)buf;
         break;
-    case 73:
-        v6->moveEffectsData.flashFire = v4[0];
+
+    case BATTLEMON_TRUANT:
+        mon->moveEffectsData.truant = *(u8 *)buf;
         break;
-    case 74:
-        v6->moveEffectsData.lockOnTarget = v4[0];
+
+    case BATTLEMON_FLASH_FIRE:
+        mon->moveEffectsData.flashFire = *(u8 *)buf;
         break;
-    case 75:
-        v6->moveEffectsData.mimickedMoveSlot = v4[0];
+
+    case BATTLEMON_LOCK_ON_TARGET:
+        mon->moveEffectsData.lockOnTarget = *(u8 *)buf;
         break;
-    case 76:
-        v6->moveEffectsData.bindTarget = v4[0];
+
+    case BATTLEMON_MIMICKED_MOVE_SLOT:
+        mon->moveEffectsData.mimickedMoveSlot = *(u8 *)buf;
         break;
-    case 77:
-        v6->moveEffectsData.meanLookTarget = v4[0];
+
+    case BATTLEMON_BIND_TARGET:
+        mon->moveEffectsData.bindTarget = *(u8 *)buf;
         break;
-    case 78:
-        v6->moveEffectsData.lastResortCount = v4[0];
+
+    case BATTLEMON_MEAN_LOOK_TARGET:
+        mon->moveEffectsData.meanLookTarget = *(u8 *)buf;
         break;
-    case 79:
-        v6->moveEffectsData.magnetRiseTurns = v4[0];
+
+    case BATTLEMON_LAST_RESORT_COUNT:
+        mon->moveEffectsData.lastResortCount = *(u8 *)buf;
         break;
-    case 80:
-        v6->moveEffectsData.healBlockTurns = v4[0];
+
+    case BATTLEMON_MAGNET_RISE_TURNS:
+        mon->moveEffectsData.magnetRiseTurns = *(u8 *)buf;
         break;
-    case 81:
-        v6->moveEffectsData.embargoTurns = v4[0];
+
+    case BATTLEMON_HEAL_BLOCK_TURNS:
+        mon->moveEffectsData.healBlockTurns = *(u8 *)buf;
         break;
-    case 82:
-        v6->moveEffectsData.canUnburden = v4[0];
+
+    case BATTLEMON_EMBARGO_TURNS:
+        mon->moveEffectsData.embargoTurns = *(u8 *)buf;
         break;
-    case 83:
-        v6->moveEffectsData.metronomeTurns = v4[0];
+
+    case BATTLEMON_CAN_UNBURDEN:
+        mon->moveEffectsData.canUnburden = *(u8 *)buf;
         break;
-    case 84:
-        v6->moveEffectsData.micleBerry = v4[0];
+
+    case BATTLEMON_METRONOME_TURNS:
+        mon->moveEffectsData.metronomeTurns = *(u8 *)buf;
         break;
-    case 85:
-        v6->moveEffectsData.custapBerry = v4[0];
+
+    case BATTLEMON_MICLE_BERRY:
+        mon->moveEffectsData.micleBerry = *(u8 *)buf;
         break;
-    case 86:
-        v6->moveEffectsData.quickClaw = v4[0];
+
+    case BATTLEMON_CUSTAP_BERRY:
+        mon->moveEffectsData.custapBerry = *(u8 *)buf;
         break;
-    case 87:
-        v6->moveEffectsData.rechargeTurnNumber = v1[0];
+
+    case BATTLEMON_QUICK_CLAW:
+        mon->moveEffectsData.quickClaw = *(u8 *)buf;
         break;
-    case 88:
-        v6->moveEffectsData.fakeOutTurnNumber = v1[0];
+
+    case BATTLEMON_RECHARGE_TURN_NUMBER:
+        mon->moveEffectsData.rechargeTurnNumber = *(u32 *)buf;
         break;
-    case 89:
-        v6->moveEffectsData.slowStartTurnNumber = v1[0];
+
+    case BATTLEMON_FAKE_OUT_TURN_NUMBER:
+        mon->moveEffectsData.fakeOutTurnNumber = *(u32 *)buf;
         break;
-    case 90:
-        v6->moveEffectsData.substituteHP = v1[0];
+
+    case BATTLEMON_SLOW_START_TURN_NUMBER:
+        mon->moveEffectsData.slowStartTurnNumber = *(u32 *)buf;
         break;
-    case 91:
-        v6->moveEffectsData.transformedPID = v1[0];
+
+    case BATTLEMON_SUBSTITUTE_HP:
+        mon->moveEffectsData.substituteHP = *(u32 *)buf;
         break;
-    case 92:
-        v6->moveEffectsData.disabledMove = v2[0];
+
+    case BATTLEMON_TRANSFORMED_PERSONALITY:
+        mon->moveEffectsData.transformedPID = *(u32 *)buf;
         break;
-    case 93:
-        v6->moveEffectsData.encoredMove = v2[0];
+
+    case BATTLEMON_DISABLED_MOVE:
+        mon->moveEffectsData.disabledMove = *(u16 *)buf;
         break;
-    case 94:
-        v6->moveEffectsData.bindingMove = v2[0];
+
+    case BATTLEMON_ENCORED_MOVE:
+        mon->moveEffectsData.encoredMove = *(u16 *)buf;
         break;
-    case 95:
-        v6->moveEffectsData.itemHPRecovery = v1[0];
+
+    case BATTLEMON_BINDING_MOVE:
+        mon->moveEffectsData.bindingMove = *(u16 *)buf;
         break;
-    case 96:
-        v6->slowStartAnnounced = v4[0];
+
+    case BATTLEMON_ITEM_HP_RECOVERY:
+        mon->moveEffectsData.itemHPRecovery = *(u32 *)buf;
         break;
-    case 97:
-        v6->slowStartFinished = v4[0];
+
+    case BATTLEMON_SLOW_START_ANNOUNCED:
+        mon->slowStartAnnounced = *(u8 *)buf;
         break;
-    case 98:
-        v6->formNum = v4[0];
+
+    case BATTLEMON_SLOW_START_FINISHED:
+        mon->slowStartFinished = *(u8 *)buf;
         break;
-    case 100:
-        ov16_022523E8(param0, param1, param0->scriptTemp, param3);
+
+    case BATTLEMON_FORM_NUM:
+        mon->formNum = *(u8 *)buf;
         break;
+
+    case BATTLEMON_TEMP:
+        BattleMon_Set(battleCtx, battler, battleCtx->scriptTemp, buf);
+        break;
+
     default:
-        GF_ASSERT(0);
+        GF_ASSERT(FALSE);
         break;
     }
 }

--- a/src/overlay016/ov16_0226485C.c
+++ b/src/overlay016/ov16_0226485C.c
@@ -325,7 +325,7 @@ void BattleIO_SetEncounter (BattleSystem * param0, int param1)
     v0.unk_01_0 = param0->battleCtx->battleMons[param1].gender;
     v0.unk_01_2 = param0->battleCtx->battleMons[param1].isShiny;
     v0.unk_02 = param0->battleCtx->battleMons[param1].species;
-    v0.unk_04 = param0->battleCtx->battleMons[param1].pid;
+    v0.unk_04 = param0->battleCtx->battleMons[param1].personality;
     v0.unk_08 = ov16_022599D0(param0->battleCtx, param1, BattleSystem_BattlerSlot(param0, param1), 1);
     v0.unk_01_3 = param0->battleCtx->battleMons[param1].formNum;
 
@@ -348,7 +348,7 @@ void BattleIO_ShowEncounter (BattleSystem * param0, int param1)
     v0.unk_01_0 = param0->battleCtx->battleMons[param1].gender;
     v0.unk_01_2 = param0->battleCtx->battleMons[param1].isShiny;
     v0.unk_02 = param0->battleCtx->battleMons[param1].species;
-    v0.unk_04 = param0->battleCtx->battleMons[param1].pid;
+    v0.unk_04 = param0->battleCtx->battleMons[param1].personality;
     v0.unk_08 = ov16_022599D0(param0->battleCtx, param1, BattleSystem_BattlerSlot(param0, param1), 1);
     v0.unk_0C = param0->battleCtx->selectedPartySlot[param1];
     v0.unk_01_3 = param0->battleCtx->battleMons[param1].formNum;
@@ -379,7 +379,7 @@ void BattleIO_ShowPokemon (BattleSystem * param0, int param1, int param2, int pa
         v0.unk_04 = param0->battleCtx->battleMons[param1].moveEffectsData.transformedPID;
     } else {
         v0.unk_01_0 = param0->battleCtx->battleMons[param1].gender;
-        v0.unk_04 = param0->battleCtx->battleMons[param1].pid;
+        v0.unk_04 = param0->battleCtx->battleMons[param1].personality;
     }
 
     v0.unk_01_2 = param0->battleCtx->battleMons[param1].isShiny;
@@ -417,7 +417,7 @@ void BattleIO_ShowPokemon (BattleSystem * param0, int param1, int param2, int pa
             v0.unk_64[v1] = param0->battleCtx->battleMons[v1].moveEffectsData.transformedPID;
         } else {
             v0.unk_58[v1] = param0->battleCtx->battleMons[v1].gender;
-            v0.unk_64[v1] = param0->battleCtx->battleMons[v1].pid;
+            v0.unk_64[v1] = param0->battleCtx->battleMons[v1].personality;
         }
     }
 
@@ -443,7 +443,7 @@ void BattleIO_ReturnPokemon (BattleSystem * param0, BattleContext * param1, int 
     if (param0->battleCtx->battleMons[param2].statusVolatile & 0x200000) {
         v0.unk_01 = sub_02076648(param0->battleCtx->battleMons[param2].species, param0->battleCtx->battleMons[param2].moveEffectsData.transformedGender, v1, v2, param0->battleCtx->battleMons[param2].moveEffectsData.transformedPID);
     } else {
-        v0.unk_01 = sub_02076648(param0->battleCtx->battleMons[param2].species, param0->battleCtx->battleMons[param2].gender, v1, v2, param0->battleCtx->battleMons[param2].pid);
+        v0.unk_01 = sub_02076648(param0->battleCtx->battleMons[param2].species, param0->battleCtx->battleMons[param2].gender, v1, v2, param0->battleCtx->battleMons[param2].personality);
     }
 
     v0.unk_02 = param0->battleCtx->battleMons[param2].capturedBall;
@@ -459,7 +459,7 @@ void BattleIO_ReturnPokemon (BattleSystem * param0, BattleContext * param1, int 
             v0.unk_1C[v3] = param1->battleMons[v3].moveEffectsData.transformedPID;
         } else {
             v0.unk_10[v3] = param1->battleMons[v3].gender;
-            v0.unk_1C[v3] = param1->battleMons[v3].pid;
+            v0.unk_1C[v3] = param1->battleMons[v3].personality;
         }
     }
 
@@ -484,7 +484,7 @@ void ov16_02265050 (BattleSystem * param0, int param1, int param2)
     if (param0->battleCtx->battleMons[param1].statusVolatile & 0x200000) {
         v0.unk_01 = sub_02076648(param0->battleCtx->battleMons[param1].species, param0->battleCtx->battleMons[param1].moveEffectsData.transformedGender, v1, v2, param0->battleCtx->battleMons[param1].moveEffectsData.transformedPID);
     } else {
-        v0.unk_01 = sub_02076648(param0->battleCtx->battleMons[param1].species, param0->battleCtx->battleMons[param1].gender, v1, v2, param0->battleCtx->battleMons[param1].pid);
+        v0.unk_01 = sub_02076648(param0->battleCtx->battleMons[param1].species, param0->battleCtx->battleMons[param1].gender, v1, v2, param0->battleCtx->battleMons[param1].personality);
     }
 
     v0.unk_02 = param2;
@@ -1051,7 +1051,7 @@ void BattleIO_PlayFaintingSequence (BattleSystem * param0, BattleContext * param
         v0.unk_04 = param1->battleMons[param2].moveEffectsData.transformedPID;
     } else {
         v0.unk_01 = param1->battleMons[param2].gender;
-        v0.unk_04 = param1->battleMons[param2].pid;
+        v0.unk_04 = param1->battleMons[param2].personality;
     }
 
     for (v1 = 0; v1 < 4; v1++) {
@@ -1064,7 +1064,7 @@ void BattleIO_PlayFaintingSequence (BattleSystem * param0, BattleContext * param
             v0.unk_20[v1] = param1->battleMons[v1].moveEffectsData.transformedPID;
         } else {
             v0.unk_14[v1] = param1->battleMons[v1].gender;
-            v0.unk_20[v1] = param1->battleMons[v1].pid;
+            v0.unk_20[v1] = param1->battleMons[v1].personality;
         }
     }
 
@@ -1107,7 +1107,7 @@ void ov16_02265EE8 (BattleSystem * param0, int param1, int param2)
             v0.unk_18[v1] = param0->battleCtx->battleMons[v1].moveEffectsData.transformedPID;
         } else {
             v0.unk_0C[v1] = param0->battleCtx->battleMons[v1].gender;
-            v0.unk_18[v1] = param0->battleCtx->battleMons[v1].pid;
+            v0.unk_18[v1] = param0->battleCtx->battleMons[v1].personality;
         }
     }
 
@@ -1362,7 +1362,7 @@ void ov16_0226651C (BattleSystem * param0, int param1)
         v0.unk_08 = param0->battleCtx->battleMons[param1].moveEffectsData.transformedPID;
     } else {
         v0.unk_04 = param0->battleCtx->battleMons[param1].gender;
-        v0.unk_08 = param0->battleCtx->battleMons[param1].pid;
+        v0.unk_08 = param0->battleCtx->battleMons[param1].personality;
     }
 
     v0.unk_01 = param0->battleCtx->battleMons[param1].formNum;
@@ -1469,7 +1469,7 @@ void ov16_0226673C (BattleSystem * param0, BattleContext * param1, int param2)
             v1.unk_2C[v0] = param1->battleMons[v0].moveEffectsData.transformedPID;
         } else {
             v1.unk_20[v0] = param1->battleMons[v0].gender;
-            v1.unk_2C[v0] = param1->battleMons[v0].pid;
+            v1.unk_2C[v0] = param1->battleMons[v0].personality;
         }
     }
 
@@ -1551,7 +1551,7 @@ void ov16_0226692C (BattleSystem * param0, BattleContext * param1, int param2)
             v1.unk_2C[v0] = param1->battleMons[v0].moveEffectsData.transformedPID;
         } else {
             v1.unk_20[v0] = param1->battleMons[v0].gender;
-            v1.unk_2C[v0] = param1->battleMons[v0].pid;
+            v1.unk_2C[v0] = param1->battleMons[v0].personality;
         }
     }
 
@@ -1710,7 +1710,7 @@ void ov16_02266B78 (BattleSystem * param0, BattleContext * param1, UnkStruct_ov1
                 param2->unk_2C[v0] = param1->battleMons[v0].moveEffectsData.transformedPID;
             } else {
                 param2->unk_20[v0] = param1->battleMons[v0].gender;
-                param2->unk_2C[v0] = param1->battleMons[v0].pid;
+                param2->unk_2C[v0] = param1->battleMons[v0].personality;
             }
         }
     }

--- a/src/overlay016/ov16_0226485C.c
+++ b/src/overlay016/ov16_0226485C.c
@@ -103,9 +103,9 @@ void BattleIO_UpdateExpGauge(BattleSystem * param0, BattleContext * param1, int 
 void BattleIO_PlayFaintingSequence(BattleSystem * param0, BattleContext * param1, int param2);
 void BattleIO_PlaySound(BattleSystem * param0, BattleContext * param1, int param2, int param3);
 void BattleIO_FadeOut(BattleSystem * param0, BattleContext * param1);
-void ov16_02265EE8(BattleSystem * param0, int param1, int param2);
-void ov16_02265FB8(BattleSystem * param0, int param1, int param2);
-void ov16_02265FD8(BattleSystem * param0, int param1, int param2);
+void BattleIO_ToggleVanish(BattleSystem * param0, int param1, int param2);
+void BattleIO_SetStatusIcon(BattleSystem * param0, int param1, int param2);
+void BattleIO_TrainerMessage(BattleSystem * param0, int param1, int param2);
 void BattleIO_PlayStatusEffect(BattleSystem * param0, BattleContext * param1, int param2, int param3);
 void ov16_02266028(BattleSystem * param0, BattleContext * param1, int param2, int param3, int param4);
 void ov16_02266058(BattleSystem * param0, BattleContext * param1, int param2, int param3);
@@ -1088,7 +1088,7 @@ void BattleIO_FadeOut (BattleSystem * param0, BattleContext * param1)
     ov16_02264A04(param0, 1, 0, &v0, 4);
 }
 
-void ov16_02265EE8 (BattleSystem * param0, int param1, int param2)
+void BattleIO_ToggleVanish (BattleSystem * param0, int param1, int param2)
 {
     UnkStruct_ov16_0225C3BC v0;
     int v1;
@@ -1114,7 +1114,7 @@ void ov16_02265EE8 (BattleSystem * param0, int param1, int param2)
     ov16_02264A04(param0, 1, param1, &v0, sizeof(UnkStruct_ov16_0225C3BC));
 }
 
-void ov16_02265FB8 (BattleSystem * param0, int param1, int param2)
+void BattleIO_SetStatusIcon (BattleSystem * param0, int param1, int param2)
 {
     UnkStruct_ov16_0225C3D0 v0;
 
@@ -1124,7 +1124,7 @@ void ov16_02265FB8 (BattleSystem * param0, int param1, int param2)
     ov16_02264A04(param0, 1, param1, &v0, sizeof(UnkStruct_ov16_0225C3D0));
 }
 
-void ov16_02265FD8 (BattleSystem * param0, int param1, int param2)
+void BattleIO_TrainerMessage (BattleSystem * param0, int param1, int param2)
 {
     UnkStruct_ov16_0225C3E4 v0;
 


### PR DESCRIPTION
## Documented Commands

- `StartCatchMonTask`
- `WaitCatchMonTask`
- `SetMonDataValue`
- `ClearVolatileStatus`
- `ToggleVanish`
- `CheckAbility`
- `Random`
- `SetVarFromVar`
- `SetMonDataFromVar`
- `Jump`
- `CallSub`
- `CallSubFromVar`
- `SetMirrorMove`
- `ResetStatChanges`
- `LockMoveChoice`
- `UnlockMoveChoice`
- `SetStatusIcon`
- `TrainerMessage`

## Functions Labeled

- `ov16_02265EE8` -> `BattleIO_ToggleVanish`
- `ov16_02265FB8` -> `BattleIO_SetStatusIcon`
- `ov16_02265FD8` -> `BattleIO_TrainerMessage`

## Functions Documented

- `BattleMon_Set`
- `Battler_LockMoveChoice`
- `Battler_UnlockMoveChoice`
- `BattleSystem_CanEncoreMove`