### PR TITLE
Use absolute path for directory in generated compile_commands.json

### DIFF
--- a/gen_compile_commands.py
+++ b/gen_compile_commands.py
@@ -1,7 +1,7 @@
 import json
 import pathlib
 
-homedir = pathlib.Path(__file__).parent
+homedir = pathlib.Path(__file__).resolve().parent
 builddir = homedir / 'build'
 
 arm7_c_flags = [


### PR DESCRIPTION
Some editors (for some reason) move the CWD in and out of various directories when hooking into an LSP. This patches an issue where an editor moves into the `src` subdirectory, then tries to look for the `build` directory from within that subdir (and fails to find it, breaking LSP-integration).