### PR TITLE
Add convenience target 'rom' to build.sh

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -158,6 +158,13 @@ To build the rom, run:
 If everything works, then the following ROM should be built:
 - [build/pokeplatinum.us.nds](https://datomatic.no-intro.org/index.php?page=show_record&s=28&n=3541) `sha1: ce81046eda7d232513069519cb2085349896dec7`
 
+If you want to make modifications to the ROM, you can instead run:
+```
+./build.sh rom
+```
+
+After which, you should see the built ROM `pokeplatinum.us.nds` in the `build` folder.
+
 # 4. Docker
 
 A Dockerfile is provided for your convenience. To begin, setup docker on your local machine following the instructions at https://docs.docker.com/desktop/. Then, run

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,8 @@ export NINJA_STATUS="[%p %f/%t] "
 # Build the project
 if [ "$target" = test ]; then
     "${MESON:-meson}" test -C build "$@"
+elif [ "$target" = rom ]; then
+    "${MESON:-meson}" compile -C build "pokeplatinum.us.nds"
 else
     "${MESON:-meson}" compile -C build "$target" "$@"
 fi


### PR DESCRIPTION
This is purely for modders who are trying to build a non-matching ROM. `test` remains the default target for the project.