### PR TITLE
Add scr_seq.naix to naix_headers

### DIFF
--- a/res/field/scripts/meson.build
+++ b/res/field/scripts/meson.build
@@ -1133,7 +1133,7 @@ scr_seq_files = files(
 
 scr_seq_narc_order = files('scripts.order')
 
-src_seq_narc = custom_target('scr_seq.narc',
+scr_seq_narc = custom_target('scr_seq.narc',
     output: [
         'scr_seq.narc',
         'scr_seq.naix',
@@ -1151,4 +1151,6 @@ src_seq_narc = custom_target('scr_seq.narc',
     ]
 )
 
-nitrofs_files += src_seq_narc
+nitrofs_files += scr_seq_narc
+
+naix_headers += scr_seq_narc[1]


### PR DESCRIPTION
It's possible for the build to fail without this dependency-addition, as `scr_seq_narc` can be prioritized lower than source files making use of the file `scr_seq.naix` generated as part of the target.