### PR TITLE
Update json2bin for python3.8 compatibility

### DIFF
--- a/tools/json2bin/evo.py
+++ b/tools/json2bin/evo.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from collections.abc import Sequence
 import pathlib
 
 
@@ -17,7 +18,7 @@ from consts.pokemon import (
 )
 
 
-def get_evo_params(method: evo_methods.EvoMethod, evo: list):
+def get_evo_params(method: evo_methods.EvoMethod, evo: Sequence):
     maybe_param = evo[1]
     final_param = 0
     #None of these take an extra parameter
@@ -70,7 +71,7 @@ def table_line(evo_method: int, evo_params: int, species: int) -> bytes:
     return bytes(binary)
     
 
-def parse_evolutions(table: list, _size: int, _enum: None) -> bytes:
+def parse_evolutions(table: Sequence, _size: int, _enum: None) -> bytes:
     out = bytearray([])
     for j in range(min(len(table), 7)):
         evo = table[j]

--- a/tools/json2bin/pokemon_wotbl_data.py
+++ b/tools/json2bin/pokemon_wotbl_data.py
@@ -21,9 +21,9 @@ def parse_level_up_moves(table: dict, _size: int, _enum: None):
     for key, value in table.items():
         level = int(key)
         level_moves = value
-        if type(level_moves) == str:
+        if isinstance(level_moves, str):
             out.extend(table_line(moves.Move[level_moves].value, level))
-        elif type(level_moves) == list:
+        elif isinstance(level_moves, list):
             for move in level_moves:
                 out.extend(table_line(moves.Move[move].value, level))
         else:

--- a/tools/json2bin/trainer_data.py
+++ b/tools/json2bin/trainer_data.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from collections.abc import Mapping, Sequence
 import pathlib, functools
 
 from consts import (
@@ -12,7 +13,7 @@ from consts.pokemon import species
 import json2bin as j2b
 
 
-def derive_data_flags(party: list[dict], *args) -> bytes:
+def derive_data_flags(party: Sequence[Mapping], *args) -> bytes:
     defined_moves = False
     defined_items = False
     for mon in party:
@@ -25,7 +26,7 @@ def derive_data_flags(party: list[dict], *args) -> bytes:
     return (int(defined_moves) | (int(defined_items) << 1)).to_bytes(1, 'little')
 
 
-def parse_trainer_items(item_list: list[str], *args) -> bytes:
+def parse_trainer_items(item_list: Sequence[str], *args) -> bytes:
     item_bin = bytearray([])
     for item_str in item_list:
         item_bin.extend(item.Item[item_str].value.to_bytes(2, 'little'))
@@ -35,7 +36,7 @@ def parse_trainer_items(item_list: list[str], *args) -> bytes:
     return item_bin
 
 
-def parse_poke_moves(move_list: list[str], *args) -> bytes:
+def parse_poke_moves(move_list: Sequence[str], *args) -> bytes:
     move_bin = bytearray([])
     for move_str in move_list:
         move_bin.extend(moves.Move[move_str].value.to_bytes(2, 'little'))
@@ -64,7 +65,7 @@ def parse_party_mon(mon: dict, has_moves: bool, has_items: bool) -> bytes:
 
 # Parties are a complicated and variable structure, so just process them wholly
 # independently
-def parse_party_mons(party_list: list[dict], *args) -> bytes:
+def parse_party_mons(party_list: Sequence[Mapping], *args) -> bytes:
     if len(party_list) == 0: # special case, pads to 2 words instead of 1 word
         return (0).to_bytes(8, 'little')
 


### PR DESCRIPTION
Targeting python3.8 since that is the oldest current LTS (and the default on Ubuntu 20.04).