### PR TITLE
Fix macOS build

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,7 +94,7 @@ You now have the choice between two different environments to use to build the p
 
 Continue with the [building instructions](#Downloading_the_repository)
 
-## Mac OSX (<= 10.14)
+## macOS
 
 Apple bundles a number of the requisite utilities into Xcode Command Line Tools; to install these, run:
 

--- a/config.sh
+++ b/config.sh
@@ -59,7 +59,7 @@ fi
 touch "$build/.mwconfig"
 export MWCONFIG="$(realpath -- "$build/.mwconfig")"
 
-if [ "$native_file" = "native_unix.ini" ]; then
+if [ "$native_file" = "native_unix.ini" ] || [ "$native_file" = "native_macos.ini" ]; then
     wrap_wine="$(command -v "${WINELOADER:-wine}")"
     wrap_path_unx="$PWD"
     wrap_path_win="$("$wrap_wine" winepath -w "$wrap_path_unx")"


### PR DESCRIPTION
This fixes a bug introduced by #247, where the configure script was not using wine anymore.
Tested on macOS 14.5 with an Intel CPU