### PR TITLE
Point all subprojects to branches instead of head

### DIFF
--- a/subprojects/NitroDWC.wrap
+++ b/subprojects/NitroDWC.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/Nomura-RH/NitroDWC.git
-revision = head
+revision = main
 depth = 1
 directory = NitroDWC-2.2.30008
 

--- a/subprojects/NitroSDK.wrap
+++ b/subprojects/NitroSDK.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/Nomura-RH/NitroSDK.git
-revision = head
+revision = main
 depth = 1
 directory = NitroSDK-4.2.30001
 

--- a/subprojects/NitroSystem.wrap
+++ b/subprojects/NitroSystem.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/Nomura-RH/NitroSystem.git
-revision = head
+revision = main
 depth = 1
 directory = NitroSystem-071126.1
 

--- a/subprojects/NitroWiFi.wrap
+++ b/subprojects/NitroWiFi.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/Nomura-RH/NitroWiFi.git
-revision = head
+revision = main
 depth = 1
 directory = NitroWiFi-2.1.30003
 

--- a/subprojects/libvct.wrap
+++ b/subprojects/libvct.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/Nomura-RH/libvct.git
-revision = head
+revision = main
 depth = 1
 directory = libvct-1.3.1
 

--- a/subprojects/nitrogfx.wrap
+++ b/subprojects/nitrogfx.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/red031000/nitrogfx.git
-revision = head
+revision = master
 depth = 1
 patch_directory = nitrogfx_patch
 


### PR DESCRIPTION
This will enable users to update all their subprojects via `meson subprojects update` rather than having to purge them and re-pull.