### PR TITLE
Rename all PoketchSystem, PoketchData, and PoketchButtonManager variables in the codebase

### DIFF
--- a/include/field/field_system_sub2_t.h
+++ b/include/field/field_system_sub2_t.h
@@ -16,7 +16,7 @@ struct FieldSystem_sub2_t {
     UnkStruct_ov5_021DD9C8 * unk_08;
     UnkStruct_ov5_021D5EF8 * unk_0C;
     UnkStruct_ov5_021D5CB0 * unk_10;
-    PoketchSystem * unk_14;
+    PoketchSystem *poketchSys;
     UnkStruct_02055CBC * unk_18;
     HBlankSystem * hBlankSystem;
     UnkStruct_ov5_021EF4F8 * unk_20;

--- a/include/overlay006/battle_params.h
+++ b/include/overlay006/battle_params.h
@@ -31,7 +31,7 @@ typedef struct {
     PokedexData * unk_E8;
     PCBoxes * unk_EC;
     ChatotCry * unk_F0[4];
-    PoketchData * unk_100;
+    PoketchData *poketchData;
     UnkStruct_0202C878 * unk_104;
     Options * unk_108;
     UnkStruct_0206D140 * unk_10C;

--- a/include/overlay025/ov25_02254560.h
+++ b/include/overlay025/ov25_02254560.h
@@ -9,7 +9,7 @@
 
 #include <nnsys.h>
 
-BOOL ov25_02254560(UnkStruct_ov25_02254560 ** param0, const UnkStruct_ov25_02254560_1 * param1, NNSG2dOamManagerInstance * param2, PoketchSystem * param3);
+BOOL ov25_02254560(UnkStruct_ov25_02254560 ** param0, const UnkStruct_ov25_02254560_1 * param1, NNSG2dOamManagerInstance * param2, PoketchSystem *poketchSys);
 UnkStruct_ov25_022555E8 * ov25_02254664(void);
 BGL * ov25_02254674(void);
 void ov25_022546B8(u32 param0, u32 param1);

--- a/include/overlay025/poketch_system.h
+++ b/include/overlay025/poketch_system.h
@@ -131,7 +131,7 @@ void ov25_02254444(u32 param0, u32 param1);
 BOOL PoketchSystem_GetDisplayHeldCoords(u32 *x, u32 *y);
 BOOL PoketchSystem_GetDisplayTappedCoords(u32 *x, u32 *y);
 BOOL ov25_0225450C(const PoketchSystem *poketchSys);
-void ov25_02254518(const PoketchSystem *poketchSys, PoketchButtonManager * param1);
+void ov25_02254518(const PoketchSystem *poketchSys, PoketchButtonManager *buttonManager);
 BOOL PoketchSystem_IsPlayerMoving(const PoketchSystem *poketchSys);
 BOOL PoketchSystem_PedometerUpdated(const PoketchSystem *poketchSys);
 FieldSystem * PoketchSystem_GetFieldSystem(const PoketchSystem *poketchSys);

--- a/include/struct_defs/battle_system.h
+++ b/include/struct_defs/battle_system.h
@@ -69,7 +69,7 @@ struct BattleSystem {
     UnkStruct_ov12_0221FCDC * unk_8C;
     SpriteRenderer * unk_90;
     SpriteGfxHandler * unk_94;
-    PoketchData * unk_98;
+    PoketchData *poketchData;
     UnkStruct_0206D140 * unk_9C;
     u16 trainerIDs[4];
     u8 unk_A8[4];

--- a/include/struct_defs/struct_0207AE68_t.h
+++ b/include/struct_defs/struct_0207AE68_t.h
@@ -43,7 +43,7 @@ struct UnkStruct_0207AE68_t {
     PokedexData * unk_48;
     Bag * unk_4C;
     UnkStruct_0202CD88 * unk_50;
-    PoketchData * unk_54;
+    PoketchData *poketchData;
     void * unk_58;
     int unk_5C;
     u16 unk_60;

--- a/include/unk_0207AE68.h
+++ b/include/unk_0207AE68.h
@@ -10,7 +10,7 @@
 #include "struct_decls/struct_0207AE68_decl.h"
 #include "bag.h"
 
-UnkStruct_0207AE68 * sub_0207AE68(Party * param0, Pokemon * param1, int param2, Options * param3, int param4, PokedexData * param5, Bag * param6, UnkStruct_0202CD88 * param7, PoketchData * param8, int param9, int param10, int param11);
+UnkStruct_0207AE68 * sub_0207AE68(Party * param0, Pokemon * param1, int param2, Options * param3, int param4, PokedexData * param5, Bag * param6, UnkStruct_0202CD88 * param7, PoketchData *poketchData, int param9, int param10, int param11);
 BOOL sub_0207B0D0(UnkStruct_0207AE68 * param0);
 void sub_0207B0E0(UnkStruct_0207AE68 * param0);
 

--- a/src/battle/ov16_0223B140.c
+++ b/src/battle/ov16_0223B140.c
@@ -273,7 +273,7 @@ BOOL Battle_Main (OverlayManager * param0, int * param1)
         if (v2) {
             Heap_Create(3, 73, 0x30000);
             v4 = Party_GetPokemonBySlotIndex(v0->parties[0], v1);
-            v0->unk_170 = sub_0207AE68(v0->parties[0], v4, v2, v0->unk_108, v0->unk_140, v0->unk_E8, v0->unk_E0, v0->unk_11C, v0->unk_100, v3, 0x1 | 0x2, 73);
+            v0->unk_170 = sub_0207AE68(v0->parties[0], v4, v2, v0->unk_108, v0->unk_140, v0->unk_E8, v0->unk_E0, v0->unk_11C, v0->poketchData, v3, 0x1 | 0x2, 73);
             *param1 = 14;
         } else {
             *param1 = 15;
@@ -745,7 +745,7 @@ static void ov16_0223BCB4 (OverlayManager * param0)
     v1->unk_EC = v0->pcBoxes;
     v1->unk_E4 = v0->unk_5C;
     v1->unk_190 = v0->unk_1BC;
-    v1->unk_100 = v0->unk_98;
+    v1->poketchData = v0->poketchData;
     v1->unk_10C = v0->unk_9C;
     v1->unk_168 = v0->safariBalls;
     v1->unk_14 = v0->resultMask & (0xc0 ^ 0xff);
@@ -1100,7 +1100,7 @@ static void ov16_0223C2C0 (BattleSystem * param0, BattleParams * param1)
     param0->unk_1B4 = param1->unk_124;
     param0->unk_5C = param1->unk_E4;
     param0->unk_1BC = param1->unk_190;
-    param0->unk_98 = param1->unk_100;
+    param0->poketchData = param1->poketchData;
     param0->unk_2420 = param1->unk_13C;
     param0->unk_9C = param1->unk_10C;
     param0->safariBalls = param1->unk_168;

--- a/src/battle/ov16_0223DF00.c
+++ b/src/battle/ov16_0223DF00.c
@@ -1121,8 +1121,8 @@ void ov16_0223EF2C (BattleSystem * param0, int param1, int param2)
 
 void ov16_0223EF48 (BattleSystem * param0, Pokemon * param1)
 {
-    if (param0->unk_98) {
-        PoketchData_PokemonHistoryEnqueue(param0->unk_98, Pokemon_GetBoxPokemon(param1));
+    if (param0->poketchData) {
+        PoketchData_PokemonHistoryEnqueue(param0->poketchData, Pokemon_GetBoxPokemon(param1));
     }
 }
 

--- a/src/field_system.c
+++ b/src/field_system.c
@@ -315,10 +315,10 @@ void FieldSystem_Control (FieldSystem * fieldSystem)
 
                 {
                     BOOL v3 = 0;
-                    PoketchSystem * v4 = FieldSystem_GetPoketchSystem();
+                    PoketchSystem *poketchSys = FieldSystem_GetPoketchSystem();
 
-                    if (v4 != NULL) {
-                        v3 = PoketchSystem_IsTapped(v4);
+                    if (poketchSys != NULL) {
+                        v3 = PoketchSystem_IsTapped(poketchSys);
                     }
 
                     PlayerAvatar_MoveControl(fieldSystem->playerAvatar, fieldSystem->unk_28, -1, v1.pressedKeys, v1.heldKeys, v3);
@@ -341,10 +341,10 @@ void FieldSystem_Control (FieldSystem * fieldSystem)
 
                 {
                     BOOL v5 = 0;
-                    PoketchSystem * v6 = FieldSystem_GetPoketchSystem();
+                    PoketchSystem *poketchSys = FieldSystem_GetPoketchSystem();
 
-                    if (v6 != NULL) {
-                        v5 = PoketchSystem_IsTapped(v6);
+                    if (poketchSys != NULL) {
+                        v5 = PoketchSystem_IsTapped(poketchSys);
                     }
 
                     PlayerAvatar_MoveControl(fieldSystem->playerAvatar, fieldSystem->unk_28, -1, v1.pressedKeys, v1.heldKeys, v5);
@@ -373,7 +373,7 @@ struct PoketchSystem * FieldSystem_GetPoketchSystem (void)
         return NULL;
     }
 
-    return sFieldSystem->unk_04->unk_14;
+    return sFieldSystem->unk_04->poketchSys;
 }
 
 BGL * sub_0203D170 (void * param0)

--- a/src/overlay005/ov5_021DDAE4.c
+++ b/src/overlay005/ov5_021DDAE4.c
@@ -41,11 +41,11 @@ static BOOL ov5_021DDAE4 (TaskManager * param0)
         break;
     case 2:
         if (ov24_02253DB4(fieldSystem->unk_08)) {
-            PoketchData * v2 = SaveData_PoketchData(fieldSystem->saveData);
+            PoketchData *poketchData = SaveData_PoketchData(fieldSystem->saveData);
 
             Overlay_UnloadByID(FS_OVERLAY_ID(overlay24));
             Overlay_LoadByID(FS_OVERLAY_ID(overlay25), 2);
-            PoketchData_Enable(v2);
+            PoketchData_Enable(poketchData);
             PoketchSystem_Create(fieldSystem, &fieldSystem->unk_04->poketchSys, fieldSystem->saveData, fieldSystem->unk_08, sub_0200A914(1));
             v1->unk_00++;
         }

--- a/src/overlay005/ov5_021DDAE4.c
+++ b/src/overlay005/ov5_021DDAE4.c
@@ -46,7 +46,7 @@ static BOOL ov5_021DDAE4 (TaskManager * param0)
             Overlay_UnloadByID(FS_OVERLAY_ID(overlay24));
             Overlay_LoadByID(FS_OVERLAY_ID(overlay25), 2);
             PoketchData_Enable(v2);
-            PoketchSystem_Create(fieldSystem, &fieldSystem->unk_04->unk_14, fieldSystem->saveData, fieldSystem->unk_08, sub_0200A914(1));
+            PoketchSystem_Create(fieldSystem, &fieldSystem->unk_04->poketchSys, fieldSystem->saveData, fieldSystem->unk_08, sub_0200A914(1));
             v1->unk_00++;
         }
         break;

--- a/src/overlay005/ov5_021EA714.c
+++ b/src/overlay005/ov5_021EA714.c
@@ -18,8 +18,8 @@ FS_EXTERN_OVERLAY(overlay25);
 
 void ov5_021EA714 (FieldSystem * fieldSystem, int param1, u32 param2)
 {
-    if ((fieldSystem->unk_04 != NULL) && (fieldSystem->unk_04->unk_14 != NULL)) {
-        PoketchSystem_SendEvent(fieldSystem->unk_04->unk_14, param1, param2);
+    if ((fieldSystem->unk_04 != NULL) && (fieldSystem->unk_04->poketchSys != NULL)) {
+        PoketchSystem_SendEvent(fieldSystem->unk_04->poketchSys, param1, param2);
     }
 }
 
@@ -32,7 +32,7 @@ void ov5_021EA728 (FieldSystem * fieldSystem)
     if (PoketchData_IsEnabled(v0)
         && (sub_0206AE2C(v1) == 0)) {
         Overlay_LoadByID(FS_OVERLAY_ID(overlay25), 2);
-        PoketchSystem_Create(fieldSystem, &fieldSystem->unk_04->unk_14, fieldSystem->saveData, fieldSystem->unk_08, sub_0200A914(1));
+        PoketchSystem_Create(fieldSystem, &fieldSystem->unk_04->poketchSys, fieldSystem->saveData, fieldSystem->unk_08, sub_0200A914(1));
     } else {
         Overlay_LoadByID(FS_OVERLAY_ID(overlay24), 2);
         ov24_02253CE0(fieldSystem->unk_08);
@@ -46,7 +46,7 @@ void ov5_021EA790 (FieldSystem * fieldSystem)
 
     if (PoketchData_IsEnabled(v0)
         && (sub_0206AE2C(v1) == 0)) {
-        PoketchSystem_StartShutdown(fieldSystem->unk_04->unk_14);
+        PoketchSystem_StartShutdown(fieldSystem->unk_04->poketchSys);
     } else {
         ov24_02253DA4(fieldSystem->unk_08);
     }
@@ -59,8 +59,8 @@ u8 ov5_021EA7CC (FieldSystem * fieldSystem)
 
     if (PoketchData_IsEnabled(v0)
         && (sub_0206AE2C(v1) == 0)) {
-        if (PoketchSystem_IsSystemShutdown(fieldSystem->unk_04->unk_14)) {
-            fieldSystem->unk_04->unk_14 = NULL;
+        if (PoketchSystem_IsSystemShutdown(fieldSystem->unk_04->poketchSys)) {
+            fieldSystem->unk_04->poketchSys = NULL;
             Overlay_UnloadByID(FS_OVERLAY_ID(overlay25));
             return 1;
         }

--- a/src/overlay005/ov5_021EA714.c
+++ b/src/overlay005/ov5_021EA714.c
@@ -26,10 +26,10 @@ void ov5_021EA714 (FieldSystem * fieldSystem, int param1, u32 param2)
 
 void ov5_021EA728 (FieldSystem * fieldSystem)
 {
-    PoketchData * v0 = SaveData_PoketchData(fieldSystem->saveData);
+    PoketchData *poketchData = SaveData_PoketchData(fieldSystem->saveData);
     VarsFlags * v1 = SaveData_GetVarsFlags(fieldSystem->saveData);
 
-    if (PoketchData_IsEnabled(v0)
+    if (PoketchData_IsEnabled(poketchData)
         && (sub_0206AE2C(v1) == 0)) {
         Overlay_LoadByID(FS_OVERLAY_ID(overlay25), 2);
         PoketchSystem_Create(fieldSystem, &fieldSystem->unk_04->poketchSys, fieldSystem->saveData, fieldSystem->unk_08, sub_0200A914(1));
@@ -41,10 +41,10 @@ void ov5_021EA728 (FieldSystem * fieldSystem)
 
 void ov5_021EA790 (FieldSystem * fieldSystem)
 {
-    PoketchData * v0 = SaveData_PoketchData(fieldSystem->saveData);
+    PoketchData *poketchData = SaveData_PoketchData(fieldSystem->saveData);
     VarsFlags * v1 = SaveData_GetVarsFlags(fieldSystem->saveData);
 
-    if (PoketchData_IsEnabled(v0)
+    if (PoketchData_IsEnabled(poketchData)
         && (sub_0206AE2C(v1) == 0)) {
         PoketchSystem_StartShutdown(fieldSystem->unk_04->poketchSys);
     } else {
@@ -54,10 +54,10 @@ void ov5_021EA790 (FieldSystem * fieldSystem)
 
 u8 ov5_021EA7CC (FieldSystem * fieldSystem)
 {
-    PoketchData * v0 = SaveData_PoketchData(fieldSystem->saveData);
+    PoketchData *poketchData = SaveData_PoketchData(fieldSystem->saveData);
     VarsFlags * v1 = SaveData_GetVarsFlags(fieldSystem->saveData);
 
-    if (PoketchData_IsEnabled(v0)
+    if (PoketchData_IsEnabled(poketchData)
         && (sub_0206AE2C(v1) == 0)) {
         if (PoketchSystem_IsSystemShutdown(fieldSystem->unk_04->poketchSys)) {
             fieldSystem->unk_04->poketchSys = NULL;

--- a/src/overlay025/ov25_02254560.c
+++ b/src/overlay025/ov25_02254560.c
@@ -166,8 +166,8 @@ static void ov25_02254684 (UnkStruct_ov25_02254560 * param0)
 void ov25_022546B8 (u32 param0, u32 param1)
 {
     UnkStruct_ov25_02254560 * v0 = ov25_02254418();
-    PoketchData * v1 = PoketchSystem_GetPoketchData(v0->poketchSys);
-    u32 v2 = PoketchData_CurrentScreenColor(v1);
+    PoketchData *poketchData = PoketchSystem_GetPoketchData(v0->poketchSys);
+    u32 v2 = PoketchData_CurrentScreenColor(poketchData);
 
     GXS_LoadBGPltt(&v0->unk_200[v2 * 32], param0 * 0x20, 0x20);
     GXS_LoadOBJPltt(&v0->unk_200[v2 * 32], param1, 0x20);
@@ -176,8 +176,8 @@ void ov25_022546B8 (u32 param0, u32 param1)
 void ov25_022546F0 (u32 param0, u32 param1)
 {
     UnkStruct_ov25_02254560 * v0 = ov25_02254418();
-    PoketchData * v1 = PoketchSystem_GetPoketchData(v0->poketchSys);
-    u32 v2 = PoketchData_CurrentScreenColor(v1);
+    PoketchData *poketchData = PoketchSystem_GetPoketchData(v0->poketchSys);
+    u32 v2 = PoketchData_CurrentScreenColor(poketchData);
 
     GXS_LoadBGPltt(&v0->unk_200[v2 * 32 + 16], 0, 0x20);
     GXS_LoadOBJPltt(&v0->unk_200[v2 * 32 + 16], 0, 0x20);
@@ -186,8 +186,8 @@ void ov25_022546F0 (u32 param0, u32 param1)
 void ov25_02254728 (u16 * param0)
 {
     UnkStruct_ov25_02254560 * v0 = ov25_02254418();
-    PoketchData * v1 = PoketchSystem_GetPoketchData(v0->poketchSys);
-    u32 v2 = PoketchData_CurrentScreenColor(v1);
+    PoketchData *poketchData = PoketchSystem_GetPoketchData(v0->poketchSys);
+    u32 v2 = PoketchData_CurrentScreenColor(poketchData);
 
     MI_CpuCopy16(&v0->unk_200[v2 * 32], param0, 0x20);
 }
@@ -608,8 +608,8 @@ static void ov25_02254DE0 (UnkStruct_ov25_02254560 * param0, UnkStruct_ov25_0225
 
 static void ov25_02254E84 (UnkStruct_ov25_02254560 * param0, u32 param1)
 {
-    PoketchData * v1 = PoketchSystem_GetPoketchData(param0->poketchSys);
-    u32 v2 = PoketchData_CurrentScreenColor(v1);
+    PoketchData *poketchData = PoketchSystem_GetPoketchData(param0->poketchSys);
+    u32 v2 = PoketchData_CurrentScreenColor(poketchData);
 
     ov25_02254728(param0->unk_400);
 

--- a/src/overlay025/ov25_02254560.c
+++ b/src/overlay025/ov25_02254560.c
@@ -50,7 +50,7 @@ struct UnkStruct_ov25_02254560_t {
     SysTask * unk_1D0;
     UnkStruct_ov25_02254DD8 unk_1D4;
     BGL * unk_1F8;
-    PoketchSystem * unk_1FC;
+    PoketchSystem *poketchSys;
     u16 unk_200[256];
     u16 unk_400[16];
 };
@@ -90,7 +90,7 @@ static void ov25_02255064(SysTask * param0, void * param1);
 struct PoketchSystem * FieldSystem_GetPoketchSystem(void);
 SysTask * CoreSys_ExecuteAfterVBlank(SysTaskFunc param0, void * param1, u32 param2);
 
-BOOL ov25_02254560 (UnkStruct_ov25_02254560 ** param0, const UnkStruct_ov25_02254560_1 * param1, NNSG2dOamManagerInstance * param2, PoketchSystem * param3)
+BOOL ov25_02254560 (UnkStruct_ov25_02254560 ** param0, const UnkStruct_ov25_02254560_1 * param1, NNSG2dOamManagerInstance * param2, PoketchSystem *poketchSys)
 {
     *param0 = Heap_AllocFromHeap(HEAP_ID_POKETCH_MAIN, sizeof(UnkStruct_ov25_02254560));
 
@@ -109,7 +109,7 @@ BOOL ov25_02254560 (UnkStruct_ov25_02254560 ** param0, const UnkStruct_ov25_0225
 
         v0->unk_00 = param1;
         v0->unk_1F8 = sub_02018340(7);
-        v0->unk_1FC = param3;
+        v0->poketchSys = poketchSys;
 
         ov25_02254684(v0);
         ov25_02254DD8(&v0->unk_1D4, v0->unk_1CC);
@@ -166,7 +166,7 @@ static void ov25_02254684 (UnkStruct_ov25_02254560 * param0)
 void ov25_022546B8 (u32 param0, u32 param1)
 {
     UnkStruct_ov25_02254560 * v0 = ov25_02254418();
-    PoketchData * v1 = PoketchSystem_GetPoketchData(v0->unk_1FC);
+    PoketchData * v1 = PoketchSystem_GetPoketchData(v0->poketchSys);
     u32 v2 = PoketchData_CurrentScreenColor(v1);
 
     GXS_LoadBGPltt(&v0->unk_200[v2 * 32], param0 * 0x20, 0x20);
@@ -176,7 +176,7 @@ void ov25_022546B8 (u32 param0, u32 param1)
 void ov25_022546F0 (u32 param0, u32 param1)
 {
     UnkStruct_ov25_02254560 * v0 = ov25_02254418();
-    PoketchData * v1 = PoketchSystem_GetPoketchData(v0->unk_1FC);
+    PoketchData * v1 = PoketchSystem_GetPoketchData(v0->poketchSys);
     u32 v2 = PoketchData_CurrentScreenColor(v1);
 
     GXS_LoadBGPltt(&v0->unk_200[v2 * 32 + 16], 0, 0x20);
@@ -186,7 +186,7 @@ void ov25_022546F0 (u32 param0, u32 param1)
 void ov25_02254728 (u16 * param0)
 {
     UnkStruct_ov25_02254560 * v0 = ov25_02254418();
-    PoketchData * v1 = PoketchSystem_GetPoketchData(v0->unk_1FC);
+    PoketchData * v1 = PoketchSystem_GetPoketchData(v0->poketchSys);
     u32 v2 = PoketchData_CurrentScreenColor(v1);
 
     MI_CpuCopy16(&v0->unk_200[v2 * 32], param0, 0x20);
@@ -324,7 +324,7 @@ static void ov25_02254820 (SysTask * param0, void * param1)
 
     sub_02006E3C(12, 14, v2->unk_1F8, 4, 64, 0, 1, 7);
     sub_02006E60(12, 15, v2->unk_1F8, 4, 0, 0, 1, 7);
-    sub_02006E9C(12, 13, 4, PoketchSystem_GetBorderColor(v2->unk_1FC) * 0x20, 15 * 0x20, 0x20, 7);
+    sub_02006E9C(12, 13, 4, PoketchSystem_GetBorderColor(v2->poketchSys) * 0x20, 15 * 0x20, 0x20, 7);
 
     sub_02019CB8(v2->unk_1F8, 5, 64 + 164, 0, 0, 32, 24, 15);
     sub_02019448(v2->unk_1F8, 5);
@@ -608,7 +608,7 @@ static void ov25_02254DE0 (UnkStruct_ov25_02254560 * param0, UnkStruct_ov25_0225
 
 static void ov25_02254E84 (UnkStruct_ov25_02254560 * param0, u32 param1)
 {
-    PoketchData * v1 = PoketchSystem_GetPoketchData(param0->unk_1FC);
+    PoketchData * v1 = PoketchSystem_GetPoketchData(param0->poketchSys);
     u32 v2 = PoketchData_CurrentScreenColor(v1);
 
     ov25_02254728(param0->unk_400);

--- a/src/overlay026/ov26_022561C0.c
+++ b/src/overlay026/ov26_022561C0.c
@@ -30,13 +30,13 @@ typedef struct {
     PoketchButtonManager * unk_10;
     UnkStruct_ov26_02256404_1 unk_14;
     UnkStruct_ov26_02256404 * unk_24;
-    PoketchSystem * unk_28;
+    PoketchSystem *poketchSys;
 } UnkStruct_ov26_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov26_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov26_0225621C(UnkStruct_ov26_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov26_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov26_0225621C(UnkStruct_ov26_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov26_022562A4(UnkStruct_ov26_0225621C * param0);
 static void ov26_022562BC(SysTask * param0, void * param1);
 static void ov26_022562F8(void * param0);
@@ -55,12 +55,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov26_022561D4, ov26_022562F8);
 }
 
-static BOOL ov26_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov26_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov26_0225621C * v0 = (UnkStruct_ov26_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov26_0225621C));
 
     if (v0 != NULL) {
-        if (ov26_0225621C(v0, param1, param2, param3)) {
+        if (ov26_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov26_022562BC, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -73,7 +73,7 @@ static BOOL ov26_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov26_0225621C (UnkStruct_ov26_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov26_0225621C (UnkStruct_ov26_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     if (ov26_02256404(&(param0->unk_24), &(param0->unk_14), param2)) {
         param0->unk_00 = 0;
@@ -102,7 +102,7 @@ static BOOL ov26_0225621C (UnkStruct_ov26_0225621C * param0, PoketchSystem * par
             return 0;
         }
 
-        param0->unk_28 = param1;
+        param0->poketchSys = poketchSys;
         return 1;
     }
 
@@ -125,12 +125,12 @@ static void ov26_022562BC (SysTask * param0, void * param1)
     UnkStruct_ov26_0225621C * v1 = (UnkStruct_ov26_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_28, v1->unk_10);
+        ov25_02254518(v1->poketchSys, v1->unk_10);
 
         if (v0[v1->unk_00](v1)) {
             ov26_022562A4(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_28);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -177,7 +177,7 @@ static BOOL ov26_02256330 (UnkStruct_ov26_0225621C * param0)
         break;
     case 1:
         if (ov26_022564CC(param0->unk_24, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_28);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov26_0225631C(param0, 1);
         }
         break;

--- a/src/overlay026/ov26_022561C0.c
+++ b/src/overlay026/ov26_022561C0.c
@@ -27,7 +27,7 @@ typedef struct {
     u8 unk_07;
     u32 unk_08;
     u32 unk_0C;
-    PoketchButtonManager * unk_10;
+    PoketchButtonManager *buttonManager;
     UnkStruct_ov26_02256404_1 unk_14;
     UnkStruct_ov26_02256404 * unk_24;
     PoketchSystem *poketchSys;
@@ -96,9 +96,9 @@ static BOOL ov26_0225621C (UnkStruct_ov26_0225621C * param0, PoketchSystem *poke
 
         param0->unk_06 = param0->unk_14.unk_00.minute;
         param0->unk_05 = param0->unk_14.unk_00.hour;
-        param0->unk_10 = PoketchButtonManager_New(Unk_ov26_02256718, NELEMS(Unk_ov26_02256718), ov26_02256300, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(Unk_ov26_02256718, NELEMS(Unk_ov26_02256718), ov26_02256300, param0, 8);
 
-        if (param0->unk_10 == NULL) {
+        if (param0->buttonManager == NULL) {
             return 0;
         }
 
@@ -112,7 +112,7 @@ static BOOL ov26_0225621C (UnkStruct_ov26_0225621C * param0, PoketchSystem *poke
 static void ov26_022562A4 (UnkStruct_ov26_0225621C * param0)
 {
     ov26_0225649C(param0->unk_24);
-    PoketchButtonManager_Free(param0->unk_10);
+    PoketchButtonManager_Free(param0->buttonManager);
     Heap_FreeToHeap(param0);
 }
 
@@ -125,7 +125,7 @@ static void ov26_022562BC (SysTask * param0, void * param1)
     UnkStruct_ov26_0225621C * v1 = (UnkStruct_ov26_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_10);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov26_022562A4(v1);

--- a/src/overlay027/ov27_022561C0.c
+++ b/src/overlay027/ov27_022561C0.c
@@ -39,7 +39,7 @@ typedef struct {
     u64 unk_14;
     UnkStruct_ov27_0225680C_1 unk_1C;
     UnkStruct_ov27_0225621C_sub1 unk_38;
-    PoketchButtonManager * unk_5C;
+    PoketchButtonManager *buttonManager;
     UnkStruct_ov27_0225680C * unk_60;
     PoketchSystem *poketchSys;
 } UnkStruct_ov27_0225621C;
@@ -166,7 +166,7 @@ static void ov27_022562FC (SysTask * param0, void * param1)
             v1->unk_02 = 0;
         }
 
-        ov25_02254518(v1->poketchSys, v1->unk_5C);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
         ov27_022566D8(v1, &(v1->unk_1C));
 
         if (v0[v1->unk_00](v1)) {
@@ -375,11 +375,11 @@ static BOOL ov27_02256608 (UnkStruct_ov27_0225621C * param0)
         {0xfe, 112, 112, 39},
     };
 
-    param0->unk_5C = PoketchButtonManager_New(v0, NELEMS(v0), ov27_02256660, param0, 8);
+    param0->buttonManager = PoketchButtonManager_New(v0, NELEMS(v0), ov27_02256660, param0, 8);
 
-    if (param0->unk_5C != NULL) {
-        PoketchButtonManager_SetButtonTimer(param0->unk_5C, 0, 0, 15);
-        PoketchButtonManager_SetButtonTimer(param0->unk_5C, 0, 1, 75);
+    if (param0->buttonManager != NULL) {
+        PoketchButtonManager_SetButtonTimer(param0->buttonManager, 0, 0, 15);
+        PoketchButtonManager_SetButtonTimer(param0->buttonManager, 0, 1, 75);
         param0->unk_04 = 0;
         return 1;
     }
@@ -389,7 +389,7 @@ static BOOL ov27_02256608 (UnkStruct_ov27_0225621C * param0)
 
 static void ov27_02256654 (UnkStruct_ov27_0225621C * param0)
 {
-    PoketchButtonManager_Free(param0->unk_5C);
+    PoketchButtonManager_Free(param0->buttonManager);
 }
 
 static void ov27_02256660 (u32 param0, u32 param1, u32 param2, void * param3)

--- a/src/overlay027/ov27_022561C0.c
+++ b/src/overlay027/ov27_022561C0.c
@@ -41,12 +41,12 @@ typedef struct {
     UnkStruct_ov27_0225621C_sub1 unk_38;
     PoketchButtonManager * unk_5C;
     UnkStruct_ov27_0225680C * unk_60;
-    PoketchSystem * unk_64;
+    PoketchSystem *poketchSys;
 } UnkStruct_ov27_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov27_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov27_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static BOOL ov27_0225621C(UnkStruct_ov27_0225621C * param0, BGL * param1, u32 param2);
 static void ov27_022562AC(UnkStruct_ov27_0225621C * param0);
 static void ov27_022562FC(SysTask * param0, void * param1);
@@ -71,13 +71,13 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov27_022561D4, ov27_02256358);
 }
 
-static BOOL ov27_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov27_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov27_0225621C * v0 = (UnkStruct_ov27_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov27_0225621C));
 
     if (v0 != NULL) {
         if (ov27_0225621C(v0, param2, param3)) {
-            v0->unk_64 = param1;
+            v0->poketchSys = poketchSys;
 
             if (SysTask_Start(ov27_022562FC, v0, 1) != NULL) {
                 *param0 = v0;
@@ -166,13 +166,13 @@ static void ov27_022562FC (SysTask * param0, void * param1)
             v1->unk_02 = 0;
         }
 
-        ov25_02254518(v1->unk_64, v1->unk_5C);
+        ov25_02254518(v1->poketchSys, v1->unk_5C);
         ov27_022566D8(v1, &(v1->unk_1C));
 
         if (v0[v1->unk_00](v1)) {
             ov27_022562AC(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_64);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -206,7 +206,7 @@ static BOOL ov27_0225637C (UnkStruct_ov27_0225621C * param0)
         break;
     case 1:
         if (ov27_022569EC(param0->unk_60, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_64);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
 
             if (param0->unk_1C.unk_00) {
                 ov27_02256360(param0, 2);

--- a/src/overlay028/ov28_022561C0.c
+++ b/src/overlay028/ov28_022561C0.c
@@ -30,7 +30,7 @@ typedef struct {
     u8 unk_05;
     u16 unk_06;
     u32 unk_08;
-    PoketchButtonManager * unk_0C;
+    PoketchButtonManager *buttonManager;
     PoketchSystem *poketchSys;
     UnkStruct_ov28_0225697C * unk_14;
     UnkStruct_ov28_0225697C_1 unk_18;
@@ -117,9 +117,9 @@ static BOOL ov28_02256210 (UnkStruct_ov28_02256210 * param0, u32 param1, BGL * p
             return 0;
         }
 
-        param0->unk_0C = PoketchButtonManager_New(Unk_ov28_02257658, NELEMS(Unk_ov28_02257658), ov28_02256344, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(Unk_ov28_02257658, NELEMS(Unk_ov28_02257658), ov28_02256344, param0, 8);
 
-        if (param0->unk_0C == NULL) {
+        if (param0->buttonManager == NULL) {
             return 0;
         }
     }
@@ -141,8 +141,8 @@ static void ov28_02256298 (UnkStruct_ov28_02256210 * param0)
         ov28_02256EC0(param0->unk_18.unk_0C);
     }
 
-    if (param0->unk_0C) {
-        PoketchButtonManager_Free(param0->unk_0C);
+    if (param0->buttonManager) {
+        PoketchButtonManager_Free(param0->buttonManager);
     }
 
     ov28_022569AC(param0->unk_14);
@@ -169,7 +169,7 @@ static void ov28_022562CC (SysTask * param0, void * param1)
 
     if (v1->unk_00 < NELEMS(v0)) {
         v1->unk_06 = 17;
-        ov25_02254518(v1->poketchSys, v1->unk_0C);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov28_02256298(v1);

--- a/src/overlay028/ov28_022561C0.c
+++ b/src/overlay028/ov28_022561C0.c
@@ -31,14 +31,14 @@ typedef struct {
     u16 unk_06;
     u32 unk_08;
     PoketchButtonManager * unk_0C;
-    PoketchSystem * unk_10;
+    PoketchSystem *poketchSys;
     UnkStruct_ov28_0225697C * unk_14;
     UnkStruct_ov28_0225697C_1 unk_18;
 } UnkStruct_ov28_02256210;
 
 static void NitroStaticInit(void);
 
-static BOOL ov28_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov28_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static BOOL ov28_02256210(UnkStruct_ov28_02256210 * param0, u32 param1, BGL * param2);
 static void ov28_02256298(UnkStruct_ov28_02256210 * param0);
 static void ov28_022562CC(SysTask * param0, void * param1);
@@ -81,13 +81,13 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov28_022561D4, ov28_02256324);
 }
 
-static BOOL ov28_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov28_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov28_02256210 * v0 = (UnkStruct_ov28_02256210 *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov28_02256210));
 
     if (v0 != NULL) {
         if (ov28_02256210(v0, param3, param2)) {
-            v0->unk_10 = param1;
+            v0->poketchSys = poketchSys;
             SysTask_Start(ov28_022562CC, v0, 1);
             *param0 = v0;
 
@@ -169,13 +169,13 @@ static void ov28_022562CC (SysTask * param0, void * param1)
 
     if (v1->unk_00 < NELEMS(v0)) {
         v1->unk_06 = 17;
-        ov25_02254518(v1->unk_10, v1->unk_0C);
+        ov25_02254518(v1->poketchSys, v1->unk_0C);
 
         if (v0[v1->unk_00](v1)) {
             ov28_02256298(v1);
             Heap_FreeToHeap(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_10);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -227,7 +227,7 @@ static BOOL ov28_02256374 (UnkStruct_ov28_02256210 * param0)
         break;
     case 1:
         if (ov28_022569DC(param0->unk_14, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_10);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov28_0225632C(param0, 1);
         }
         break;
@@ -634,7 +634,7 @@ static void ov28_02256914 (UnkStruct_ov28_02256210 * param0, const UnkStruct_ov2
         PokedexData * v1;
         u16 v2;
 
-        v1 = SaveData_Pokedex(PoketchSystem_GetSaveData(param0->unk_10));
+        v1 = SaveData_Pokedex(PoketchSystem_GetSaveData(param0->poketchSys));
 
         if (sub_02027474(v1)) {
             v2 = v0;

--- a/src/overlay029/ov29_022561C0.c
+++ b/src/overlay029/ov29_022561C0.c
@@ -23,14 +23,14 @@ typedef struct {
     u32 unk_04;
     UnkStruct_ov29_022566C8_1 unk_08;
     UnkStruct_ov29_022566C8 * unk_16F4;
-    PoketchSystem * unk_16F8;
+    PoketchSystem *poketchSys;
     PoketchButtonManager * unk_16FC;
 } UnkStruct_ov29_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov29_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov29_0225621C(UnkStruct_ov29_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov29_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov29_0225621C(UnkStruct_ov29_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov29_02256288(UnkStruct_ov29_0225621C * param0);
 static void ov29_022562AC(SysTask * param0, void * param1);
 static void ov29_022562F4(u32 param0, u32 param1, u32 param2, void * param3);
@@ -53,12 +53,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov29_022561D4, ov29_02256324);
 }
 
-static BOOL ov29_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov29_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov29_0225621C * v0 = (UnkStruct_ov29_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov29_0225621C));
 
     if (v0 != NULL) {
-        if (ov29_0225621C(v0, param1, param2, param3)) {
+        if (ov29_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov29_022562AC, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -71,7 +71,7 @@ static BOOL ov29_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov29_0225621C (UnkStruct_ov29_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov29_0225621C (UnkStruct_ov29_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     memset(param0->unk_08.unk_0C, 0, sizeof(u8) * (78 * 75));
 
@@ -86,7 +86,7 @@ static BOOL ov29_0225621C (UnkStruct_ov29_0225621C * param0, PoketchSystem * par
         param0->unk_02 = 0;
         param0->unk_03 = 0;
         param0->unk_16FC = PoketchButtonManager_New(Unk_ov29_02256B3C, NELEMS(Unk_ov29_02256B3C), ov29_022562F4, param0, 8);
-        param0->unk_16F8 = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -112,12 +112,12 @@ static void ov29_022562AC (SysTask * param0, void * param1)
     UnkStruct_ov29_0225621C * v1 = (UnkStruct_ov29_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_16F8, v1->unk_16FC);
+        ov25_02254518(v1->poketchSys, v1->unk_16FC);
 
         if (v0[v1->unk_00](v1)) {
             ov29_02256288(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_16F8);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -160,7 +160,7 @@ static BOOL ov29_02256340 (UnkStruct_ov29_0225621C * param0)
         break;
     case 1:
         if (ov29_022567D8(param0->unk_16F4, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_16F8);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov29_0225632C(param0, 1);
         }
         break;
@@ -177,7 +177,7 @@ static BOOL ov29_0225638C (UnkStruct_ov29_0225621C * param0)
 
     switch (param0->unk_01) {
     case 0:
-        if (ov25_0225450C(param0->unk_16F8)) {
+        if (ov25_0225450C(param0->poketchSys)) {
             break;
         }
 

--- a/src/overlay029/ov29_022561C0.c
+++ b/src/overlay029/ov29_022561C0.c
@@ -24,7 +24,7 @@ typedef struct {
     UnkStruct_ov29_022566C8_1 unk_08;
     UnkStruct_ov29_022566C8 * unk_16F4;
     PoketchSystem *poketchSys;
-    PoketchButtonManager * unk_16FC;
+    PoketchButtonManager *buttonManager;
 } UnkStruct_ov29_0225621C;
 
 static void NitroStaticInit(void);
@@ -85,7 +85,7 @@ static BOOL ov29_0225621C (UnkStruct_ov29_0225621C * param0, PoketchSystem *poke
         param0->unk_01 = 0;
         param0->unk_02 = 0;
         param0->unk_03 = 0;
-        param0->unk_16FC = PoketchButtonManager_New(Unk_ov29_02256B3C, NELEMS(Unk_ov29_02256B3C), ov29_022562F4, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(Unk_ov29_02256B3C, NELEMS(Unk_ov29_02256B3C), ov29_022562F4, param0, 8);
         param0->poketchSys = poketchSys;
 
         return 1;
@@ -96,7 +96,7 @@ static BOOL ov29_0225621C (UnkStruct_ov29_0225621C * param0, PoketchSystem *poke
 
 static void ov29_02256288 (UnkStruct_ov29_0225621C * param0)
 {
-    PoketchButtonManager_Free(param0->unk_16FC);
+    PoketchButtonManager_Free(param0->buttonManager);
     ov29_02256770(param0->unk_16F4);
     Heap_FreeToHeap(param0);
 }
@@ -112,7 +112,7 @@ static void ov29_022562AC (SysTask * param0, void * param1)
     UnkStruct_ov29_0225621C * v1 = (UnkStruct_ov29_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_16FC);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov29_02256288(v1);

--- a/src/overlay030/ov30_022561C0.c
+++ b/src/overlay030/ov30_022561C0.c
@@ -29,13 +29,13 @@ typedef struct {
     PoketchButtonManager * unk_10;
     UnkStruct_ov30_022563EC_1 unk_14;
     UnkStruct_ov30_022563EC * unk_24;
-    PoketchSystem * unk_28;
+    PoketchSystem *poketchSys;
 } UnkStruct_ov30_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov30_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov30_0225621C(UnkStruct_ov30_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov30_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov30_0225621C(UnkStruct_ov30_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov30_02256298(UnkStruct_ov30_0225621C * param0);
 static void ov30_022562B0(SysTask * param0, void * param1);
 static void ov30_022562EC(void * param0);
@@ -54,12 +54,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov30_022561D4, ov30_022562EC);
 }
 
-static BOOL ov30_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov30_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov30_0225621C * v0 = (UnkStruct_ov30_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov30_0225621C));
 
     if (v0 != NULL) {
-        if (ov30_0225621C(v0, param1, param2, param3)) {
+        if (ov30_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov30_022562B0, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -72,7 +72,7 @@ static BOOL ov30_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov30_0225621C (UnkStruct_ov30_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov30_0225621C (UnkStruct_ov30_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     if (ov30_022563EC(&(param0->unk_24), &(param0->unk_14), param2)) {
         param0->unk_00 = 0;
@@ -99,7 +99,7 @@ static BOOL ov30_0225621C (UnkStruct_ov30_0225621C * param0, PoketchSystem * par
             return 0;
         }
 
-        param0->unk_28 = param1;
+        param0->poketchSys = poketchSys;
         return 1;
     }
 
@@ -124,12 +124,12 @@ static void ov30_022562B0 (SysTask * param0, void * param1)
     UnkStruct_ov30_0225621C * v1 = (UnkStruct_ov30_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_28, v1->unk_10);
+        ov25_02254518(v1->poketchSys, v1->unk_10);
 
         if (v0[v1->unk_00](v1)) {
             ov30_02256298(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_28);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -176,7 +176,7 @@ static BOOL ov30_02256324 (UnkStruct_ov30_0225621C * param0)
         break;
     case 1:
         if (ov30_02256488(param0->unk_24, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_28);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov30_02256310(param0, 1);
         }
         break;

--- a/src/overlay030/ov30_022561C0.c
+++ b/src/overlay030/ov30_022561C0.c
@@ -26,7 +26,7 @@ typedef struct {
     u8 unk_06;
     u32 unk_08;
     u32 unk_0C;
-    PoketchButtonManager * unk_10;
+    PoketchButtonManager *buttonManager;
     UnkStruct_ov30_022563EC_1 unk_14;
     UnkStruct_ov30_022563EC * unk_24;
     PoketchSystem *poketchSys;
@@ -93,9 +93,9 @@ static BOOL ov30_0225621C (UnkStruct_ov30_0225621C * param0, PoketchSystem *poke
         }
 
         param0->unk_05 = param0->unk_14.unk_00.minute;
-        param0->unk_10 = PoketchButtonManager_New(Unk_ov30_02256678, NELEMS(Unk_ov30_02256678), ov30_022562F4, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(Unk_ov30_02256678, NELEMS(Unk_ov30_02256678), ov30_022562F4, param0, 8);
 
-        if (param0->unk_10 == NULL) {
+        if (param0->buttonManager == NULL) {
             return 0;
         }
 
@@ -109,7 +109,7 @@ static BOOL ov30_0225621C (UnkStruct_ov30_0225621C * param0, PoketchSystem *poke
 static void ov30_02256298 (UnkStruct_ov30_0225621C * param0)
 {
     ov30_02256444(param0->unk_24);
-    PoketchButtonManager_Free(param0->unk_10);
+    PoketchButtonManager_Free(param0->buttonManager);
     Heap_FreeToHeap(param0);
 }
 
@@ -124,7 +124,7 @@ static void ov30_022562B0 (SysTask * param0, void * param1)
     UnkStruct_ov30_0225621C * v1 = (UnkStruct_ov30_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_10);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov30_02256298(v1);

--- a/src/overlay031/ov31_022561C0.c
+++ b/src/overlay031/ov31_022561C0.c
@@ -25,14 +25,14 @@ typedef struct {
     u32 unk_08;
     UnkStruct_ov31_02256554_1 unk_0C;
     UnkStruct_ov31_02256554 * unk_1EC;
-    PoketchSystem * unk_1F0;
+    PoketchSystem *poketchSys;
     u8 unk_1F4[120];
 } UnkStruct_ov31_02256228;
 
 static void NitroStaticInit(void);
 
-static BOOL ov31_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov31_02256228(UnkStruct_ov31_02256228 * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov31_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov31_02256228(UnkStruct_ov31_02256228 * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov31_02256268(UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_02256554_1 * param1);
 static inline u8 inline_ov31_02256298(const u8 * param0, int param1);
 static inline void inline_ov31_022562EC(u8 * param0, int param1, int param2);
@@ -53,12 +53,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov31_022561D4, ov31_02256404);
 }
 
-static BOOL ov31_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov31_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov31_02256228 * v0 = (UnkStruct_ov31_02256228 *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov31_02256228));
 
     if (v0 != NULL) {
-        if (ov31_02256228(v0, param1, param2, param3)) {
+        if (ov31_02256228(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov31_022563CC, v0, 1) != NULL) {
                 *param0 = v0;
                 PoketchSystem_SetSaveFunction(ov31_022563B0, v0);
@@ -72,9 +72,9 @@ static BOOL ov31_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov31_02256228 (UnkStruct_ov31_02256228 * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov31_02256228 (UnkStruct_ov31_02256228 * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
-    param0->unk_1F0 = param1;
+    param0->poketchSys = poketchSys;
     ov31_02256268(param0, &(param0->unk_0C));
 
     if (ov31_02256554(&(param0->unk_1EC), &(param0->unk_0C), param2)) {
@@ -92,7 +92,7 @@ static BOOL ov31_02256228 (UnkStruct_ov31_02256228 * param0, PoketchSystem * par
 
 static void ov31_02256268 (UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_02256554_1 * param1)
 {
-    PoketchData * v0 = PoketchSystem_GetPoketchData(param0->unk_1F0);
+    PoketchData * v0 = PoketchSystem_GetPoketchData(param0->poketchSys);
 
     if (PoketchData_DotArtModified(v0)) {
         ov31_02256298(param0, param1, v0);
@@ -178,7 +178,7 @@ static void ov31_0225635C (UnkStruct_ov31_02256554_1 * param0)
 
 static void ov31_02256384 (UnkStruct_ov31_02256228 * param0)
 {
-    ov31_022562EC(param0, &param0->unk_0C, PoketchSystem_GetPoketchData(param0->unk_1F0));
+    ov31_022562EC(param0, &param0->unk_0C, PoketchSystem_GetPoketchData(param0->poketchSys));
     ov31_02256584(param0->unk_1EC);
 
     Heap_FreeToHeap(param0);
@@ -187,7 +187,7 @@ static void ov31_02256384 (UnkStruct_ov31_02256228 * param0)
 static void ov31_022563B0 (void * param0)
 {
     UnkStruct_ov31_02256228 * v0 = param0;
-    ov31_022562EC(v0, &v0->unk_0C, PoketchSystem_GetPoketchData(v0->unk_1F0));
+    ov31_022562EC(v0, &v0->unk_0C, PoketchSystem_GetPoketchData(v0->poketchSys));
 }
 
 static void ov31_022563CC (SysTask * param0, void * param1)
@@ -204,7 +204,7 @@ static void ov31_022563CC (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov31_02256384(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_1F0);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -235,7 +235,7 @@ static BOOL ov31_02256420 (UnkStruct_ov31_02256228 * param0)
         break;
     case 1:
         if (ov31_022565B4(param0->unk_1EC, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_1F0);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov31_0225640C(param0, 1);
         }
         break;

--- a/src/overlay031/ov31_022561C0.c
+++ b/src/overlay031/ov31_022561C0.c
@@ -36,8 +36,8 @@ static BOOL ov31_02256228(UnkStruct_ov31_02256228 * param0, PoketchSystem *poket
 static void ov31_02256268(UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_02256554_1 * param1);
 static inline u8 inline_ov31_02256298(const u8 * param0, int param1);
 static inline void inline_ov31_022562EC(u8 * param0, int param1, int param2);
-static void ov31_02256298(UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_02256554_1 * param1, PoketchData * param2);
-static void ov31_022562EC(UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_02256554_1 * param1, PoketchData * param2);
+static void ov31_02256298(UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_02256554_1 * param1, PoketchData *poketchData);
+static void ov31_022562EC(UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_02256554_1 * param1, PoketchData *poketchData);
 static void ov31_0225635C(UnkStruct_ov31_02256554_1 * param0);
 static void ov31_02256384(UnkStruct_ov31_02256228 * param0);
 static void ov31_022563B0(void * param0);
@@ -92,10 +92,10 @@ static BOOL ov31_02256228 (UnkStruct_ov31_02256228 * param0, PoketchSystem *poke
 
 static void ov31_02256268 (UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_02256554_1 * param1)
 {
-    PoketchData * v0 = PoketchSystem_GetPoketchData(param0->poketchSys);
+    PoketchData *poketchData = PoketchSystem_GetPoketchData(param0->poketchSys);
 
-    if (PoketchData_DotArtModified(v0)) {
-        ov31_02256298(param0, param1, v0);
+    if (PoketchData_DotArtModified(poketchData)) {
+        ov31_02256298(param0, param1, poketchData);
     } else {
         ov31_0225635C(param1);
     }
@@ -111,11 +111,11 @@ static inline void inline_ov31_022562EC (u8 * param0, int param1, int param2)
     param0[(param1 / 4)] |= ((param2 & 3) << ((param1 & 3) * 2));
 }
 
-static void ov31_02256298 (UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_02256554_1 * param1, PoketchData * param2)
+static void ov31_02256298 (UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_02256554_1 * param1, PoketchData *poketchData)
 {
     int v0, v1, v2;
 
-    PoketchData_CopyDotArtData(param2, param0->unk_1F4);
+    PoketchData_CopyDotArtData(poketchData, param0->unk_1F4);
 
     v2 = 0;
 
@@ -126,7 +126,7 @@ static void ov31_02256298 (UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_0225
     }
 }
 
-static void ov31_022562EC (UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_02256554_1 * param1, PoketchData * param2)
+static void ov31_022562EC (UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_02256554_1 * param1, PoketchData *poketchData)
 {
     int v0, v1, v2;
 
@@ -140,7 +140,7 @@ static void ov31_022562EC (UnkStruct_ov31_02256228 * param0, UnkStruct_ov31_0225
         }
     }
 
-    PoketchData_ModifyDotArtData(param2, param0->unk_1F4);
+    PoketchData_ModifyDotArtData(poketchData, param0->unk_1F4);
 }
 
 static void ov31_0225635C (UnkStruct_ov31_02256554_1 * param0)

--- a/src/overlay032/ov32_022561C0.c
+++ b/src/overlay032/ov32_022561C0.c
@@ -25,13 +25,13 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov32_02256470_1 unk_04;
     UnkStruct_ov32_02256470 * unk_74;
-    PoketchSystem * unk_78;
+    PoketchSystem *poketchSys;
 } UnkStruct_ov32_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov32_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov32_0225621C(UnkStruct_ov32_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov32_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov32_0225621C(UnkStruct_ov32_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov32_02256264(UnkStruct_ov32_0225621C * param0);
 static void ov32_02256278(SysTask * param0, void * param1);
 static void ov32_022562AC(void * param0);
@@ -46,12 +46,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov32_022561D4, ov32_022562AC);
 }
 
-static BOOL ov32_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov32_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov32_0225621C * v0 = (UnkStruct_ov32_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov32_0225621C));
 
     if (v0 != NULL) {
-        if (ov32_0225621C(v0, param1, param2, param3)) {
+        if (ov32_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov32_02256278, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -64,20 +64,20 @@ static BOOL ov32_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov32_0225621C (UnkStruct_ov32_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov32_0225621C (UnkStruct_ov32_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     if (ov32_02256470(&(param0->unk_74), &(param0->unk_04), param2)) {
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
 
-        ov32_022563C8(&param0->unk_04, Party_GetFromSavedata(PoketchSystem_GetSaveData(param1)));
+        ov32_022563C8(&param0->unk_04, Party_GetFromSavedata(PoketchSystem_GetSaveData(poketchSys)));
 
         param0->unk_04.unk_64 = 0;
         param0->unk_04.unk_66 = 0;
         param0->unk_04.unk_68 = 0;
         param0->unk_04.unk_6C = 0;
-        param0->unk_78 = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -105,7 +105,7 @@ static void ov32_02256278 (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov32_02256264(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_78);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -136,7 +136,7 @@ static BOOL ov32_022562C8 (UnkStruct_ov32_0225621C * param0)
         break;
     case 1:
         if (ov32_0225655C(param0->unk_74, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_78);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov32_022562B4(param0, 1);
         }
         break;
@@ -162,7 +162,7 @@ static BOOL ov32_02256308 (UnkStruct_ov32_0225621C * param0)
                 u32 v0 = ov32_02256B78(param0->unk_04.unk_68, param0->unk_04.unk_6C, param0->unk_04.unk_00);
 
                 if (v0 >= param0->unk_04.unk_00) {
-                    ov32_022563C8(&param0->unk_04, Party_GetFromSavedata(PoketchSystem_GetSaveData(param0->unk_78)));
+                    ov32_022563C8(&param0->unk_04, Party_GetFromSavedata(PoketchSystem_GetSaveData(param0->poketchSys)));
                     ov32_02256538(param0->unk_74, 2);
                 }
             }

--- a/src/overlay033/ov33_022561C0.c
+++ b/src/overlay033/ov33_022561C0.c
@@ -26,13 +26,13 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov33_02256474_1 unk_04;
     UnkStruct_ov33_02256474 * unk_5C;
-    PoketchSystem * unk_60;
+    PoketchSystem *poketchSys;
 } UnkStruct_ov33_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov33_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov33_0225621C(UnkStruct_ov33_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov33_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov33_0225621C(UnkStruct_ov33_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static u32 ov33_0225630C(u32 param0);
 static void ov33_0225632C(UnkStruct_ov33_0225621C * param0);
 static void ov33_02256340(SysTask * param0, void * param1);
@@ -47,12 +47,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov33_022561D4, ov33_02256374);
 }
 
-static BOOL ov33_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov33_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov33_0225621C * v0 = (UnkStruct_ov33_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov33_0225621C));
 
     if (v0 != NULL) {
-        if (ov33_0225621C(v0, param1, param2, param3)) {
+        if (ov33_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov33_02256340, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -65,13 +65,13 @@ static BOOL ov33_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov33_0225621C (UnkStruct_ov33_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov33_0225621C (UnkStruct_ov33_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     if (ov33_02256474(&(param0->unk_5C), &(param0->unk_04), param2)) {
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_60 = param1;
+        param0->poketchSys = poketchSys;
 
         {
             Party * v0 = Party_GetFromSavedata(SaveData_Ptr());
@@ -163,7 +163,7 @@ static void ov33_02256340 (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov33_0225632C(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_60);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -194,7 +194,7 @@ static BOOL ov33_02256390 (UnkStruct_ov33_0225621C * param0)
         break;
     case 1:
         if (ov33_0225656C(param0->unk_5C, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_60);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov33_0225637C(param0, 1);
         }
         break;

--- a/src/overlay034/ov34_022561C0.c
+++ b/src/overlay034/ov34_022561C0.c
@@ -22,14 +22,14 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov34_02256540_1 unk_04;
     UnkStruct_ov34_02256540 * unk_48;
-    PoketchSystem * unk_4C;
+    PoketchSystem *poketchSys;
     UnkStruct_0203F478 * unk_50;
 } UnkStruct_ov34_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov34_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov34_0225621C(UnkStruct_ov34_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov34_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov34_0225621C(UnkStruct_ov34_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov34_02256244(UnkStruct_ov34_0225621C * param0);
 static void ov34_02256260(SysTask * param0, void * param1);
 static void ov34_02256294(void * param0);
@@ -46,12 +46,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov34_022561D4, ov34_02256294);
 }
 
-static BOOL ov34_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov34_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov34_0225621C * v0 = (UnkStruct_ov34_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov34_0225621C));
 
     if (v0 != NULL) {
-        if (ov34_0225621C(v0, param1, param2, param3)) {
+        if (ov34_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov34_02256260, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -64,14 +64,14 @@ static BOOL ov34_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov34_0225621C (UnkStruct_ov34_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov34_0225621C (UnkStruct_ov34_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     if (ov34_02256540(&(param0->unk_48), &(param0->unk_04), param2)) {
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
         param0->unk_50 = NULL;
-        param0->unk_4C = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -103,7 +103,7 @@ static void ov34_02256260 (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov34_02256244(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_4C);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -134,7 +134,7 @@ static BOOL ov34_022562B0 (UnkStruct_ov34_0225621C * param0)
         break;
     case 1:
         if (ov34_02256664(param0->unk_48, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_4C);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov34_0225629C(param0, 1);
         }
         break;
@@ -168,7 +168,7 @@ static BOOL ov34_022562F0 (UnkStruct_ov34_0225621C * param0)
             break;
         }
 
-        if ((PoketchSystem_IsPlayerMoving(param0->unk_4C) == 1) || (ov25_0225450C(param0->unk_4C))) {
+        if ((PoketchSystem_IsPlayerMoving(param0->poketchSys) == 1) || (ov25_0225450C(param0->poketchSys))) {
             ov34_02256A0C(param0->unk_48);
             param0->unk_01 = 2;
             break;
@@ -200,7 +200,7 @@ static BOOL ov34_022562F0 (UnkStruct_ov34_0225621C * param0)
 
 static BOOL ov34_022563E4 (UnkStruct_ov34_0225621C * param0, u32 * param1, u32 * param2)
 {
-    if (ov25_0225450C(param0->unk_4C) == 0) {
+    if (ov25_0225450C(param0->poketchSys) == 0) {
         if (TouchScreen_GetTapState(param1, param2)) {
             if (((u32)((*param1) - 24) < (u32)(200 - 24)) & ((u32)((*param2) - 24) < (u32)(168 - 24))) {
                 return 1;
@@ -216,7 +216,7 @@ static void ov34_02256428 (UnkStruct_ov34_0225621C * param0, int param1, int par
     static const fx32 v0[] = {
         8 << FX32_SHIFT, 24 << FX32_SHIFT, 48 << FX32_SHIFT,
     };
-    UnkStruct_0203F478 * v1 = sub_0203F478(PoketchSystem_GetFieldSystem(param0->unk_4C), 8);
+    UnkStruct_0203F478 * v1 = sub_0203F478(PoketchSystem_GetFieldSystem(param0->poketchSys), 8);
     UnkStruct_ov34_02256540_1 * v2 = &(param0->unk_04);
 
     v2->unk_08 = 0;

--- a/src/overlay035/ov35_022561C0.c
+++ b/src/overlay035/ov35_022561C0.c
@@ -23,15 +23,15 @@ typedef struct {
     u32 unk_04;
     UnkStruct_ov35_02256410_1 unk_08;
     UnkStruct_ov35_02256410 * unk_10;
-    PoketchSystem * unk_14;
+    PoketchSystem *poketchSys;
     PoketchButtonManager * unk_18;
     u32 unk_1C;
 } UnkStruct_ov35_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov35_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov35_0225621C(UnkStruct_ov35_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov35_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov35_0225621C(UnkStruct_ov35_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov35_02256284(u32 param0, u32 param1, u32 param2, void * param3);
 static void ov35_0225628C(UnkStruct_ov35_0225621C * param0);
 static void ov35_022562B0(SysTask * param0, void * param1);
@@ -46,12 +46,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov35_022561D4, ov35_022562EC);
 }
 
-static BOOL ov35_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov35_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov35_0225621C * v0 = (UnkStruct_ov35_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov35_0225621C));
 
     if (v0 != NULL) {
-        if (ov35_0225621C(v0, param1, param2, param3)) {
+        if (ov35_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov35_022562B0, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -64,7 +64,7 @@ static BOOL ov35_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov35_0225621C (UnkStruct_ov35_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov35_0225621C (UnkStruct_ov35_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     static const TouchScreenHitTable v0[] = {
         {
@@ -89,7 +89,7 @@ static BOOL ov35_0225621C (UnkStruct_ov35_0225621C * param0, PoketchSystem * par
         param0->unk_02 = 0;
         param0->unk_18 = PoketchButtonManager_New(v0, NELEMS(v0), ov35_02256284, param0, 8);
         param0->unk_1C = 0;
-        param0->unk_14 = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -123,12 +123,12 @@ static void ov35_022562B0 (SysTask * param0, void * param1)
     UnkStruct_ov35_0225621C * v1 = (UnkStruct_ov35_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_14, v1->unk_18);
+        ov25_02254518(v1->poketchSys, v1->unk_18);
 
         if (v0[v1->unk_00](v1)) {
             ov35_0225628C(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_14);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -159,7 +159,7 @@ static BOOL ov35_02256308 (UnkStruct_ov35_0225621C * param0)
         break;
     case 1:
         if (ov35_0225656C(param0->unk_10, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_14);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov35_022562F4(param0, 1);
         }
         break;

--- a/src/overlay035/ov35_022561C0.c
+++ b/src/overlay035/ov35_022561C0.c
@@ -24,7 +24,7 @@ typedef struct {
     UnkStruct_ov35_02256410_1 unk_08;
     UnkStruct_ov35_02256410 * unk_10;
     PoketchSystem *poketchSys;
-    PoketchButtonManager * unk_18;
+    PoketchButtonManager *buttonManager;
     u32 unk_1C;
 } UnkStruct_ov35_0225621C;
 
@@ -87,7 +87,7 @@ static BOOL ov35_0225621C (UnkStruct_ov35_0225621C * param0, PoketchSystem *poke
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_18 = PoketchButtonManager_New(v0, NELEMS(v0), ov35_02256284, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(v0, NELEMS(v0), ov35_02256284, param0, 8);
         param0->unk_1C = 0;
         param0->poketchSys = poketchSys;
 
@@ -109,7 +109,7 @@ static void ov35_02256284 (u32 param0, u32 param1, u32 param2, void * param3)
 static void ov35_0225628C (UnkStruct_ov35_0225621C * param0)
 {
     sub_02099D54(param0->unk_04, (u8 *)(&(param0->unk_08.unk_00)), sizeof(u32));
-    PoketchButtonManager_Free(param0->unk_18);
+    PoketchButtonManager_Free(param0->buttonManager);
     ov35_0225644C(param0->unk_10);
     Heap_FreeToHeap(param0);
 }
@@ -123,7 +123,7 @@ static void ov35_022562B0 (SysTask * param0, void * param1)
     UnkStruct_ov35_0225621C * v1 = (UnkStruct_ov35_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_18);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov35_0225628C(v1);

--- a/src/overlay036/ov36_022561C0.c
+++ b/src/overlay036/ov36_022561C0.c
@@ -23,7 +23,7 @@ typedef struct {
     PoketchSystem *poketchSys;
     PoketchButtonManager * unk_14;
     u32 unk_18;
-    PoketchData * unk_1C;
+    PoketchData *poketchData;
 } UnkStruct_ov36_0225621C;
 
 static void NitroStaticInit(void);
@@ -74,9 +74,9 @@ static BOOL ov36_0225621C (UnkStruct_ov36_0225621C * param0, PoketchSystem *poke
     };
 
     param0->poketchSys = poketchSys;
-    param0->unk_1C = PoketchSystem_GetPoketchData(poketchSys);
+    param0->poketchData = PoketchSystem_GetPoketchData(poketchSys);
     param0->unk_04.unk_04 = 1;
-    param0->unk_04.unk_00 = PoketchData_StepCount(param0->unk_1C);
+    param0->unk_04.unk_00 = PoketchData_StepCount(param0->poketchData);
 
     if (ov36_02256404(&(param0->unk_0C), &(param0->unk_04), param2)) {
         param0->unk_00 = 0;
@@ -184,7 +184,7 @@ static BOOL ov36_02256330 (UnkStruct_ov36_0225621C * param0)
         }
 
         if (PoketchSystem_PedometerUpdated(param0->poketchSys)) {
-            v0->unk_00 = PoketchData_StepCount(param0->unk_1C);
+            v0->unk_00 = PoketchData_StepCount(param0->poketchData);
             ov36_0225653C(param0->unk_0C, 3);
             break;
         }
@@ -204,7 +204,7 @@ static BOOL ov36_02256330 (UnkStruct_ov36_0225621C * param0)
             v0->unk_04 = 1;
             v0->unk_00 = 0;
 
-            PoketchData_SetStepCount(param0->unk_1C, 0);
+            PoketchData_SetStepCount(param0->poketchData, 0);
 
             ov36_0225653C(param0->unk_0C, 2);
             ov36_0225653C(param0->unk_0C, 3);

--- a/src/overlay036/ov36_022561C0.c
+++ b/src/overlay036/ov36_022561C0.c
@@ -21,7 +21,7 @@ typedef struct {
     UnkStruct_ov36_02256404_1 unk_04;
     UnkStruct_ov36_02256404 * unk_0C;
     PoketchSystem *poketchSys;
-    PoketchButtonManager * unk_14;
+    PoketchButtonManager *buttonManager;
     u32 unk_18;
     PoketchData *poketchData;
 } UnkStruct_ov36_0225621C;
@@ -82,7 +82,7 @@ static BOOL ov36_0225621C (UnkStruct_ov36_0225621C * param0, PoketchSystem *poke
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_14 = PoketchButtonManager_New(v0, NELEMS(v0), ov36_02256278, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(v0, NELEMS(v0), ov36_02256278, param0, 8);
         param0->unk_18 = 0;
 
         return 1;
@@ -102,7 +102,7 @@ static void ov36_02256278 (u32 param0, u32 param1, u32 param2, void * param3)
 
 static void ov36_02256280 (UnkStruct_ov36_0225621C * param0)
 {
-    PoketchButtonManager_Free(param0->unk_14);
+    PoketchButtonManager_Free(param0->buttonManager);
     ov36_02256440(param0->unk_0C);
 
     Heap_FreeToHeap(param0);
@@ -119,7 +119,7 @@ static void ov36_02256298 (SysTask * param0, void * param1)
     UnkStruct_ov36_0225621C * v1 = (UnkStruct_ov36_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_14);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov36_02256280(v1);

--- a/src/overlay036/ov36_022561C0.c
+++ b/src/overlay036/ov36_022561C0.c
@@ -20,7 +20,7 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov36_02256404_1 unk_04;
     UnkStruct_ov36_02256404 * unk_0C;
-    PoketchSystem * unk_10;
+    PoketchSystem *poketchSys;
     PoketchButtonManager * unk_14;
     u32 unk_18;
     PoketchData * unk_1C;
@@ -28,8 +28,8 @@ typedef struct {
 
 static void NitroStaticInit(void);
 
-static BOOL ov36_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov36_0225621C(UnkStruct_ov36_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov36_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov36_0225621C(UnkStruct_ov36_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov36_02256278(u32 param0, u32 param1, u32 param2, void * param3);
 static void ov36_02256280(UnkStruct_ov36_0225621C * param0);
 static void ov36_02256298(SysTask * param0, void * param1);
@@ -44,12 +44,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov36_022561D4, ov36_022562D4);
 }
 
-static BOOL ov36_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov36_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov36_0225621C * v0 = (UnkStruct_ov36_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov36_0225621C));
 
     if (v0 != NULL) {
-        if (ov36_0225621C(v0, param1, param2, param3)) {
+        if (ov36_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov36_02256298, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -62,7 +62,7 @@ static BOOL ov36_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov36_0225621C (UnkStruct_ov36_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov36_0225621C (UnkStruct_ov36_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     static const TouchScreenHitTable v0[] = {
         {
@@ -73,8 +73,8 @@ static BOOL ov36_0225621C (UnkStruct_ov36_0225621C * param0, PoketchSystem * par
         },
     };
 
-    param0->unk_10 = param1;
-    param0->unk_1C = PoketchSystem_GetPoketchData(param1);
+    param0->poketchSys = poketchSys;
+    param0->unk_1C = PoketchSystem_GetPoketchData(poketchSys);
     param0->unk_04.unk_04 = 1;
     param0->unk_04.unk_00 = PoketchData_StepCount(param0->unk_1C);
 
@@ -119,12 +119,12 @@ static void ov36_02256298 (SysTask * param0, void * param1)
     UnkStruct_ov36_0225621C * v1 = (UnkStruct_ov36_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_10, v1->unk_14);
+        ov25_02254518(v1->poketchSys, v1->unk_14);
 
         if (v0[v1->unk_00](v1)) {
             ov36_02256280(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_10);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -155,7 +155,7 @@ static BOOL ov36_022562F0 (UnkStruct_ov36_0225621C * param0)
         break;
     case 1:
         if (ov36_02256560(param0->unk_0C, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_10);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov36_022562DC(param0, 1);
         }
         break;
@@ -183,7 +183,7 @@ static BOOL ov36_02256330 (UnkStruct_ov36_0225621C * param0)
             break;
         }
 
-        if (PoketchSystem_PedometerUpdated(param0->unk_10)) {
+        if (PoketchSystem_PedometerUpdated(param0->poketchSys)) {
             v0->unk_00 = PoketchData_StepCount(param0->unk_1C);
             ov36_0225653C(param0->unk_0C, 3);
             break;

--- a/src/overlay037/ov37_022561C0.c
+++ b/src/overlay037/ov37_022561C0.c
@@ -22,7 +22,7 @@ typedef struct {
     UnkStruct_ov37_022563D4_1 unk_04;
     UnkStruct_ov37_022563D4 * unk_08;
     PoketchSystem *poketchSys;
-    PoketchButtonManager * unk_10;
+    PoketchButtonManager *buttonManager;
     u32 unk_14;
     u32 unk_18;
 } UnkStruct_ov37_0225621C;
@@ -78,7 +78,7 @@ static BOOL ov37_0225621C (UnkStruct_ov37_0225621C * param0, PoketchSystem *poke
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_10 = PoketchButtonManager_New(v0, NELEMS(v0), ov37_02256298, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(v0, NELEMS(v0), ov37_02256298, param0, 8);
         param0->unk_14 = 0;
         param0->poketchSys = poketchSys;
 
@@ -90,7 +90,7 @@ static BOOL ov37_0225621C (UnkStruct_ov37_0225621C * param0, PoketchSystem *poke
 
 static void ov37_02256280 (UnkStruct_ov37_0225621C * param0)
 {
-    PoketchButtonManager_Free(param0->unk_10);
+    PoketchButtonManager_Free(param0->buttonManager);
     ov37_02256410(param0->unk_08);
     Heap_FreeToHeap(param0);
 }
@@ -114,7 +114,7 @@ static void ov37_022562A0 (SysTask * param0, void * param1)
     UnkStruct_ov37_0225621C * v1 = (UnkStruct_ov37_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_10);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov37_02256280(v1);

--- a/src/overlay037/ov37_022561C0.c
+++ b/src/overlay037/ov37_022561C0.c
@@ -21,7 +21,7 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov37_022563D4_1 unk_04;
     UnkStruct_ov37_022563D4 * unk_08;
-    PoketchSystem * unk_0C;
+    PoketchSystem *poketchSys;
     PoketchButtonManager * unk_10;
     u32 unk_14;
     u32 unk_18;
@@ -29,8 +29,8 @@ typedef struct {
 
 static void NitroStaticInit(void);
 
-static BOOL ov37_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov37_0225621C(UnkStruct_ov37_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov37_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov37_0225621C(UnkStruct_ov37_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov37_02256280(UnkStruct_ov37_0225621C * param0);
 static void ov37_02256298(u32 param0, u32 param1, u32 param2, void * param3);
 static void ov37_022562A0(SysTask * param0, void * param1);
@@ -45,12 +45,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov37_022561D4, ov37_022562DC);
 }
 
-static BOOL ov37_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov37_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov37_0225621C * v0 = (UnkStruct_ov37_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov37_0225621C));
 
     if (v0 != NULL) {
-        if (ov37_0225621C(v0, param1, param2, param3)) {
+        if (ov37_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov37_022562A0, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -63,7 +63,7 @@ static BOOL ov37_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov37_0225621C (UnkStruct_ov37_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov37_0225621C (UnkStruct_ov37_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     static const TouchScreenHitTable v0[] = {
         {72, 104, 92, 132},
@@ -80,7 +80,7 @@ static BOOL ov37_0225621C (UnkStruct_ov37_0225621C * param0, PoketchSystem * par
         param0->unk_02 = 0;
         param0->unk_10 = PoketchButtonManager_New(v0, NELEMS(v0), ov37_02256298, param0, 8);
         param0->unk_14 = 0;
-        param0->unk_0C = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -114,12 +114,12 @@ static void ov37_022562A0 (SysTask * param0, void * param1)
     UnkStruct_ov37_0225621C * v1 = (UnkStruct_ov37_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_0C, v1->unk_10);
+        ov25_02254518(v1->poketchSys, v1->unk_10);
 
         if (v0[v1->unk_00](v1)) {
             ov37_02256280(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_0C);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -150,7 +150,7 @@ static BOOL ov37_022562F8 (UnkStruct_ov37_0225621C * param0)
         break;
     case 1:
         if (ov37_022564AC(param0->unk_08, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_0C);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov37_022562E4(param0, 1);
         }
         break;

--- a/src/overlay038/ov38_022561C0.c
+++ b/src/overlay038/ov38_022561C0.c
@@ -19,15 +19,15 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov38_0225632C_1 unk_04;
     UnkStruct_ov38_0225632C * unk_08;
-    PoketchSystem * unk_0C;
+    PoketchSystem *poketchSys;
 } UnkStruct_ov38_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov38_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov38_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov38_02256254(SysTask * param0, void * param1);
 static void ov38_02256288(void * param0);
-static BOOL ov38_0225621C(UnkStruct_ov38_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov38_0225621C(UnkStruct_ov38_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov38_02256240(UnkStruct_ov38_0225621C * param0);
 static void ov38_02256290(UnkStruct_ov38_0225621C * param0, u32 param1);
 static BOOL ov38_022562A4(UnkStruct_ov38_0225621C * param0);
@@ -39,12 +39,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov38_022561D4, ov38_02256288);
 }
 
-static BOOL ov38_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov38_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov38_0225621C * v0 = (UnkStruct_ov38_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov38_0225621C));
 
     if (v0 != NULL) {
-        if (ov38_0225621C(v0, param1, param2, param3)) {
+        if (ov38_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov38_02256254, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -57,13 +57,13 @@ static BOOL ov38_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov38_0225621C (UnkStruct_ov38_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov38_0225621C (UnkStruct_ov38_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     if (ov38_0225632C(&(param0->unk_08), &(param0->unk_04), param2)) {
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_0C = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -91,7 +91,7 @@ static void ov38_02256254 (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov38_02256240(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_0C);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -122,7 +122,7 @@ static BOOL ov38_022562A4 (UnkStruct_ov38_0225621C * param0)
         break;
     case 1:
         if (ov38_0225638C(param0->unk_08, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_0C);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov38_02256290(param0, 1);
         }
         break;

--- a/src/overlay039/ov39_022561C0.c
+++ b/src/overlay039/ov39_022561C0.c
@@ -22,7 +22,7 @@ typedef struct {
     UnkStruct_ov39_022563DC_1 unk_04;
     UnkStruct_ov39_022563DC * unk_24;
     PoketchSystem *poketchSys;
-    PoketchButtonManager * unk_2C;
+    PoketchButtonManager *buttonManager;
     u32 unk_30;
     u32 unk_34;
 } UnkStruct_ov39_0225621C;
@@ -80,7 +80,7 @@ static BOOL ov39_0225621C (UnkStruct_ov39_0225621C * param0, PoketchSystem *poke
         param0->unk_01 = 0;
         param0->unk_02 = 0;
         param0->poketchSys = poketchSys;
-        param0->unk_2C = PoketchButtonManager_New(v0, NELEMS(v0), ov39_02256284, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(v0, NELEMS(v0), ov39_02256284, param0, 8);
         param0->unk_30 = 0;
 
         for (v1 = 0; v1 < 6; v1++) {
@@ -95,8 +95,8 @@ static BOOL ov39_0225621C (UnkStruct_ov39_0225621C * param0, PoketchSystem *poke
 
 static void ov39_02256268 (UnkStruct_ov39_0225621C * param0)
 {
-    if (param0->unk_2C) {
-        PoketchButtonManager_Free(param0->unk_2C);
+    if (param0->buttonManager) {
+        PoketchButtonManager_Free(param0->buttonManager);
     }
 
     ov39_0225640C(param0->unk_24);
@@ -122,7 +122,7 @@ static void ov39_0225628C (SysTask * param0, void * param1)
     UnkStruct_ov39_0225621C * v1 = (UnkStruct_ov39_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_2C);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov39_02256268(v1);

--- a/src/overlay039/ov39_022561C0.c
+++ b/src/overlay039/ov39_022561C0.c
@@ -21,7 +21,7 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov39_022563DC_1 unk_04;
     UnkStruct_ov39_022563DC * unk_24;
-    PoketchSystem * unk_28;
+    PoketchSystem *poketchSys;
     PoketchButtonManager * unk_2C;
     u32 unk_30;
     u32 unk_34;
@@ -29,8 +29,8 @@ typedef struct {
 
 static void NitroStaticInit(void);
 
-static BOOL ov39_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov39_0225621C(UnkStruct_ov39_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov39_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov39_0225621C(UnkStruct_ov39_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov39_02256268(UnkStruct_ov39_0225621C * param0);
 static void ov39_02256284(u32 param0, u32 param1, u32 param2, void * param3);
 static void ov39_0225628C(SysTask * param0, void * param1);
@@ -45,12 +45,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov39_022561D4, ov39_022562C8);
 }
 
-static BOOL ov39_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov39_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov39_0225621C * v0 = (UnkStruct_ov39_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov39_0225621C));
 
     if (v0 != NULL) {
-        if (ov39_0225621C(v0, param1, param2, param3)) {
+        if (ov39_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov39_0225628C, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -63,7 +63,7 @@ static BOOL ov39_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov39_0225621C (UnkStruct_ov39_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov39_0225621C (UnkStruct_ov39_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     if (ov39_022563DC(&(param0->unk_24), &(param0->unk_04), param2)) {
         static const TouchScreenHitTable v0[] = {
@@ -79,7 +79,7 @@ static BOOL ov39_0225621C (UnkStruct_ov39_0225621C * param0, PoketchSystem * par
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_28 = param1;
+        param0->poketchSys = poketchSys;
         param0->unk_2C = PoketchButtonManager_New(v0, NELEMS(v0), ov39_02256284, param0, 8);
         param0->unk_30 = 0;
 
@@ -122,12 +122,12 @@ static void ov39_0225628C (SysTask * param0, void * param1)
     UnkStruct_ov39_0225621C * v1 = (UnkStruct_ov39_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_28, v1->unk_2C);
+        ov25_02254518(v1->poketchSys, v1->unk_2C);
 
         if (v0[v1->unk_00](v1)) {
             ov39_02256268(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_28);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -158,7 +158,7 @@ static BOOL ov39_022562E4 (UnkStruct_ov39_0225621C * param0)
         break;
     case 1:
         if (ov39_0225643C(param0->unk_24, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_28);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov39_022562D0(param0, 1);
         }
         break;

--- a/src/overlay040/ov40_022561C0.c
+++ b/src/overlay040/ov40_022561C0.c
@@ -27,14 +27,14 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov40_0225645C_1 unk_04;
     UnkStruct_ov40_0225645C * unk_28;
-    PoketchSystem * unk_2C;
+    PoketchSystem *poketchSys;
     UnkStruct_02026310 * unk_30;
 } UnkStruct_ov40_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov40_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov40_0225621C(UnkStruct_ov40_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov40_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov40_0225621C(UnkStruct_ov40_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov40_0225625C(UnkStruct_ov40_0225621C * param0);
 static void ov40_02256270(SysTask * param0, void * param1);
 static void ov40_022562A4(void * param0);
@@ -50,12 +50,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov40_022561D4, ov40_022562A4);
 }
 
-static BOOL ov40_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov40_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov40_0225621C * v0 = (UnkStruct_ov40_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov40_0225621C));
 
     if (v0 != NULL) {
-        if (ov40_0225621C(v0, param1, param2, param3)) {
+        if (ov40_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov40_02256270, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -68,9 +68,9 @@ static BOOL ov40_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov40_0225621C (UnkStruct_ov40_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov40_0225621C (UnkStruct_ov40_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
-    param0->unk_30 = sub_02026310(PoketchSystem_GetSaveData(param1));
+    param0->unk_30 = sub_02026310(PoketchSystem_GetSaveData(poketchSys));
 
     ov40_022563D0(&param0->unk_04, param0->unk_30);
 
@@ -78,7 +78,7 @@ static BOOL ov40_0225621C (UnkStruct_ov40_0225621C * param0, PoketchSystem * par
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_2C = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -106,7 +106,7 @@ static void ov40_02256270 (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov40_0225625C(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_2C);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -137,7 +137,7 @@ static BOOL ov40_022562C0 (UnkStruct_ov40_0225621C * param0)
         break;
     case 1:
         if (ov40_022565EC(param0->unk_28, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_2C);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov40_022562AC(param0, 1);
         }
         break;
@@ -190,7 +190,7 @@ static BOOL ov40_02256354 (UnkStruct_ov40_0225621C * param0)
 
 static BOOL ov40_02256388 (UnkStruct_ov40_0225621C * param0)
 {
-    if (ov25_0225450C(param0->unk_2C) == 0) {
+    if (ov25_0225450C(param0->poketchSys) == 0) {
         u32 v0, v1;
 
         if (TouchScreen_GetTapState(&v0, &v1)) {

--- a/src/overlay041/ov41_022561C0.c
+++ b/src/overlay041/ov41_022561C0.c
@@ -22,7 +22,7 @@ typedef struct {
     u8 unk_03;
     UnkStruct_ov41_022567B0_1 unk_04;
     UnkStruct_ov41_022567B0 * unk_5B7C;
-    PoketchSystem * unk_5B80;
+    PoketchSystem *poketchSys;
     PoketchButtonManager * unk_5B84;
     u32 unk_5B88;
     u32 unk_5B8C;
@@ -30,8 +30,8 @@ typedef struct {
 
 static void NitroStaticInit(void);
 
-static BOOL ov41_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov41_02256220(UnkStruct_ov41_02256220 * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov41_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov41_02256220(UnkStruct_ov41_02256220 * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov41_02256294(UnkStruct_ov41_02256220 * param0);
 static void ov41_022562B8(SysTask * param0, void * param1);
 static void ov41_02256300(u32 param0, u32 param1, u32 param2, void * param3);
@@ -50,12 +50,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov41_022561D4, ov41_02256310);
 }
 
-static BOOL ov41_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov41_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov41_02256220 * v0 = (UnkStruct_ov41_02256220 *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov41_02256220));
 
     if (v0 != NULL) {
-        if (ov41_02256220(v0, param1, param2, param3)) {
+        if (ov41_02256220(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov41_022562B8, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -68,7 +68,7 @@ static BOOL ov41_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov41_02256220 (UnkStruct_ov41_02256220 * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov41_02256220 (UnkStruct_ov41_02256220 * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     static const TouchScreenHitTable v0[] = {
         {34, 66, 167, 207},
@@ -91,7 +91,7 @@ static BOOL ov41_02256220 (UnkStruct_ov41_02256220 * param0, PoketchSystem * par
 
         param0->unk_5B84 = PoketchButtonManager_New(v0, NELEMS(v0), ov41_02256300, param0, 8);
         param0->unk_5B88 = 0;
-        param0->unk_5B80 = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -117,12 +117,12 @@ static void ov41_022562B8 (SysTask * param0, void * param1)
     UnkStruct_ov41_02256220 * v1 = (UnkStruct_ov41_02256220 *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_5B80, v1->unk_5B84);
+        ov25_02254518(v1->poketchSys, v1->unk_5B84);
 
         if (v0[v1->unk_00](v1)) {
             ov41_02256294(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_5B80);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -161,7 +161,7 @@ static BOOL ov41_0225632C (UnkStruct_ov41_02256220 * param0)
         break;
     case 1:
         if (ov41_022568B0(param0->unk_5B7C, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_5B80);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov41_02256318(param0, 1);
         }
         break;
@@ -178,7 +178,7 @@ static BOOL ov41_02256378 (UnkStruct_ov41_02256220 * param0)
 
     switch (param0->unk_01) {
     case 0:
-        if (ov25_0225450C(param0->unk_5B80)) {
+        if (ov25_0225450C(param0->poketchSys)) {
             break;
         }
 

--- a/src/overlay041/ov41_022561C0.c
+++ b/src/overlay041/ov41_022561C0.c
@@ -23,7 +23,7 @@ typedef struct {
     UnkStruct_ov41_022567B0_1 unk_04;
     UnkStruct_ov41_022567B0 * unk_5B7C;
     PoketchSystem *poketchSys;
-    PoketchButtonManager * unk_5B84;
+    PoketchButtonManager *buttonManager;
     u32 unk_5B88;
     u32 unk_5B8C;
 } UnkStruct_ov41_02256220;
@@ -89,7 +89,7 @@ static BOOL ov41_02256220 (UnkStruct_ov41_02256220 * param0, PoketchSystem *poke
 
         ov41_02256790(&param0->unk_04);
 
-        param0->unk_5B84 = PoketchButtonManager_New(v0, NELEMS(v0), ov41_02256300, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(v0, NELEMS(v0), ov41_02256300, param0, 8);
         param0->unk_5B88 = 0;
         param0->poketchSys = poketchSys;
 
@@ -101,7 +101,7 @@ static BOOL ov41_02256220 (UnkStruct_ov41_02256220 * param0, PoketchSystem *poke
 
 static void ov41_02256294 (UnkStruct_ov41_02256220 * param0)
 {
-    PoketchButtonManager_Free(param0->unk_5B84);
+    PoketchButtonManager_Free(param0->buttonManager);
     ov41_022567F8(param0->unk_5B7C);
     Heap_FreeToHeap(param0);
 }
@@ -117,7 +117,7 @@ static void ov41_022562B8 (SysTask * param0, void * param1)
     UnkStruct_ov41_02256220 * v1 = (UnkStruct_ov41_02256220 *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_5B84);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov41_02256294(v1);

--- a/src/overlay042/ov42_022561C0.c
+++ b/src/overlay042/ov42_022561C0.c
@@ -22,13 +22,13 @@ typedef struct {
     u32 unk_04;
     UnkStruct_ov42_022563D4_1 unk_08;
     UnkStruct_ov42_022563D4 * unk_0C;
-    PoketchSystem * unk_10;
+    PoketchSystem *poketchSys;
 } UnkStruct_ov42_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov42_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov42_0225621C(UnkStruct_ov42_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov42_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov42_0225621C(UnkStruct_ov42_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov42_02256260(UnkStruct_ov42_0225621C * param0);
 static void ov42_02256280(SysTask * param0, void * param1);
 static void ov42_022562B4(void * param0);
@@ -43,12 +43,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov42_022561D4, ov42_022562B4);
 }
 
-static BOOL ov42_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov42_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov42_0225621C * v0 = (UnkStruct_ov42_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov42_0225621C));
 
     if (v0 != NULL) {
-        if (ov42_0225621C(v0, param1, param2, param3)) {
+        if (ov42_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov42_02256280, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -61,7 +61,7 @@ static BOOL ov42_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov42_0225621C (UnkStruct_ov42_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov42_0225621C (UnkStruct_ov42_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     param0->unk_04 = param3;
 
@@ -73,7 +73,7 @@ static BOOL ov42_0225621C (UnkStruct_ov42_0225621C * param0, PoketchSystem * par
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_10 = param1;
+        param0->poketchSys = poketchSys;
         return 1;
     }
 
@@ -101,7 +101,7 @@ static void ov42_02256280 (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov42_02256260(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_10);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -132,7 +132,7 @@ static BOOL ov42_022562D0 (UnkStruct_ov42_0225621C * param0)
         break;
     case 1:
         if (ov42_022564C4(param0->unk_0C, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_10);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov42_022562BC(param0, 1);
         }
         break;

--- a/src/overlay043/ov43_022561C0.c
+++ b/src/overlay043/ov43_022561C0.c
@@ -23,15 +23,15 @@ typedef struct {
     u32 unk_04;
     UnkStruct_ov43_02256544_1 unk_08;
     UnkStruct_ov43_02256544 * unk_14;
-    PoketchSystem * unk_18;
+    PoketchSystem *poketchSys;
     PoketchButtonManager * unk_1C;
     u32 unk_20;
 } UnkStruct_ov43_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov43_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov43_0225621C(UnkStruct_ov43_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov43_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov43_0225621C(UnkStruct_ov43_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov43_02256288(UnkStruct_ov43_02256544_1 * param0);
 static void ov43_022562A8(UnkStruct_ov43_0225621C * param0);
 static void ov43_022562CC(SysTask * param0, void * param1);
@@ -49,12 +49,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov43_022561D4, ov43_02256310);
 }
 
-static BOOL ov43_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov43_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov43_0225621C * v0 = (UnkStruct_ov43_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov43_0225621C));
 
     if (v0 != NULL) {
-        if (ov43_0225621C(v0, param1, param2, param3)) {
+        if (ov43_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov43_022562CC, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -67,7 +67,7 @@ static BOOL ov43_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov43_0225621C (UnkStruct_ov43_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov43_0225621C (UnkStruct_ov43_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     static const TouchScreenHitTable v0[] = {
         {112, 144, 16, 40},
@@ -90,7 +90,7 @@ static BOOL ov43_0225621C (UnkStruct_ov43_0225621C * param0, PoketchSystem * par
         param0->unk_02 = 0;
         param0->unk_1C = PoketchButtonManager_New(v0, NELEMS(v0), ov43_02256308, param0, 8);
         param0->unk_20 = 0;
-        param0->unk_18 = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -126,12 +126,12 @@ static void ov43_022562CC (SysTask * param0, void * param1)
     UnkStruct_ov43_0225621C * v1 = (UnkStruct_ov43_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_18, v1->unk_1C);
+        ov25_02254518(v1->poketchSys, v1->unk_1C);
 
         if (v0[v1->unk_00](v1)) {
             ov43_022562A8(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_18);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -170,7 +170,7 @@ static BOOL ov43_0225632C (UnkStruct_ov43_0225621C * param0)
         break;
     case 1:
         if (ov43_022566D4(param0->unk_14, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_18);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov43_02256318(param0, 1);
         }
         break;

--- a/src/overlay043/ov43_022561C0.c
+++ b/src/overlay043/ov43_022561C0.c
@@ -24,7 +24,7 @@ typedef struct {
     UnkStruct_ov43_02256544_1 unk_08;
     UnkStruct_ov43_02256544 * unk_14;
     PoketchSystem *poketchSys;
-    PoketchButtonManager * unk_1C;
+    PoketchButtonManager *buttonManager;
     u32 unk_20;
 } UnkStruct_ov43_0225621C;
 
@@ -88,7 +88,7 @@ static BOOL ov43_0225621C (UnkStruct_ov43_0225621C * param0, PoketchSystem *poke
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_1C = PoketchButtonManager_New(v0, NELEMS(v0), ov43_02256308, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(v0, NELEMS(v0), ov43_02256308, param0, 8);
         param0->unk_20 = 0;
         param0->poketchSys = poketchSys;
 
@@ -110,7 +110,7 @@ static void ov43_02256288 (UnkStruct_ov43_02256544_1 * param0)
 static void ov43_022562A8 (UnkStruct_ov43_0225621C * param0)
 {
     sub_02099D54(param0->unk_04, &(param0->unk_08), sizeof(param0->unk_08));
-    PoketchButtonManager_Free(param0->unk_1C);
+    PoketchButtonManager_Free(param0->buttonManager);
     ov43_02256680(param0->unk_14);
     Heap_FreeToHeap(param0);
 }
@@ -126,7 +126,7 @@ static void ov43_022562CC (SysTask * param0, void * param1)
     UnkStruct_ov43_0225621C * v1 = (UnkStruct_ov43_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_1C);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov43_022562A8(v1);

--- a/src/overlay044/ov44_022561C0.c
+++ b/src/overlay044/ov44_022561C0.c
@@ -28,7 +28,7 @@ typedef struct {
     UnkStruct_ov44_022565BC_1 unk_04;
     UnkStruct_ov44_022565BC * unk_38;
     PoketchSystem *poketchSys;
-    PoketchButtonManager * unk_40;
+    PoketchButtonManager *buttonManager;
     u16 unk_44;
     u16 unk_46;
     BoxPokemon * unk_48[6];
@@ -110,7 +110,7 @@ static BOOL ov44_0225621C (UnkStruct_ov44_0225621C * param0, PoketchSystem *poke
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_40 = PoketchButtonManager_New(v4, NELEMS(v4), ov44_0225632C, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(v4, NELEMS(v4), ov44_0225632C, param0, 8);
         param0->unk_46 = 0;
         param0->poketchSys = poketchSys;
 
@@ -122,7 +122,7 @@ static BOOL ov44_0225621C (UnkStruct_ov44_0225621C * param0, PoketchSystem *poke
 
 static void ov44_02256314 (UnkStruct_ov44_0225621C * param0)
 {
-    PoketchButtonManager_Free(param0->unk_40);
+    PoketchButtonManager_Free(param0->buttonManager);
     ov44_022565F8(param0->unk_38);
     Heap_FreeToHeap(param0);
 }
@@ -144,7 +144,7 @@ static void ov44_02256338 (SysTask * param0, void * param1)
     UnkStruct_ov44_0225621C * v1 = (UnkStruct_ov44_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_40);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov44_02256314(v1);

--- a/src/overlay044/ov44_022561C0.c
+++ b/src/overlay044/ov44_022561C0.c
@@ -27,7 +27,7 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov44_022565BC_1 unk_04;
     UnkStruct_ov44_022565BC * unk_38;
-    PoketchSystem * unk_3C;
+    PoketchSystem *poketchSys;
     PoketchButtonManager * unk_40;
     u16 unk_44;
     u16 unk_46;
@@ -37,8 +37,8 @@ typedef struct {
 
 static void NitroStaticInit(void);
 
-static BOOL ov44_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov44_0225621C(UnkStruct_ov44_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov44_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov44_0225621C(UnkStruct_ov44_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov44_02256314(UnkStruct_ov44_0225621C * param0);
 static void ov44_0225632C(u32 param0, u32 param1, u32 param2, void * param3);
 static void ov44_02256338(SysTask * param0, void * param1);
@@ -55,12 +55,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov44_022561D4, ov44_02256374);
 }
 
-static BOOL ov44_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov44_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov44_0225621C * v0 = (UnkStruct_ov44_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov44_0225621C));
 
     if (v0 != NULL) {
-        if (ov44_0225621C(v0, param1, param2, param3)) {
+        if (ov44_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov44_02256338, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -73,9 +73,9 @@ static BOOL ov44_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov44_0225621C (UnkStruct_ov44_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov44_0225621C (UnkStruct_ov44_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
-    Party * v0 = Party_GetFromSavedata(PoketchSystem_GetSaveData(param1));
+    Party * v0 = Party_GetFromSavedata(PoketchSystem_GetSaveData(poketchSys));
     Pokemon * v1;
     int v2;
     int v3 = 0;
@@ -112,7 +112,7 @@ static BOOL ov44_0225621C (UnkStruct_ov44_0225621C * param0, PoketchSystem * par
         param0->unk_02 = 0;
         param0->unk_40 = PoketchButtonManager_New(v4, NELEMS(v4), ov44_0225632C, param0, 8);
         param0->unk_46 = 0;
-        param0->unk_3C = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -144,12 +144,12 @@ static void ov44_02256338 (SysTask * param0, void * param1)
     UnkStruct_ov44_0225621C * v1 = (UnkStruct_ov44_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_3C, v1->unk_40);
+        ov25_02254518(v1->poketchSys, v1->unk_40);
 
         if (v0[v1->unk_00](v1)) {
             ov44_02256314(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_3C);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -180,7 +180,7 @@ static BOOL ov44_02256390 (UnkStruct_ov44_0225621C * param0)
         break;
     case 1:
         if (ov44_02256768(param0->unk_38, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_3C);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov44_0225637C(param0, 1);
         }
         break;

--- a/src/overlay045/ov45_022561C0.c
+++ b/src/overlay045/ov45_022561C0.c
@@ -24,7 +24,7 @@ typedef struct {
     UnkStruct_ov45_022566EC_1 unk_03;
     UnkStruct_ov45_022566EC * unk_08;
     PoketchSystem *poketchSys;
-    PoketchData * unk_10;
+    PoketchData *poketchData;
     PoketchButtonManager * unk_14;
     u32 unk_18;
     u32 unk_1C;
@@ -88,10 +88,10 @@ static BOOL ov45_0225621C (UnkStruct_ov45_022561D4 * param0, PoketchSystem *poke
     };
     u32 v1, v2;
 
-    param0->unk_10 = PoketchSystem_GetPoketchData(poketchSys);
-    param0->unk_03.unk_00 = PoketchData_IsAlarmSet(param0->unk_10);
+    param0->poketchData = PoketchSystem_GetPoketchData(poketchSys);
+    param0->unk_03.unk_00 = PoketchData_IsAlarmSet(param0->poketchData);
 
-    PoketchData_AlarmTime(param0->unk_10, &v1, &v2);
+    PoketchData_AlarmTime(param0->poketchData, &v1, &v2);
 
     param0->unk_03.unk_03 = v1;
     param0->unk_03.unk_04 = v2;
@@ -229,7 +229,7 @@ static BOOL ov45_022563C0 (UnkStruct_ov45_022561D4 * param0)
         if ((param0->unk_1C == 1) && (param0->unk_18 == 0)) {
             param0->unk_03.unk_00 = 1;
             ov45_022562C0(&param0->unk_03);
-            PoketchData_SetAlarm(param0->unk_10, 1, param0->unk_03.unk_03, param0->unk_03.unk_04);
+            PoketchData_SetAlarm(param0->poketchData, 1, param0->unk_03.unk_03, param0->unk_03.unk_04);
             ov45_02256918(param0->unk_08, 2);
             param0->unk_1C = 0;
             param0->unk_01++;

--- a/src/overlay045/ov45_022561C0.c
+++ b/src/overlay045/ov45_022561C0.c
@@ -25,7 +25,7 @@ typedef struct {
     UnkStruct_ov45_022566EC * unk_08;
     PoketchSystem *poketchSys;
     PoketchData *poketchData;
-    PoketchButtonManager * unk_14;
+    PoketchButtonManager *buttonManager;
     u32 unk_18;
     u32 unk_1C;
     RTCTime unk_20;
@@ -102,13 +102,13 @@ static BOOL ov45_0225621C (UnkStruct_ov45_022561D4 * param0, PoketchSystem *poke
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_14 = PoketchButtonManager_New(v0, NELEMS(v0), ov45_02256310, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(v0, NELEMS(v0), ov45_02256310, param0, 8);
         param0->unk_1C = 0;
 
-        PoketchButtonManager_SetRepeatTime(param0->unk_14, 2, 4);
-        PoketchButtonManager_SetRepeatTime(param0->unk_14, 3, 4);
-        PoketchButtonManager_SetRepeatTime(param0->unk_14, 4, 4);
-        PoketchButtonManager_SetRepeatTime(param0->unk_14, 5, 4);
+        PoketchButtonManager_SetRepeatTime(param0->buttonManager, 2, 4);
+        PoketchButtonManager_SetRepeatTime(param0->buttonManager, 3, 4);
+        PoketchButtonManager_SetRepeatTime(param0->buttonManager, 4, 4);
+        PoketchButtonManager_SetRepeatTime(param0->buttonManager, 5, 4);
 
         param0->unk_2C = 0;
         param0->unk_30 = 0;
@@ -140,7 +140,7 @@ static void ov45_022562C0 (UnkStruct_ov45_022566EC_1 * param0)
 
 static void ov45_022562F8 (UnkStruct_ov45_022561D4 * param0)
 {
-    PoketchButtonManager_Free(param0->unk_14);
+    PoketchButtonManager_Free(param0->buttonManager);
     ov45_02256728(param0->unk_08);
 
     Heap_FreeToHeap(param0);
@@ -167,7 +167,7 @@ static void ov45_02256318 (SysTask * param0, void * param1)
     UnkStruct_ov45_022561D4 * v1 = (UnkStruct_ov45_022561D4 *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_14);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov45_022562F8(v1);

--- a/src/overlay045/ov45_022561C0.c
+++ b/src/overlay045/ov45_022561C0.c
@@ -23,7 +23,7 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov45_022566EC_1 unk_03;
     UnkStruct_ov45_022566EC * unk_08;
-    PoketchSystem * unk_0C;
+    PoketchSystem *poketchSys;
     PoketchData * unk_10;
     PoketchButtonManager * unk_14;
     u32 unk_18;
@@ -35,8 +35,8 @@ typedef struct {
 
 static void NitroStaticInit(void);
 
-static BOOL ov45_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov45_0225621C(UnkStruct_ov45_022561D4 * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov45_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov45_0225621C(UnkStruct_ov45_022561D4 * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov45_022562C0(UnkStruct_ov45_022566EC_1 * param0);
 static void ov45_022562F8(UnkStruct_ov45_022561D4 * param0);
 static void ov45_02256310(u32 param0, u32 param1, u32 param2, void * param3);
@@ -58,12 +58,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov45_022561D4, ov45_02256354);
 }
 
-static BOOL ov45_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov45_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov45_022561D4 * v0 = (UnkStruct_ov45_022561D4 *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov45_022561D4));
 
     if (v0 != NULL) {
-        if (ov45_0225621C(v0, param1, param2, param3)) {
+        if (ov45_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov45_02256318, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -76,7 +76,7 @@ static BOOL ov45_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov45_0225621C (UnkStruct_ov45_022561D4 * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov45_0225621C (UnkStruct_ov45_022561D4 * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     static const TouchScreenHitTable v0[] = {
         {72, 104, 176, 208, },
@@ -88,7 +88,7 @@ static BOOL ov45_0225621C (UnkStruct_ov45_022561D4 * param0, PoketchSystem * par
     };
     u32 v1, v2;
 
-    param0->unk_10 = PoketchSystem_GetPoketchData(param1);
+    param0->unk_10 = PoketchSystem_GetPoketchData(poketchSys);
     param0->unk_03.unk_00 = PoketchData_IsAlarmSet(param0->unk_10);
 
     PoketchData_AlarmTime(param0->unk_10, &v1, &v2);
@@ -112,7 +112,7 @@ static BOOL ov45_0225621C (UnkStruct_ov45_022561D4 * param0, PoketchSystem * par
 
         param0->unk_2C = 0;
         param0->unk_30 = 0;
-        param0->unk_0C = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -167,12 +167,12 @@ static void ov45_02256318 (SysTask * param0, void * param1)
     UnkStruct_ov45_022561D4 * v1 = (UnkStruct_ov45_022561D4 *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_0C, v1->unk_14);
+        ov25_02254518(v1->poketchSys, v1->unk_14);
 
         if (v0[v1->unk_00](v1)) {
             ov45_022562F8(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_0C);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -203,7 +203,7 @@ static BOOL ov45_02256370 (UnkStruct_ov45_022561D4 * param0)
         break;
     case 1:
         if (ov45_0225693C(param0->unk_08, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_0C);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
 
             if (param0->unk_03.unk_00) {
                 ov45_0225635C(param0, 2);

--- a/src/overlay046/ov46_022561C0.c
+++ b/src/overlay046/ov46_022561C0.c
@@ -37,7 +37,7 @@ typedef struct {
     u8 unk_03;
     u32 unk_04;
     UnkStruct_ov46_02256BCC * unk_08;
-    PoketchSystem * unk_0C;
+    PoketchSystem *poketchSys;
     PoketchButtonManager * unk_10;
     u32 unk_14;
     u32 unk_18;
@@ -57,14 +57,14 @@ enum {
 
 static void NitroStaticInit(void);
 
-static BOOL ov46_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov46_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov46_0225621C(UnkStruct_ov46_0225621C * param0);
 static void ov46_0225623C(UnkStruct_ov46_0225621C * param0, u32 param1, BOOL param2);
 static void ov46_02256258(UnkStruct_ov46_0225621C * param0, u32 param1, u32 param2);
 static void ov46_02256270(UnkStruct_ov46_0225621C * param0, UnkStruct_ov46_02256270 * param1);
 static void ov46_0225628C(UnkStruct_ov46_0225621C * param0);
 static void ov46_022562D4(UnkStruct_ov46_0225621C * param0);
-static BOOL ov46_02256310(UnkStruct_ov46_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov46_02256310(UnkStruct_ov46_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov46_022563B8(UnkStruct_ov46_0225621C * param0);
 static void ov46_022563D8(u32 param0, u32 param1, u32 param2, void * param3);
 static void ov46_02256408(SysTask * param0, void * param1);
@@ -90,12 +90,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov46_022561D4, ov46_02256458);
 }
 
-static BOOL ov46_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov46_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov46_0225621C * v0 = (UnkStruct_ov46_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov46_0225621C));
 
     if (v0 != NULL) {
-        if (ov46_02256310(v0, param1, param2, param3)) {
+        if (ov46_02256310(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov46_02256408, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -173,7 +173,7 @@ static void ov46_022562D4 (UnkStruct_ov46_0225621C * param0)
     ov46_0225623C(param0, 1, 0);
 }
 
-static BOOL ov46_02256310 (UnkStruct_ov46_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov46_02256310 (UnkStruct_ov46_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     static const TouchScreenHitTable v0[] = {
         {144, 176, 16, 80},
@@ -208,7 +208,7 @@ static BOOL ov46_02256310 (UnkStruct_ov46_0225621C * param0, PoketchSystem * par
         PoketchButtonManager_SetRepeatTime(param0->unk_10, 8, 4);
         PoketchButtonManager_SetRepeatTime(param0->unk_10, 10, 4);
 
-        param0->unk_0C = param1;
+        param0->poketchSys = poketchSys;
         return 1;
     }
 
@@ -255,7 +255,7 @@ static void ov46_02256408 (SysTask * param0, void * param1)
     UnkStruct_ov46_0225621C * v1 = (UnkStruct_ov46_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_0C, v1->unk_10);
+        ov25_02254518(v1->poketchSys, v1->unk_10);
 
         if (v1->unk_44) {
             ov46_02256D24(v1->unk_08, 4);
@@ -265,7 +265,7 @@ static void ov46_02256408 (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov46_022563B8(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_0C);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -328,7 +328,7 @@ static BOOL ov46_022564D8 (UnkStruct_ov46_0225621C * param0)
         break;
     case 1:
         if (ov46_02256D48(param0->unk_08, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_0C);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov46_02256460(param0, param0->unk_48.unk_44);
         }
         break;

--- a/src/overlay046/ov46_022561C0.c
+++ b/src/overlay046/ov46_022561C0.c
@@ -38,7 +38,7 @@ typedef struct {
     u32 unk_04;
     UnkStruct_ov46_02256BCC * unk_08;
     PoketchSystem *poketchSys;
-    PoketchButtonManager * unk_10;
+    PoketchButtonManager *buttonManager;
     u32 unk_14;
     u32 unk_18;
     u64 unk_1C;
@@ -196,17 +196,17 @@ static BOOL ov46_02256310 (UnkStruct_ov46_0225621C * param0, PoketchSystem *poke
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_03 = 0;
-        param0->unk_10 = PoketchButtonManager_New(v0, NELEMS(v0), ov46_022563D8, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(v0, NELEMS(v0), ov46_022563D8, param0, 8);
         param0->unk_18 = 0;
 
-        PoketchButtonManager_SetRepeatTime(param0->unk_10, 3, 4);
-        PoketchButtonManager_SetRepeatTime(param0->unk_10, 5, 4);
-        PoketchButtonManager_SetRepeatTime(param0->unk_10, 4, 4);
-        PoketchButtonManager_SetRepeatTime(param0->unk_10, 6, 4);
-        PoketchButtonManager_SetRepeatTime(param0->unk_10, 7, 4);
-        PoketchButtonManager_SetRepeatTime(param0->unk_10, 9, 4);
-        PoketchButtonManager_SetRepeatTime(param0->unk_10, 8, 4);
-        PoketchButtonManager_SetRepeatTime(param0->unk_10, 10, 4);
+        PoketchButtonManager_SetRepeatTime(param0->buttonManager, 3, 4);
+        PoketchButtonManager_SetRepeatTime(param0->buttonManager, 5, 4);
+        PoketchButtonManager_SetRepeatTime(param0->buttonManager, 4, 4);
+        PoketchButtonManager_SetRepeatTime(param0->buttonManager, 6, 4);
+        PoketchButtonManager_SetRepeatTime(param0->buttonManager, 7, 4);
+        PoketchButtonManager_SetRepeatTime(param0->buttonManager, 9, 4);
+        PoketchButtonManager_SetRepeatTime(param0->buttonManager, 8, 4);
+        PoketchButtonManager_SetRepeatTime(param0->buttonManager, 10, 4);
 
         param0->poketchSys = poketchSys;
         return 1;
@@ -218,7 +218,7 @@ static BOOL ov46_02256310 (UnkStruct_ov46_0225621C * param0, PoketchSystem *poke
 static void ov46_022563B8 (UnkStruct_ov46_0225621C * param0)
 {
     ov46_02256270(param0, &param0->unk_48);
-    PoketchButtonManager_Free(param0->unk_10);
+    PoketchButtonManager_Free(param0->buttonManager);
     ov46_02256C0C(param0->unk_08);
 
     Heap_FreeToHeap(param0);
@@ -255,7 +255,7 @@ static void ov46_02256408 (SysTask * param0, void * param1)
     UnkStruct_ov46_0225621C * v1 = (UnkStruct_ov46_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_10);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v1->unk_44) {
             ov46_02256D24(v1->unk_08, 4);

--- a/src/overlay047/ov47_022561C0.c
+++ b/src/overlay047/ov47_022561C0.c
@@ -27,7 +27,7 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov47_02256634_1 unk_04;
     UnkStruct_ov47_02256634 * unk_70;
-    PoketchSystem * unk_74;
+    PoketchSystem *poketchSys;
     PoketchData * unk_78;
     UnkStruct_0206C638 * unk_7C[6];
     u8 unk_94[6];
@@ -36,8 +36,8 @@ typedef struct {
 
 static void NitroStaticInit(void);
 
-static BOOL ov47_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov47_0225621C(UnkStruct_ov47_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov47_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov47_0225621C(UnkStruct_ov47_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov47_0225634C(UnkStruct_ov47_0225621C * param0);
 static void ov47_02256384(SysTask * param0, void * param1);
 static void ov47_022563B8(void * param0);
@@ -54,12 +54,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov47_022561D4, ov47_022563B8);
 }
 
-static BOOL ov47_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov47_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov47_0225621C * v0 = (UnkStruct_ov47_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov47_0225621C));
 
     if (v0 != NULL) {
-        if (ov47_0225621C(v0, param1, param2, param3)) {
+        if (ov47_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov47_02256384, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -72,11 +72,11 @@ static BOOL ov47_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov47_0225621C (UnkStruct_ov47_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov47_0225621C (UnkStruct_ov47_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     int v0;
 
-    param0->unk_78 = PoketchSystem_GetPoketchData(param1);
+    param0->unk_78 = PoketchSystem_GetPoketchData(poketchSys);
 
     for (v0 = 0; v0 < 6; v0++) {
         param0->unk_04.unk_0C[v0].unk_03 = 1;
@@ -95,7 +95,7 @@ static BOOL ov47_0225621C (UnkStruct_ov47_0225621C * param0, PoketchSystem * par
     param0->unk_04.unk_08 = 0;
 
     {
-        VarsFlags * v1 = SaveData_GetVarsFlags(PoketchSystem_GetSaveData(param1));
+        VarsFlags * v1 = SaveData_GetVarsFlags(PoketchSystem_GetSaveData(poketchSys));
 
         for (v0 = 0; v0 < 4; v0++) {
             param0->unk_04.unk_2C[v0] = sub_0206B1F0(v1, v0);
@@ -103,7 +103,7 @@ static BOOL ov47_0225621C (UnkStruct_ov47_0225621C * param0, PoketchSystem * par
     }
 
     {
-        UnkStruct_0202D7B0 * v2 = sub_0202D834(PoketchSystem_GetSaveData(param1));
+        UnkStruct_0202D7B0 * v2 = sub_0202D834(PoketchSystem_GetSaveData(poketchSys));
 
         for (v0 = 0; v0 < 6; v0++) {
             param0->unk_7C[v0] = sub_0202D924(v2, v0);
@@ -112,13 +112,13 @@ static BOOL ov47_0225621C (UnkStruct_ov47_0225621C * param0, PoketchSystem * par
         }
     }
 
-    inline_ov47_0225621C(PoketchSystem_GetFieldSystem(param1), &(param0->unk_04.unk_00), &(param0->unk_04.unk_04));
+    inline_ov47_0225621C(PoketchSystem_GetFieldSystem(poketchSys), &(param0->unk_04.unk_00), &(param0->unk_04.unk_04));
 
     if (ov47_02256634(&(param0->unk_70), &(param0->unk_04), param2)) {
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_74 = param1;
+        param0->poketchSys = poketchSys;
         return 1;
     }
 
@@ -152,7 +152,7 @@ static void ov47_02256384 (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov47_0225634C(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_74);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -183,7 +183,7 @@ static BOOL ov47_022563D4 (UnkStruct_ov47_0225621C * param0)
         break;
     case 1:
         if (ov47_02256890(param0->unk_70, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_74);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov47_022563C0(param0, 1);
         }
         break;
@@ -299,10 +299,10 @@ static BOOL ov47_02256584 (UnkStruct_ov47_0225621C * param0)
 {
     BOOL v0 = 0;
 
-    if (PoketchSystem_IsPlayerMoving(param0->unk_74)) {
+    if (PoketchSystem_IsPlayerMoving(param0->poketchSys)) {
         int v1, v2;
 
-        inline_ov47_0225621C(PoketchSystem_GetFieldSystem(param0->unk_74), &v1, &v2);
+        inline_ov47_0225621C(PoketchSystem_GetFieldSystem(param0->poketchSys), &v1, &v2);
 
         if ((v1 != param0->unk_04.unk_00) || (v2 != param0->unk_04.unk_04)) {
             param0->unk_04.unk_00 = v1;

--- a/src/overlay047/ov47_022561C0.c
+++ b/src/overlay047/ov47_022561C0.c
@@ -28,7 +28,7 @@ typedef struct {
     UnkStruct_ov47_02256634_1 unk_04;
     UnkStruct_ov47_02256634 * unk_70;
     PoketchSystem *poketchSys;
-    PoketchData * unk_78;
+    PoketchData *poketchData;
     UnkStruct_0206C638 * unk_7C[6];
     u8 unk_94[6];
     u8 unk_9A;
@@ -76,13 +76,13 @@ static BOOL ov47_0225621C (UnkStruct_ov47_0225621C * param0, PoketchSystem *poke
 {
     int v0;
 
-    param0->unk_78 = PoketchSystem_GetPoketchData(poketchSys);
+    param0->poketchData = PoketchSystem_GetPoketchData(poketchSys);
 
     for (v0 = 0; v0 < 6; v0++) {
         param0->unk_04.unk_0C[v0].unk_03 = 1;
         param0->unk_04.unk_0C[v0].unk_02 = v0;
 
-        PoketchData_MapMarkerPos(param0->unk_78, v0, &(param0->unk_04.unk_0C[v0].unk_00), &(param0->unk_04.unk_0C[v0].unk_01));
+        PoketchData_MapMarkerPos(param0->poketchData, v0, &(param0->unk_04.unk_0C[v0].unk_00), &(param0->unk_04.unk_0C[v0].unk_01));
 
         param0->unk_04.unk_0C[v0].unk_00 += 16;
         param0->unk_04.unk_0C[v0].unk_01 += 16;
@@ -130,7 +130,7 @@ static void ov47_0225634C (UnkStruct_ov47_0225621C * param0)
     int v0;
 
     for (v0 = 0; v0 < 6; v0++) {
-        PoketchData_SetMapMarker(param0->unk_78, v0, (param0->unk_04.unk_0C[v0].unk_00 - 16), (param0->unk_04.unk_0C[v0].unk_01 - 16));
+        PoketchData_SetMapMarker(param0->poketchData, v0, (param0->unk_04.unk_0C[v0].unk_00 - 16), (param0->unk_04.unk_0C[v0].unk_01 - 16));
     }
 
     ov47_02256670(param0->unk_70);

--- a/src/overlay048/ov48_022561C0.c
+++ b/src/overlay048/ov48_022561C0.c
@@ -150,13 +150,13 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov48_0225650C_1 unk_04;
     UnkStruct_ov48_0225650C * unk_A8;
-    PoketchSystem * unk_AC;
+    PoketchSystem *poketchSys;
 } UnkStruct_ov48_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov48_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov48_0225621C(UnkStruct_ov48_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov48_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov48_0225621C(UnkStruct_ov48_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov48_022562A8(UnkStruct_ov48_0225621C * param0);
 static void ov48_022562BC(SysTask * param0, void * param1);
 static void ov48_022562F0(void * param0);
@@ -166,19 +166,19 @@ static BOOL ov48_02256358(UnkStruct_ov48_0225621C * param0);
 static BOOL ov48_022563D0(UnkStruct_ov48_0225621C * param0);
 static int ov48_02256408(UnkStruct_ov48_0225621C * param0);
 static BOOL ov48_02256478(UnkStruct_ov48_0225621C * param0);
-static void ov48_022564E0(UnkStruct_ov48_0225621C * param0, PoketchSystem * param1);
+static void ov48_022564E0(UnkStruct_ov48_0225621C * param0, PoketchSystem *poketchSys);
 
 static void NitroStaticInit (void)
 {
     PoketchSystem_SetAppFunctions(ov48_022561D4, ov48_022562F0);
 }
 
-static BOOL ov48_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov48_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov48_0225621C * v0 = (UnkStruct_ov48_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov48_0225621C));
 
     if (v0 != NULL) {
-        if (ov48_0225621C(v0, param1, param2, param3)) {
+        if (ov48_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov48_022562BC, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -191,14 +191,14 @@ static BOOL ov48_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov48_0225621C (UnkStruct_ov48_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov48_0225621C (UnkStruct_ov48_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
-    param0->unk_AC = param1;
+    param0->poketchSys = poketchSys;
     param0->unk_04.unk_08 = ov48_02256408(param0);
 
-    inline_ov47_0225621C(PoketchSystem_GetFieldSystem(param0->unk_AC), &(param0->unk_04.unk_00), &(param0->unk_04.unk_04));
+    inline_ov47_0225621C(PoketchSystem_GetFieldSystem(param0->poketchSys), &(param0->unk_04.unk_00), &(param0->unk_04.unk_04));
 
-    ov48_022564E0(param0, param1);
+    ov48_022564E0(param0, poketchSys);
 
     if (ov48_0225650C(&(param0->unk_A8), &(param0->unk_04), param2)) {
         param0->unk_00 = 0;
@@ -230,7 +230,7 @@ static void ov48_022562BC (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov48_022562A8(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_AC);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -261,7 +261,7 @@ static BOOL ov48_0225630C (UnkStruct_ov48_0225621C * param0)
         break;
     case 1:
         if (ov48_0225657C(param0->unk_A8, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_AC);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov48_022562F8(param0, 1);
         }
         break;
@@ -312,7 +312,7 @@ static BOOL ov48_022563D0 (UnkStruct_ov48_0225621C * param0)
 
 static int ov48_02256408 (UnkStruct_ov48_0225621C * param0)
 {
-    UnkStruct_02027854 * v0 = sub_02027854(PoketchSystem_GetSaveData(param0->unk_AC));
+    UnkStruct_02027854 * v0 = sub_02027854(PoketchSystem_GetSaveData(param0->poketchSys));
     int v1, v2;
 
     for (v1 = 0, v2 = 0; v1 < (NELEMS(Unk_ov48_02256A38)); v1++) {
@@ -337,10 +337,10 @@ static BOOL ov48_02256478 (UnkStruct_ov48_0225621C * param0)
 {
     BOOL v0 = 0;
 
-    if (PoketchSystem_IsPlayerMoving(param0->unk_AC)) {
+    if (PoketchSystem_IsPlayerMoving(param0->poketchSys)) {
         int v1, v2;
 
-        inline_ov47_0225621C(PoketchSystem_GetFieldSystem(param0->unk_AC), &v1, &v2);
+        inline_ov47_0225621C(PoketchSystem_GetFieldSystem(param0->poketchSys), &v1, &v2);
 
         if ((v1 != param0->unk_04.unk_00) || (v2 != param0->unk_04.unk_04)) {
             param0->unk_04.unk_00 = v1;
@@ -352,9 +352,9 @@ static BOOL ov48_02256478 (UnkStruct_ov48_0225621C * param0)
     return v0;
 }
 
-static void ov48_022564E0 (UnkStruct_ov48_0225621C * param0, PoketchSystem * param1)
+static void ov48_022564E0 (UnkStruct_ov48_0225621C * param0, PoketchSystem *poketchSys)
 {
-    VarsFlags * v0 = SaveData_GetVarsFlags(PoketchSystem_GetSaveData(param1));
+    VarsFlags * v0 = SaveData_GetVarsFlags(PoketchSystem_GetSaveData(poketchSys));
     int v1;
 
     for (v1 = 0; v1 < 4; v1++) {

--- a/src/overlay049/ov49_022561C0.c
+++ b/src/overlay049/ov49_022561C0.c
@@ -23,7 +23,7 @@ typedef struct {
     UnkStruct_ov49_022563D4_1 unk_04;
     UnkStruct_ov49_022563D4 * unk_08;
     PoketchSystem *poketchSys;
-    PoketchData * unk_10;
+    PoketchData *poketchData;
 } UnkStruct_ov49_0225621C;
 
 static void NitroStaticInit(void);
@@ -64,8 +64,8 @@ static BOOL ov49_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * para
 
 static BOOL ov49_0225621C (UnkStruct_ov49_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
-    param0->unk_10 = PoketchSystem_GetPoketchData(poketchSys);
-    param0->unk_04.unk_00 = PoketchData_CurrentScreenColor(param0->unk_10);
+    param0->poketchData = PoketchSystem_GetPoketchData(poketchSys);
+    param0->unk_04.unk_00 = PoketchData_CurrentScreenColor(param0->poketchData);
     param0->unk_03 = param0->unk_04.unk_00;
 
     if (ov49_022563D4(&(param0->unk_08), &(param0->unk_04), param2)) {
@@ -179,7 +179,7 @@ static BOOL ov49_02256348 (UnkStruct_ov49_0225621C * param0)
                 if (v2 != param0->unk_03) {
                     param0->unk_04.unk_00 = v2;
                     param0->unk_03 = v2;
-                    PoketchData_SetScreenColor(param0->unk_10, v2);
+                    PoketchData_SetScreenColor(param0->poketchData, v2);
                     return 1;
                 }
             }

--- a/src/overlay049/ov49_022561C0.c
+++ b/src/overlay049/ov49_022561C0.c
@@ -22,14 +22,14 @@ typedef struct {
     u8 unk_03;
     UnkStruct_ov49_022563D4_1 unk_04;
     UnkStruct_ov49_022563D4 * unk_08;
-    PoketchSystem * unk_0C;
+    PoketchSystem *poketchSys;
     PoketchData * unk_10;
 } UnkStruct_ov49_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov49_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov49_0225621C(UnkStruct_ov49_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov49_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov49_0225621C(UnkStruct_ov49_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov49_02256258(UnkStruct_ov49_0225621C * param0);
 static void ov49_0225626C(SysTask * param0, void * param1);
 static void ov49_022562A0(void * param0);
@@ -44,12 +44,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov49_022561D4, ov49_022562A0);
 }
 
-static BOOL ov49_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov49_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov49_0225621C * v0 = (UnkStruct_ov49_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov49_0225621C));
 
     if (v0 != NULL) {
-        if (ov49_0225621C(v0, param1, param2, param3)) {
+        if (ov49_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov49_0225626C, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -62,9 +62,9 @@ static BOOL ov49_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov49_0225621C (UnkStruct_ov49_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov49_0225621C (UnkStruct_ov49_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
-    param0->unk_10 = PoketchSystem_GetPoketchData(param1);
+    param0->unk_10 = PoketchSystem_GetPoketchData(poketchSys);
     param0->unk_04.unk_00 = PoketchData_CurrentScreenColor(param0->unk_10);
     param0->unk_03 = param0->unk_04.unk_00;
 
@@ -72,7 +72,7 @@ static BOOL ov49_0225621C (UnkStruct_ov49_0225621C * param0, PoketchSystem * par
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_0C = param1;
+        param0->poketchSys = poketchSys;
         return 1;
     }
 
@@ -99,7 +99,7 @@ static void ov49_0225626C (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov49_02256258(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_0C);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -130,7 +130,7 @@ static BOOL ov49_022562BC (UnkStruct_ov49_0225621C * param0)
         break;
     case 1:
         if (ov49_022564B8(param0->unk_08, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_0C);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov49_022562A8(param0, 1);
         }
         break;
@@ -165,7 +165,7 @@ static BOOL ov49_022562FC (UnkStruct_ov49_0225621C * param0)
 
 static BOOL ov49_02256348 (UnkStruct_ov49_0225621C * param0)
 {
-    if (ov25_0225450C(param0->unk_0C) == 0) {
+    if (ov25_0225450C(param0->poketchSys) == 0) {
         u32 v0, v1;
 
         if (TouchScreen_GetHoldState(&v0, &v1)) {

--- a/src/overlay050/ov50_022561C0.c
+++ b/src/overlay050/ov50_022561C0.c
@@ -23,7 +23,7 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov50_02256510_1 unk_04;
     UnkStruct_ov50_02256510 * unk_90;
-    PoketchSystem * unk_94;
+    PoketchSystem *poketchSys;
     PoketchData * unk_98;
     PoketchButtonManager * unk_9C;
     u32 unk_A0;
@@ -34,8 +34,8 @@ typedef struct {
 
 static void NitroStaticInit(void);
 
-static BOOL ov50_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov50_0225621C(UnkStruct_ov50_022561D4 * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov50_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov50_0225621C(UnkStruct_ov50_022561D4 * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov50_022562AC(UnkStruct_ov50_02256510_1 * param0, UnkStruct_ov50_022561D4 * param1, const RTCDate * param2);
 static void ov50_02256340(UnkStruct_ov50_022561D4 * param0);
 static void ov50_02256360(u32 param0, u32 param1, u32 param2, void * param3);
@@ -51,12 +51,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov50_022561D4, ov50_022563B0);
 }
 
-static BOOL ov50_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov50_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov50_022561D4 * v0 = (UnkStruct_ov50_022561D4 *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov50_022561D4));
 
     if (v0 != NULL) {
-        if (ov50_0225621C(v0, param1, param2, param3)) {
+        if (ov50_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov50_0225636C, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -69,7 +69,7 @@ static BOOL ov50_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov50_0225621C (UnkStruct_ov50_022561D4 * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov50_0225621C (UnkStruct_ov50_022561D4 * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     static const TouchScreenHitTable v0[] = {
         {((5 + 3 * 0) * 8), ((5 + 3 * 0 + 2) * 8), ((4 + 3 * 0) * 8), ((4 + 3 * 0 + 2) * 8)},
@@ -113,7 +113,7 @@ static BOOL ov50_0225621C (UnkStruct_ov50_022561D4 * param0, PoketchSystem * par
     RTCDate v1;
 
     GetCurrentDate(&v1);
-    param0->unk_98 = PoketchSystem_GetPoketchData(param1);
+    param0->unk_98 = PoketchSystem_GetPoketchData(poketchSys);
     ov50_022562AC(&(param0->unk_04), param0, &v1);
 
     param0->unk_A8 = param0->unk_04.unk_0C[0].unk_02;
@@ -125,7 +125,7 @@ static BOOL ov50_0225621C (UnkStruct_ov50_022561D4 * param0, PoketchSystem * par
         param0->unk_02 = 0;
         param0->unk_9C = PoketchButtonManager_New(v0, NELEMS(v0), ov50_02256360, param0, 8);
         param0->unk_A0 = 0;
-        param0->unk_94 = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -190,12 +190,12 @@ static void ov50_0225636C (SysTask * param0, void * param1)
     UnkStruct_ov50_022561D4 * v1 = (UnkStruct_ov50_022561D4 *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_94, v1->unk_9C);
+        ov25_02254518(v1->poketchSys, v1->unk_9C);
 
         if (v0[v1->unk_00](v1)) {
             ov50_02256340(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_94);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -226,7 +226,7 @@ static BOOL ov50_022563CC (UnkStruct_ov50_022561D4 * param0)
         break;
     case 1:
         if (ov50_02256620(param0->unk_90, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_94);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov50_022563B8(param0, 1);
         }
         break;

--- a/src/overlay050/ov50_022561C0.c
+++ b/src/overlay050/ov50_022561C0.c
@@ -24,7 +24,7 @@ typedef struct {
     UnkStruct_ov50_02256510_1 unk_04;
     UnkStruct_ov50_02256510 * unk_90;
     PoketchSystem *poketchSys;
-    PoketchData * unk_98;
+    PoketchData *poketchData;
     PoketchButtonManager * unk_9C;
     u32 unk_A0;
     u32 unk_A4;
@@ -113,7 +113,7 @@ static BOOL ov50_0225621C (UnkStruct_ov50_022561D4 * param0, PoketchSystem *poke
     RTCDate v1;
 
     GetCurrentDate(&v1);
-    param0->unk_98 = PoketchSystem_GetPoketchData(poketchSys);
+    param0->poketchData = PoketchSystem_GetPoketchData(poketchSys);
     ov50_022562AC(&(param0->unk_04), param0, &v1);
 
     param0->unk_A8 = param0->unk_04.unk_0C[0].unk_02;
@@ -158,7 +158,7 @@ static void ov50_022562AC (UnkStruct_ov50_02256510_1 * param0, UnkStruct_ov50_02
 
     for (v1 = 0; v1 < (param0->unk_04); v1++) {
         param0->unk_0C[v1].unk_00 = v1 + 1;
-        param0->unk_0C[v1].unk_03 = PoketchData_CalendarMarked(param1->unk_98, param0->unk_00, v1 + 1);
+        param0->unk_0C[v1].unk_03 = PoketchData_CalendarMarked(param1->poketchData, param0->unk_00, v1 + 1);
         param0->unk_0C[v1].unk_02 = v2 + v1;
     }
 }
@@ -250,10 +250,10 @@ static BOOL ov50_02256418 (UnkStruct_ov50_022561D4 * param0)
             if ((param0->unk_A4 >= param0->unk_A8) && (param0->unk_A4 <= param0->unk_AC)) {
                 int v0 = (param0->unk_A4 - param0->unk_A8);
 
-                if (PoketchData_CalendarMarked(param0->unk_98, param0->unk_04.unk_00, v0 + 1)) {
-                    PoketchData_ClearCalendarMark(param0->unk_98, param0->unk_04.unk_00, v0 + 1);
+                if (PoketchData_CalendarMarked(param0->poketchData, param0->unk_04.unk_00, v0 + 1)) {
+                    PoketchData_ClearCalendarMark(param0->poketchData, param0->unk_04.unk_00, v0 + 1);
                 } else {
-                    PoketchData_SetCalendarMark(param0->unk_98, param0->unk_04.unk_00, v0 + 1);
+                    PoketchData_SetCalendarMark(param0->poketchData, param0->unk_04.unk_00, v0 + 1);
                 }
 
                 param0->unk_04.unk_0C[v0].unk_03 ^= 1;

--- a/src/overlay050/ov50_022561C0.c
+++ b/src/overlay050/ov50_022561C0.c
@@ -25,7 +25,7 @@ typedef struct {
     UnkStruct_ov50_02256510 * unk_90;
     PoketchSystem *poketchSys;
     PoketchData *poketchData;
-    PoketchButtonManager * unk_9C;
+    PoketchButtonManager *buttonManager;
     u32 unk_A0;
     u32 unk_A4;
     u32 unk_A8;
@@ -123,7 +123,7 @@ static BOOL ov50_0225621C (UnkStruct_ov50_022561D4 * param0, PoketchSystem *poke
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_9C = PoketchButtonManager_New(v0, NELEMS(v0), ov50_02256360, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(v0, NELEMS(v0), ov50_02256360, param0, 8);
         param0->unk_A0 = 0;
         param0->poketchSys = poketchSys;
 
@@ -165,7 +165,7 @@ static void ov50_022562AC (UnkStruct_ov50_02256510_1 * param0, UnkStruct_ov50_02
 
 static void ov50_02256340 (UnkStruct_ov50_022561D4 * param0)
 {
-    PoketchButtonManager_Free(param0->unk_9C);
+    PoketchButtonManager_Free(param0->buttonManager);
     ov50_0225654C(param0->unk_90);
 
     Heap_FreeToHeap(param0);
@@ -190,7 +190,7 @@ static void ov50_0225636C (SysTask * param0, void * param1)
     UnkStruct_ov50_022561D4 * v1 = (UnkStruct_ov50_022561D4 *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_9C);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov50_02256340(v1);

--- a/src/overlay051/ov51_022561C0.c
+++ b/src/overlay051/ov51_022561C0.c
@@ -19,15 +19,15 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov51_0225632C_1 unk_04;
     UnkStruct_ov51_0225632C * unk_08;
-    PoketchSystem * unk_0C;
+    PoketchSystem *poketchSys;
 } UnkStruct_ov51_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov51_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov51_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov51_02256254(SysTask * param0, void * param1);
 static void ov51_02256288(void * param0);
-static BOOL ov51_0225621C(UnkStruct_ov51_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov51_0225621C(UnkStruct_ov51_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov51_02256240(UnkStruct_ov51_0225621C * param0);
 static void ov51_02256290(UnkStruct_ov51_0225621C * param0, u32 param1);
 static BOOL ov51_022562A4(UnkStruct_ov51_0225621C * param0);
@@ -39,12 +39,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov51_022561D4, ov51_02256288);
 }
 
-static BOOL ov51_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov51_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov51_0225621C * v0 = (UnkStruct_ov51_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov51_0225621C));
 
     if (v0 != NULL) {
-        if (ov51_0225621C(v0, param1, param2, param3)) {
+        if (ov51_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov51_02256254, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -57,13 +57,13 @@ static BOOL ov51_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov51_0225621C (UnkStruct_ov51_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov51_0225621C (UnkStruct_ov51_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     if (ov51_0225632C(&(param0->unk_08), &(param0->unk_04), param2)) {
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_0C = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -91,7 +91,7 @@ static void ov51_02256254 (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov51_02256240(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_0C);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -122,7 +122,7 @@ static BOOL ov51_022562A4 (UnkStruct_ov51_0225621C * param0)
         break;
     case 1:
         if (ov51_0225638C(param0->unk_08, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_0C);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov51_02256290(param0, 1);
         }
         break;

--- a/src/overlay052/ov52_022561C0.c
+++ b/src/overlay052/ov52_022561C0.c
@@ -25,7 +25,7 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov52_02256694_1 unk_04;
     UnkStruct_ov52_02256694 * unk_14;
-    PoketchSystem * unk_18;
+    PoketchSystem *poketchSys;
     u32 unk_1C;
     u8 unk_20;
     u8 unk_21;
@@ -33,8 +33,8 @@ typedef struct {
 
 static void NitroStaticInit(void);
 
-static BOOL ov52_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov52_0225621C(UnkStruct_ov52_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov52_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov52_0225621C(UnkStruct_ov52_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov52_0225624C(UnkStruct_ov52_0225621C * param0);
 static void ov52_02256260(SysTask * param0, void * param1);
 static void ov52_0225629C(void * param0);
@@ -59,12 +59,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov52_022561D4, ov52_0225629C);
 }
 
-static BOOL ov52_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov52_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov52_0225621C * v0 = (UnkStruct_ov52_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov52_0225621C));
 
     if (v0 != NULL) {
-        if (ov52_0225621C(v0, param1, param2, param3)) {
+        if (ov52_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov52_02256260, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -77,7 +77,7 @@ static BOOL ov52_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov52_0225621C (UnkStruct_ov52_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov52_0225621C (UnkStruct_ov52_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     if (ov52_02256694(&(param0->unk_14), &(param0->unk_04), param2)) {
         param0->unk_00 = 0;
@@ -85,7 +85,7 @@ static BOOL ov52_0225621C (UnkStruct_ov52_0225621C * param0, PoketchSystem * par
         param0->unk_02 = 0;
         param0->unk_20 = 0;
         param0->unk_21 = 0;
-        param0->unk_18 = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -118,7 +118,7 @@ static void ov52_02256260 (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov52_0225624C(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_18);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -149,7 +149,7 @@ static BOOL ov52_022562B8 (UnkStruct_ov52_0225621C * param0)
         break;
     case 1:
         if (ov52_022567C8(param0->unk_14, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_18);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov52_022562A4(param0, 1);
         }
         break;
@@ -169,7 +169,7 @@ static BOOL ov52_022562F8 (UnkStruct_ov52_0225621C * param0)
     case 0:
         if (ov52_02256554(param0)) {
             if (ov52_02256684(param0)) {
-                FieldSystem * fieldSystem = PoketchSystem_GetFieldSystem(param0->unk_18);
+                FieldSystem * fieldSystem = PoketchSystem_GetFieldSystem(param0->poketchSys);
 
                 ov52_022567A4(param0->unk_14, 3);
 
@@ -241,11 +241,11 @@ static BOOL ov52_02256364 (UnkStruct_ov52_0225621C * param0)
 
 static BOOL ov52_02256430 (UnkStruct_ov52_0225621C * param0)
 {
-    if (ov25_0225450C(param0->unk_18)) {
+    if (ov25_0225450C(param0->poketchSys)) {
         return 1;
     }
 
-    if (PoketchSystem_IsPlayerMoving(param0->unk_18)) {
+    if (PoketchSystem_IsPlayerMoving(param0->poketchSys)) {
         return 1;
     }
 
@@ -328,7 +328,7 @@ static BOOL ov52_02256508 (UnkStruct_ov52_0225621C * param0)
 
 static BOOL ov52_02256554 (UnkStruct_ov52_0225621C * param0)
 {
-    if (ov25_0225450C(param0->unk_18) == 0) {
+    if (ov25_0225450C(param0->poketchSys) == 0) {
         u32 v0, v1;
 
         if (TouchScreen_GetTapState(&v0, &v1)) {
@@ -409,7 +409,7 @@ static void ov52_022565EC (UnkStruct_ov52_0225621C * param0)
 static void ov52_0225664C (UnkStruct_ov52_0225621C * param0)
 {
     if (param0->unk_20 == 0) {
-        sub_02037BC0(PoketchSystem_GetSaveData(param0->unk_18));
+        sub_02037BC0(PoketchSystem_GetSaveData(param0->poketchSys));
         param0->unk_20 = 1;
     }
 }

--- a/src/overlay053/ov53_022561C0.c
+++ b/src/overlay053/ov53_022561C0.c
@@ -24,7 +24,7 @@ typedef struct {
     UnkStruct_ov53_02256420_1 unk_04;
     UnkStruct_ov53_02256420 * unk_2C;
     PoketchSystem *poketchSys;
-    PoketchButtonManager * unk_34;
+    PoketchButtonManager *buttonManager;
     u32 unk_38;
     u32 unk_3C;
 } UnkStruct_ov53_0225621C;
@@ -110,7 +110,7 @@ static BOOL ov53_0225621C (UnkStruct_ov53_0225621C * param0, PoketchSystem *poke
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_34 = PoketchButtonManager_New(v0, NELEMS(v0), ov53_02256314, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(v0, NELEMS(v0), ov53_02256314, param0, 8);
         param0->unk_38 = 0;
         param0->unk_3C = 0;
         param0->poketchSys = poketchSys;
@@ -123,7 +123,7 @@ static BOOL ov53_0225621C (UnkStruct_ov53_0225621C * param0, PoketchSystem *poke
 
 static void ov53_022562B8 (UnkStruct_ov53_0225621C * param0)
 {
-    PoketchButtonManager_Free(param0->unk_34);
+    PoketchButtonManager_Free(param0->buttonManager);
     ov53_02256454(param0->unk_2C);
 
     Heap_FreeToHeap(param0);
@@ -140,7 +140,7 @@ static void ov53_022562D0 (SysTask * param0, void * param1)
     UnkStruct_ov53_0225621C * v1 = (UnkStruct_ov53_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_34);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov53_022562B8(v1);

--- a/src/overlay053/ov53_022561C0.c
+++ b/src/overlay053/ov53_022561C0.c
@@ -23,7 +23,7 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov53_02256420_1 unk_04;
     UnkStruct_ov53_02256420 * unk_2C;
-    PoketchSystem * unk_30;
+    PoketchSystem *poketchSys;
     PoketchButtonManager * unk_34;
     u32 unk_38;
     u32 unk_3C;
@@ -31,8 +31,8 @@ typedef struct {
 
 static void NitroStaticInit(void);
 
-static BOOL ov53_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov53_0225621C(UnkStruct_ov53_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov53_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov53_0225621C(UnkStruct_ov53_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov53_022562B8(UnkStruct_ov53_0225621C * param0);
 static void ov53_022562D0(SysTask * param0, void * param1);
 static void ov53_0225630C(void * param0);
@@ -47,12 +47,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov53_022561D4, ov53_0225630C);
 }
 
-static BOOL ov53_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov53_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov53_0225621C * v0 = (UnkStruct_ov53_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov53_0225621C));
 
     if (v0 != NULL) {
-        if (ov53_0225621C(v0, param1, param2, param3)) {
+        if (ov53_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov53_022562D0, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -65,7 +65,7 @@ static BOOL ov53_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov53_0225621C (UnkStruct_ov53_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov53_0225621C (UnkStruct_ov53_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     static const TouchScreenHitTable v0[] = {
         {
@@ -90,7 +90,7 @@ static BOOL ov53_0225621C (UnkStruct_ov53_0225621C * param0, PoketchSystem * par
     FieldSystem * fieldSystem;
     int v2;
 
-    fieldSystem = PoketchSystem_GetFieldSystem(param1);
+    fieldSystem = PoketchSystem_GetFieldSystem(poketchSys);
     param0->unk_04.unk_04 = ov6_02243140(fieldSystem);
 
     if (param0->unk_04.unk_04) {
@@ -113,7 +113,7 @@ static BOOL ov53_0225621C (UnkStruct_ov53_0225621C * param0, PoketchSystem * par
         param0->unk_34 = PoketchButtonManager_New(v0, NELEMS(v0), ov53_02256314, param0, 8);
         param0->unk_38 = 0;
         param0->unk_3C = 0;
-        param0->unk_30 = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -140,12 +140,12 @@ static void ov53_022562D0 (SysTask * param0, void * param1)
     UnkStruct_ov53_0225621C * v1 = (UnkStruct_ov53_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_30, v1->unk_34);
+        ov25_02254518(v1->poketchSys, v1->unk_34);
 
         if (v0[v1->unk_00](v1)) {
             ov53_022562B8(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_30);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -184,7 +184,7 @@ static BOOL ov53_02256330 (UnkStruct_ov53_0225621C * param0)
         break;
     case 1:
         if (ov53_02256484(param0->unk_2C, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_30);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov53_0225631C(param0, 1);
         }
         break;
@@ -204,7 +204,7 @@ static BOOL ov53_02256370 (UnkStruct_ov53_0225621C * param0)
         FieldSystem * fieldSystem;
         int v1;
 
-        fieldSystem = PoketchSystem_GetFieldSystem(param0->unk_30);
+        fieldSystem = PoketchSystem_GetFieldSystem(param0->poketchSys);
         param0->unk_04.unk_04 = ov6_02243140(fieldSystem);
 
         if (param0->unk_04.unk_04 == 0) {

--- a/src/overlay054/ov54_022561C0.c
+++ b/src/overlay054/ov54_022561C0.c
@@ -140,15 +140,15 @@ static BOOL ov54_0225621C (UnkStruct_ov54_0225621C * param0, PoketchSystem *poke
             ((48 + 40 * 0) + (48 / 2))
         }
     };
-    PoketchData * v1;
+    PoketchData *poketchData;
     int v2;
 
-    v1 = PoketchSystem_GetPoketchData(poketchSys);
-    param0->unk_04.unk_90 = PoketchData_PokemonHistorySize(v1);
+    poketchData = PoketchSystem_GetPoketchData(poketchSys);
+    param0->unk_04.unk_90 = PoketchData_PokemonHistorySize(poketchData);
 
     for (v2 = 0; v2 < param0->unk_04.unk_90; v2++) {
-        PoketchData_PokemonHistorySpeciesAndIcon(v1, v2, &(param0->unk_04.unk_00[v2].unk_00), &(param0->unk_04.unk_00[v2].unk_08));
-        param0->unk_04.unk_00[v2].unk_04 = PoketchData_PokemonHistoryForm(v1, v2);
+        PoketchData_PokemonHistorySpeciesAndIcon(poketchData, v2, &(param0->unk_04.unk_00[v2].unk_00), &(param0->unk_04.unk_00[v2].unk_08));
+        param0->unk_04.unk_00[v2].unk_04 = PoketchData_PokemonHistoryForm(poketchData, v2);
     }
 
     if (ov54_0225642C(&(param0->unk_98), &(param0->unk_04), param2)) {

--- a/src/overlay054/ov54_022561C0.c
+++ b/src/overlay054/ov54_022561C0.c
@@ -22,7 +22,7 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov54_0225642C_1 unk_04;
     UnkStruct_ov54_0225642C * unk_98;
-    PoketchSystem * unk_9C;
+    PoketchSystem *poketchSys;
     PoketchButtonManager * unk_A0;
     u32 unk_A4;
     u32 unk_A8;
@@ -30,8 +30,8 @@ typedef struct {
 
 static void NitroStaticInit(void);
 
-static BOOL ov54_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
-static BOOL ov54_0225621C(UnkStruct_ov54_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov54_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
+static BOOL ov54_0225621C(UnkStruct_ov54_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov54_022562D4(UnkStruct_ov54_0225621C * param0);
 static void ov54_022562F4(SysTask * param0, void * param1);
 static void ov54_02256338(void * param0);
@@ -46,12 +46,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov54_022561D4, ov54_02256338);
 }
 
-static BOOL ov54_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov54_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov54_0225621C * v0 = (UnkStruct_ov54_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov54_0225621C));
 
     if (v0 != NULL) {
-        if (ov54_0225621C(v0, param1, param2, param3)) {
+        if (ov54_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov54_022562F4, v0, 1) != NULL) {
                 *param0 = v0;
                 return 1;
@@ -64,7 +64,7 @@ static BOOL ov54_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov54_0225621C (UnkStruct_ov54_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov54_0225621C (UnkStruct_ov54_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     static const TouchScreenHitTable v0[] = {
         {
@@ -143,7 +143,7 @@ static BOOL ov54_0225621C (UnkStruct_ov54_0225621C * param0, PoketchSystem * par
     PoketchData * v1;
     int v2;
 
-    v1 = PoketchSystem_GetPoketchData(param1);
+    v1 = PoketchSystem_GetPoketchData(poketchSys);
     param0->unk_04.unk_90 = PoketchData_PokemonHistorySize(v1);
 
     for (v2 = 0; v2 < param0->unk_04.unk_90; v2++) {
@@ -158,7 +158,7 @@ static BOOL ov54_0225621C (UnkStruct_ov54_0225621C * param0, PoketchSystem * par
         param0->unk_A0 = PoketchButtonManager_New(v0, NELEMS(v0), ov54_02256340, param0, 8);
         param0->unk_A4 = 0;
         param0->unk_A8 = 0;
-        param0->unk_9C = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -185,12 +185,12 @@ static void ov54_022562F4 (SysTask * param0, void * param1)
     UnkStruct_ov54_0225621C * v1 = (UnkStruct_ov54_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->unk_9C, v1->unk_A0);
+        ov25_02254518(v1->poketchSys, v1->unk_A0);
 
         if (v0[v1->unk_00](v1)) {
             ov54_022562D4(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_9C);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -229,7 +229,7 @@ static BOOL ov54_02256360 (UnkStruct_ov54_0225621C * param0)
         break;
     case 1:
         if (ov54_02256490(param0->unk_98, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_9C);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov54_0225634C(param0, 1);
         }
         break;

--- a/src/overlay054/ov54_022561C0.c
+++ b/src/overlay054/ov54_022561C0.c
@@ -23,7 +23,7 @@ typedef struct {
     UnkStruct_ov54_0225642C_1 unk_04;
     UnkStruct_ov54_0225642C * unk_98;
     PoketchSystem *poketchSys;
-    PoketchButtonManager * unk_A0;
+    PoketchButtonManager *buttonManager;
     u32 unk_A4;
     u32 unk_A8;
 } UnkStruct_ov54_0225621C;
@@ -155,7 +155,7 @@ static BOOL ov54_0225621C (UnkStruct_ov54_0225621C * param0, PoketchSystem *poke
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_A0 = PoketchButtonManager_New(v0, NELEMS(v0), ov54_02256340, param0, 8);
+        param0->buttonManager = PoketchButtonManager_New(v0, NELEMS(v0), ov54_02256340, param0, 8);
         param0->unk_A4 = 0;
         param0->unk_A8 = 0;
         param0->poketchSys = poketchSys;
@@ -168,7 +168,7 @@ static BOOL ov54_0225621C (UnkStruct_ov54_0225621C * param0, PoketchSystem *poke
 
 static void ov54_022562D4 (UnkStruct_ov54_0225621C * param0)
 {
-    PoketchButtonManager_Free(param0->unk_A0);
+    PoketchButtonManager_Free(param0->buttonManager);
     ov54_02256460(param0->unk_98);
 
     Heap_FreeToHeap(param0);
@@ -185,7 +185,7 @@ static void ov54_022562F4 (SysTask * param0, void * param1)
     UnkStruct_ov54_0225621C * v1 = (UnkStruct_ov54_0225621C *)param1;
 
     if (v1->unk_00 < NELEMS(v0)) {
-        ov25_02254518(v1->poketchSys, v1->unk_A0);
+        ov25_02254518(v1->poketchSys, v1->buttonManager);
 
         if (v0[v1->unk_00](v1)) {
             ov54_022562D4(v1);

--- a/src/overlay055/ov55_022561C0.c
+++ b/src/overlay055/ov55_022561C0.c
@@ -19,15 +19,15 @@ typedef struct {
     u8 unk_02;
     UnkStruct_ov55_0225632C_1 unk_04;
     UnkStruct_ov55_0225632C * unk_08;
-    PoketchSystem * unk_0C;
+    PoketchSystem *poketchSys;
 } UnkStruct_ov55_0225621C;
 
 static void NitroStaticInit(void);
 
-static BOOL ov55_022561D4(void ** param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov55_022561D4(void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov55_02256254(SysTask * param0, void * param1);
 static void ov55_02256288(void * param0);
-static BOOL ov55_0225621C(UnkStruct_ov55_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3);
+static BOOL ov55_0225621C(UnkStruct_ov55_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3);
 static void ov55_02256240(UnkStruct_ov55_0225621C * param0);
 static void ov55_02256290(UnkStruct_ov55_0225621C * param0, u32 param1);
 static BOOL ov55_022562A4(UnkStruct_ov55_0225621C * param0);
@@ -39,12 +39,12 @@ static void NitroStaticInit (void)
     PoketchSystem_SetAppFunctions(ov55_022561D4, ov55_02256288);
 }
 
-static BOOL ov55_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov55_022561D4 (void ** param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     UnkStruct_ov55_0225621C * v0 = (UnkStruct_ov55_0225621C *)Heap_AllocFromHeap(HEAP_ID_POKETCH_APP, sizeof(UnkStruct_ov55_0225621C));
 
     if (v0 != NULL) {
-        if (ov55_0225621C(v0, param1, param2, param3)) {
+        if (ov55_0225621C(v0, poketchSys, param2, param3)) {
             if (SysTask_Start(ov55_02256254, v0, 1) != NULL) {
                 *param0 = v0;
                 v0->unk_04.unk_00 = param3;
@@ -58,13 +58,13 @@ static BOOL ov55_022561D4 (void ** param0, PoketchSystem * param1, BGL * param2,
     return 0;
 }
 
-static BOOL ov55_0225621C (UnkStruct_ov55_0225621C * param0, PoketchSystem * param1, BGL * param2, u32 param3)
+static BOOL ov55_0225621C (UnkStruct_ov55_0225621C * param0, PoketchSystem *poketchSys, BGL * param2, u32 param3)
 {
     if (ov55_0225632C(&(param0->unk_08), &(param0->unk_04), param2)) {
         param0->unk_00 = 0;
         param0->unk_01 = 0;
         param0->unk_02 = 0;
-        param0->unk_0C = param1;
+        param0->poketchSys = poketchSys;
 
         return 1;
     }
@@ -92,7 +92,7 @@ static void ov55_02256254 (SysTask * param0, void * param1)
         if (v0[v1->unk_00](v1)) {
             ov55_02256240(v1);
             SysTask_Done(param0);
-            PoketchSystem_NotifyAppUnloaded(v1->unk_0C);
+            PoketchSystem_NotifyAppUnloaded(v1->poketchSys);
         }
     } else {
     }
@@ -123,7 +123,7 @@ static BOOL ov55_022562A4 (UnkStruct_ov55_0225621C * param0)
         break;
     case 1:
         if (ov55_0225639C(param0->unk_08, 0)) {
-            PoketchSystem_NotifyAppLoaded(param0->unk_0C);
+            PoketchSystem_NotifyAppLoaded(param0->poketchSys);
             ov55_02256290(param0, 1);
         }
         break;

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -5213,10 +5213,10 @@ static BOOL ScrCmd_131 (ScriptContext * ctx)
 
 static BOOL ScrCmd_132 (ScriptContext * ctx)
 {
-    PoketchData * v0 = SaveData_PoketchData(ctx->fieldSystem->saveData);
+    PoketchData *poketchData = SaveData_PoketchData(ctx->fieldSystem->saveData);
     u16 * v1 = ScriptContext_GetVarPointer(ctx);
 
-    *v1 = PoketchData_IsEnabled(v0);
+    *v1 = PoketchData_IsEnabled(poketchData);
     return 0;
 }
 

--- a/src/unk_02048DD8.c
+++ b/src/unk_02048DD8.c
@@ -338,8 +338,8 @@ static BOOL sub_02049348 (FieldSystem * fieldSystem)
 
 static BOOL sub_02049358 (FieldSystem * fieldSystem)
 {
-    PoketchData * v0 = SaveData_PoketchData(fieldSystem->saveData);
-    return PoketchData_IsEnabled(v0);
+    PoketchData *poketchData = SaveData_PoketchData(fieldSystem->saveData);
+    return PoketchData_IsEnabled(poketchData);
 }
 
 static BOOL sub_02049368 (FieldSystem * fieldSystem)

--- a/src/unk_02048DD8.c
+++ b/src/unk_02048DD8.c
@@ -293,7 +293,7 @@ static void sub_02049288 (FieldSystem * fieldSystem, StringTemplate * param1)
 {
     int v0;
 
-    v0 = PoketchSystem_CurrentAppID(fieldSystem->unk_04->unk_14);
+    v0 = PoketchSystem_CurrentAppID(fieldSystem->unk_04->poketchSys);
     StringTemplate_SetPoketchAppName(param1, 0, v0);
 }
 

--- a/src/unk_0204B830.c
+++ b/src/unk_0204B830.c
@@ -725,18 +725,18 @@ static void sub_0204C428 (UnkStruct_0204B830 * param0, u16 * param1, u16 * param
 
 static BOOL sub_0204C458 (FieldSystem * fieldSystem, void * param1)
 {
-    PoketchData * v0 = SaveData_PoketchData(fieldSystem->saveData);
+    PoketchData *poketchData = SaveData_PoketchData(fieldSystem->saveData);
     UnkUnion_0204C4D0 * v1 = sub_0204B844(fieldSystem);
 
-    return PoketchData_IsEnabled(v0);
+    return PoketchData_IsEnabled(poketchData);
 }
 
 static void sub_0204C474 (FieldSystem * fieldSystem, void * param1)
 {
-    PoketchData * v0 = SaveData_PoketchData(fieldSystem->saveData);
+    PoketchData *poketchData = SaveData_PoketchData(fieldSystem->saveData);
     UnkUnion_0204C4D0 * v1 = sub_0204B844(fieldSystem);
 
-    PoketchData_RegisterApp(v0, v1->val6.unk_00);
+    PoketchData_RegisterApp(poketchData, v1->val6.unk_00);
 }
 
 static void sub_0204C494 (UnkStruct_0204B830 * param0, u16 * param1, u16 * param2)

--- a/src/unk_02051D8C.c
+++ b/src/unk_02051D8C.c
@@ -285,7 +285,7 @@ void sub_020521B8 (BattleParams * param0, const FieldSystem * fieldSystem, SaveD
     param0->unk_14C = FieldOverworldState_GetWeather(v6);
     param0->unk_E4 = param5;
     param0->unk_190 = param6;
-    param0->unk_100 = SaveData_PoketchData(param2);
+    param0->poketchData = SaveData_PoketchData(param2);
     param0->unk_104 = sub_0202C878(param2);
     param0->unk_11C = sub_0202CD88(param2);
     param0->unk_120 = param4;
@@ -342,7 +342,7 @@ void sub_02052348 (BattleParams * param0, const FieldSystem * fieldSystem, int p
     param0->unk_138 = sub_02055BA8(fieldSystem);
     param0->unk_E4 = fieldSystem->unk_98;
     param0->unk_190 = fieldSystem->unk_BC;
-    param0->unk_100 = SaveData_PoketchData(fieldSystem->saveData);
+    param0->poketchData = SaveData_PoketchData(fieldSystem->saveData);
     param0->unk_104 = sub_0202C878(fieldSystem->saveData);
     param0->unk_11C = sub_0202CD88(fieldSystem->saveData);
     param0->unk_120 = fieldSystem->unk_9C;

--- a/src/unk_0206CCB0.c
+++ b/src/unk_0206CCB0.c
@@ -1696,7 +1696,7 @@ void sub_0206E264 (FieldSystem * fieldSystem, u16 param1)
     UnkUnion_0206D1B8 v0;
     UnkStruct_0206E28C * v1 = &v0.val28;
 
-    v1->unk_00 = PoketchSystem_CurrentAppID(fieldSystem->unk_04->unk_14);
+    v1->unk_00 = PoketchSystem_CurrentAppID(fieldSystem->unk_04->poketchSys);
     v1->unk_04 = param1;
 
     sub_0206CD70(fieldSystem, 1, 6, v1);

--- a/src/unk_0207AE68.c
+++ b/src/unk_0207AE68.c
@@ -65,7 +65,7 @@
 #include "bag.h"
 #include "pokemon_summary_app.h"
 
-UnkStruct_0207AE68 * sub_0207AE68(Party * param0, Pokemon * param1, int param2, Options * param3, int param4, PokedexData * param5, Bag * param6, UnkStruct_0202CD88 * param7, PoketchData * param8, int param9, int param10, int param11);
+UnkStruct_0207AE68 * sub_0207AE68(Party * param0, Pokemon * param1, int param2, Options * param3, int param4, PokedexData * param5, Bag * param6, UnkStruct_0202CD88 * param7, PoketchData *poketchData, int param9, int param10, int param11);
 static void sub_0207B0A0(SysTask * param0, void * param1);
 BOOL sub_0207B0D0(UnkStruct_0207AE68 * param0);
 void sub_0207B0E0(UnkStruct_0207AE68 * param0);
@@ -95,7 +95,7 @@ static const u8 Unk_020F0A2C[] = {
     0x8
 };
 
-UnkStruct_0207AE68 * sub_0207AE68 (Party * param0, Pokemon * param1, int param2, Options * param3, int param4, PokedexData * param5, Bag * param6, UnkStruct_0202CD88 * param7, PoketchData * param8, int param9, int param10, int param11)
+UnkStruct_0207AE68 * sub_0207AE68 (Party * param0, Pokemon * param1, int param2, Options * param3, int param4, PokedexData * param5, Bag * param6, UnkStruct_0202CD88 * param7, PoketchData *poketchData, int param9, int param10, int param11)
 {
     UnkStruct_0207AE68 * v0;
     ArchivedSprite v1;
@@ -154,7 +154,7 @@ UnkStruct_0207AE68 * sub_0207AE68 (Party * param0, Pokemon * param1, int param2,
     v0->unk_48 = param5;
     v0->unk_4C = param6;
     v0->unk_50 = param7;
-    v0->unk_54 = param8;
+    v0->poketchData = poketchData;
     v0->unk_78 = param9;
     v0->unk_7C = param10;
 
@@ -417,7 +417,7 @@ static void sub_0207B180 (UnkStruct_0207AE68 * param0)
                 sub_0202736C(param0->unk_48, param0->unk_28);
                 sub_0202CF28(param0->unk_50, (1 + 11));
                 sub_0202CFEC(param0->unk_50, 22);
-                PoketchData_PokemonHistoryEnqueue(param0->unk_54, Pokemon_GetBoxPokemon(param0->unk_28));
+                PoketchData_PokemonHistoryEnqueue(param0->poketchData, Pokemon_GetBoxPokemon(param0->unk_28));
 
                 if (Pokemon_GetValue(param0->unk_28, MON_DATA_HAS_NICKNAME, NULL) == 0) {
                     Pokemon_SetValue(param0->unk_28, 179, NULL);
@@ -749,7 +749,7 @@ static void sub_0207C028 (UnkStruct_0207AE68 * param0)
                 sub_0202736C(param0->unk_48, v1);
                 sub_0202CF28(param0->unk_50, (1 + 11));
                 sub_0202CFEC(param0->unk_50, 22);
-                PoketchData_PokemonHistoryEnqueue(param0->unk_54, Pokemon_GetBoxPokemon(v1));
+                PoketchData_PokemonHistoryEnqueue(param0->poketchData, Pokemon_GetBoxPokemon(v1));
                 Heap_FreeToHeap(v1);
                 Bag_TryRemoveItem(param0->unk_4C, 4, 1, param0->unk_5C);
             }


### PR DESCRIPTION
Similar to #208, for the Poketch objects that have been documented so far. I named all the `PoketchSystem` ones `poketchSys` because that's what we have so far, but open to changing to `poketchSystem` if we want it to match `fieldSystem`.