### PR TITLE
Convert hyphens to underscores in generated GMM header's include-guard

### DIFF
--- a/tools/msgenc/Gmm.cpp
+++ b/tools/msgenc/Gmm.cpp
@@ -41,6 +41,7 @@ void GMM::WriteGmmHeader(const string &_filename) {
         switch (c) {
         case '/':
         case '.':
+        case '-':
             c = '_';
             break;
         default:


### PR DESCRIPTION
`-` is not a valid token in preprocessor tokens, but is common enough in directory names to be worth handling.