### PR TITLE
Fix out of tree builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Configure Repo
-        run: ./config.sh
+        run: ./config.sh /var/tmp/pokeplatinum
 
       - name: Build Repo
-        run: ./build.sh test
+        run: meson test -C /var/tmp/pokeplatinum
 
       - name: Webhook
         if: ${{ github.event_name == 'push' }}

--- a/tools/postconf/postconf.py
+++ b/tools/postconf/postconf.py
@@ -34,11 +34,9 @@ def main():
     build_ninja_string = backslash_to_forward_slash(build_ninja_string)
     build_ninja_string = fix_static_libs(build_ninja_string)
     build_ninja_string = nasm_to_asm(build_ninja_string)
-    build_ninja_string = relativize_prebuilt_lib_paths(build_ninja_string)
 
     # compile_commands.json edits
     compile_commands_string = backslash_to_forward_slash(compile_commands_string)
-    compile_commands_string = relativize_prebuilt_lib_paths(compile_commands_string)
 
     # For WSL accessing Windows, paths to PCH input files must be relative
     if is_wsl_accessing_windows():
@@ -52,10 +50,6 @@ def main():
 
 def nasm_to_asm(fileString: str) -> str:
     return fileString.replace('Nasm', 'ASM')
-
-def relativize_prebuilt_lib_paths(fileString: str) -> str:
-    '''Make paths to prebuilt .a files relative'''
-    return re.sub(r'/[\w/\-.]+?(subprojects[\w/\-.]+?prebuilt)', r'../\1', fileString)
 
 def relativize_pch_paths(fileString: str) -> str:
     '''Make paths to headers to be precompiled relative (for WSL)'''


### PR DESCRIPTION
This allows the build directory to be located outside of the source tree.
Arguably, this has no tangible benefit, but it's more "proper" in the
meson spirit.

Depends on the following PRs:
- https://github.com/pret/pokeplatinum/pull/155
- https://github.com/Nomura-RH/libvct/pull/1
- https://github.com/Nomura-RH/NitroDWC/pull/2
- https://github.com/Nomura-RH/NitroSDK/pull/1
- https://github.com/Nomura-RH/NitroWiFi/pull/1
