### PR TITLE
INSTALL.md update for macOS (12 Monterey)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -104,15 +104,23 @@ xcode-select --install
 
 You will also need the following packages:
 
+* gcc (14.x.x)
 * meson (>= 1.3.0)
 * wine (to run the mwcc executables)
+* libpng
+* pkg-config
 
 These can be installed using Homebrew; if you do not have Homebrew installed, refer to the instructions [here](https://brew.sh/). Once Homebrew is installed, run:
 
 ```
 brew update
-brew install meson arm-none-eabi-binutils
+brew install gcc@14 meson libpng pkg-config arm-none-eabi-binutils
 brew install --cask wine-stable
+```
+
+On macOS Monterey (12) or earlier, you may also need GNU Coreutils installed to run the build script.
+```
+brew install coreutils
 ```
 
 ## Linux

--- a/config.sh
+++ b/config.sh
@@ -49,7 +49,7 @@ if [ "$(uname -s)" = "Linux" ]; then
         cross_file="cross_unix.ini"
     fi
 elif [ "$(uname -s)" = "Darwin" ]; then
-    native_file="native_unix.ini"
+    native_file="native_macos.ini"  # using gcc-14/g++-14 to avoid apple clang
     cross_file="cross_unix.ini"
 else
     native_file="native.ini"

--- a/meson/native_macos.ini
+++ b/meson/native_macos.ini
@@ -1,0 +1,8 @@
+[binaries]
+c   = 'gcc-14'
+cpp = 'g++-14'
+ar  = 'ar'
+
+makebanner  = ['wine', root + '/tools/maketools/makebanner.exe']
+makelcf     = ['wine', root + '/tools/maketools/makelcf.exe']
+makerom     = ['wine', root + '/tools/maketools/makerom.exe']


### PR DESCRIPTION
(#246) This is pretty straightforward:
- added information to `INSTALL.md` to resolve a couple of things:
  - `knarc` doesn't build on Apple clang
  - `libpng` and `pkg-config` need to be preinstalled for `nitrogfx` because `libpng` doesn't build from source on macOS (apparently)
  - `realpath` isn't included in Xcode Command Line Tools on macOS Monterey and earlier

- slightly tweaked the `config.sh` script to look for `gcc-14` and `g++-14` on macOS instead of their unversioned counterparts