### PR TITLE
Specify MESON_RSP_THRESHOLD in build scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt-get update -y
           sudo apt-get install -y --install-recommends python3-pip ninja-build winehq-stable binutils-arm-none-eabi
-          pip install --user meson==1.4.1 pyelftools
+          pip install --user meson pyelftools
 
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,13 @@ fi
 # Set up env variable to show % of completion during ninja build
 export NINJA_STATUS="[%p %f/%t] "
 
+# Explicitly set the Response File threshold to half of Wine's limit
+# Must be here in addition to in config.sh for when Meson automatically triggers a reconfigure
+# Ref: https://github.com/mesonbuild/meson/blob/8e89a38737281f7618a1284fe9e68eb6bb1fe99d/mesonbuild/backend/ninjabackend.py#L108
+# Ref: https://github.com/wine-mirror/wine/blob/34b1606019982b71818780bc84b76460f650af31/dlls/ntdll/unix/env.c#L1579
+# TODO: https://github.com/mesonbuild/meson/issues/13414
+export MESON_RSP_THRESHOLD=16387
+
 # Build the project
 if [ "$target" = test ]; then
     "${MESON:-meson}" test -C build "$@"

--- a/config.sh
+++ b/config.sh
@@ -82,5 +82,11 @@ elif is_wsl_accessing_windows; then
         -path_build_win "$wrap_path_build_win"
 fi
 
+# Explicitly set the Response File threshold to half of Wine's limit
+# Ref: https://github.com/mesonbuild/meson/blob/8e89a38737281f7618a1284fe9e68eb6bb1fe99d/mesonbuild/backend/ninjabackend.py#L108
+# Ref: https://github.com/wine-mirror/wine/blob/34b1606019982b71818780bc84b76460f650af31/dlls/ntdll/unix/env.c#L1579
+# TODO: https://github.com/mesonbuild/meson/issues/13414
+export MESON_RSP_THRESHOLD=16387
+
 # Launch meson
 "${MESON:-meson}" setup --wrap-mode=nopromote --native-file=meson/"$native_file" --native-file="$build/root.ini" --cross-file=meson/"$cross_file" --cross-file="$build/root.ini" "$@" -- "$build"


### PR DESCRIPTION
This is a stop-gap solution to support Meson 1.5.0, which introduced a regression in identification of the need for a response file.

For details on the regression, see: https://github.com/mesonbuild/meson/issues/13414