### PR TITLE
Assemble field and battle scripts with native arm-none-eabi-gcc

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -21,3 +21,7 @@ src/overlay062/ov62_0223DFA8.c
 src/overlay062/ov62_0223CAEC.c
 src/overlay062/ov62_02231690.c
 src/overlay062/ov62_02237D24.c
+
+# Do not format any .s or .inc file
+*.s
+*.inc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
           sudo dpkg --add-architecture i386
           sudo apt-get update -y
-          sudo apt-get install -y --install-recommends python3-pip ninja-build winehq-stable binutils-arm-none-eabi
+          sudo apt-get install -y --install-recommends python3-pip ninja-build winehq-stable binutils-arm-none-eabi gcc-arm-none-eabi
           pip install --user meson pyelftools
 
       - name: Checkout Repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get install -y \
         python3-pip \
         python-is-python3 \
         binutils-arm-none-eabi \
+        gcc-arm-none-eabi \
         wget
 RUN dpkg --add-architecture i386
 RUN mkdir -pm755 /etc/apt/keyrings

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,10 +31,9 @@ You now have the choice between two different environments to use to build the p
 3. Reopen an MSYS terminal (pink icon) and enter the following commands to install the necessary packages:
 
     ```
-    echo 'export MINGW_PACKAGE_PREFIX=mingw-w64-x86_64-' >> ~/.bashrc
     echo 'export PATH=${PATH}:/mingw64/bin' >> ~/.bashrc
     source ~/.bashrc
-    pacman -S git meson gcc "${MINGW_PACKAGE_PREFIX}arm-none-eabi-binutils"
+    pacman -S git meson gcc mingw-w64-x86_64-arm-none-eabi-{binutils,gcc}
     ```
 
     Press 'Y' when prompted to confirm the installation.
@@ -77,7 +76,7 @@ You now have the choice between two different environments to use to build the p
 7. Certain packages are required to build the repository. Install these packages by running the following command:
 
     ```bash
-    sudo apt install git build-essential binutils-arm-none-eabi
+    sudo apt install git build-essential binutils-arm-none-eabi gcc-arm-none-eabi
     ```
 
     We are not done yet, the 'meson' package is also necessary, but the version provided by apt is too outdated. To get the most recent meson version, run:
@@ -114,7 +113,7 @@ These can be installed using Homebrew; if you do not have Homebrew installed, re
 
 ```
 brew update
-brew install gcc@14 meson libpng pkg-config arm-none-eabi-binutils
+brew install gcc@14 meson libpng pkg-config arm-none-eabi-binutils arm-none-eabi-gcc
 brew install --cask wine-stable
 ```
 
@@ -131,6 +130,7 @@ Building the ROM requires the following packages. If you cannot find one or more
 * meson (>= 1.3.0)
 * build-essentials (build-essential on Ubuntu)
 * binutils-arm-none-eabi (arm-none-eabi-binutils on Arch Linux)
+* gcc-arm-none-eabi (arm-none-eabi-gcc on Arch Linux)
 * wine (to run the mwcc executables)
 * pkg-config
 

--- a/asm/macros/btlcmd.inc
+++ b/asm/macros/btlcmd.inc
@@ -18,8 +18,8 @@
     .include "consts/moves.inc"
     .include "consts/pokemon.inc"
 
-    .equ FALSE 0
-    .equ TRUE 1
+    .equ FALSE, 0
+    .equ TRUE, 1
 
     .macro PlayEncounterAnimation
     .long 0
@@ -1235,4 +1235,4 @@
     .long 222
     .endm
 
-    .endif ; ASM_BATTLE_SCRIPT_INC
+    .endif // ASM_BATTLE_SCRIPT_INC

--- a/asm/macros/scrcmd.inc
+++ b/asm/macros/scrcmd.inc
@@ -2,8 +2,6 @@
     .include "consts/scrcmd.inc"
     .include "consts/sdat.inc"
 
-    .option alignment off
-
     .macro Noop
     .short 0
     .endm

--- a/asm/macros/scrcmd.inc
+++ b/asm/macros/scrcmd.inc
@@ -102,9 +102,9 @@
 
     .macro CompareVar varID, valueOrVarID
     .if \valueOrVarID < 0x4000
-        .short 17 ; CompareVarToValue
+        .short 17 /* CompareVarToValue */
     .else
-        .short 18 ; CompareVarToVar
+        .short 18 /* CompareVarToVar */
     .endif
     .short \varID
     .short \valueOrVarID
@@ -223,9 +223,9 @@
 
     .macro SetVar destVarID, valueOrVarID
     .if \valueOrVarID < 0x4000
-        .short 40 ; SetVarFromValue
+        .short 40 /* SetVarFromValue */
     .else
-        .short 41 ; SetVarFromVar
+        .short 41 /* SetVarFromVar */
     .endif
     .short \destVarID
     .short \valueOrVarID
@@ -2695,8 +2695,8 @@
     .macro ScrCmd_1F8
     .short 504
     .endm
-    
-    ; this is a dummy function that doesn't do anything
+
+    /* this is a dummy function that doesn't do anything */
     .macro Dummy1 dummy
     .short 505
     .short \dummy
@@ -3735,7 +3735,7 @@
     .short \arg1
     .endm
 
-    ; this is unused, but the underlying function is called from LockAll
+    /* this is unused, but the underlying function is called from LockAll */
     .macro LockLastTalked
     .short 692
     .endm

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -76,7 +76,7 @@ or Uproar is in effect.
      UpdateVar OPCODE_ADD, BTLVAR_FAINTED_MON, BATTLER_ENEMY_SLOT_1
      UpdateVar OPCODE_RIGHT_SHIFT, BTLVAR_CALC_TEMP, 0x00000001
      CompareVarToValue OPCODE_NEQ, BTLVAR_CALC_TEMP, 0x00000000, _208
--    ; BUG: Acid Rain (see docs/bugs_and_glitches.md)
+-    // BUG: Acid Rain (see docs/bugs_and_glitches.md)
 -    UpdateVarFromVar OPCODE_SUB_TO_ZERO, BTLVAR_FIELD_CONDITIONS, BTLVAR_SCRIPT_TEMP
 +    UpdateVarFromVar OPCODE_SET, BTLVAR_FAINTED_MON, BTLVAR_SCRIPT_TEMP
      Call BATTLE_SUBSCRIPT_POP_ATTACKER_AND_DEFENDER

--- a/res/battle/scripts/effects/effect_script_0000.s
+++ b/res/battle/scripts/effects/effect_script_0000.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0001.s
+++ b/res/battle/scripts/effects/effect_script_0001.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0002.s
+++ b/res/battle/scripts/effects/effect_script_0002.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0003.s
+++ b/res/battle/scripts/effects/effect_script_0003.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0004.s
+++ b/res/battle/scripts/effects/effect_script_0004.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0005.s
+++ b/res/battle/scripts/effects/effect_script_0005.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0006.s
+++ b/res/battle/scripts/effects/effect_script_0006.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0007.s
+++ b/res/battle/scripts/effects/effect_script_0007.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0008.s
+++ b/res/battle/scripts/effects/effect_script_0008.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0009.s
+++ b/res/battle/scripts/effects/effect_script_0009.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0010.s
+++ b/res/battle/scripts/effects/effect_script_0010.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0011.s
+++ b/res/battle/scripts/effects/effect_script_0011.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0012.s
+++ b/res/battle/scripts/effects/effect_script_0012.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0013.s
+++ b/res/battle/scripts/effects/effect_script_0013.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0014.s
+++ b/res/battle/scripts/effects/effect_script_0014.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0015.s
+++ b/res/battle/scripts/effects/effect_script_0015.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0016.s
+++ b/res/battle/scripts/effects/effect_script_0016.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0017.s
+++ b/res/battle/scripts/effects/effect_script_0017.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0018.s
+++ b/res/battle/scripts/effects/effect_script_0018.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0019.s
+++ b/res/battle/scripts/effects/effect_script_0019.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0020.s
+++ b/res/battle/scripts/effects/effect_script_0020.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0021.s
+++ b/res/battle/scripts/effects/effect_script_0021.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0022.s
+++ b/res/battle/scripts/effects/effect_script_0022.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0023.s
+++ b/res/battle/scripts/effects/effect_script_0023.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0024.s
+++ b/res/battle/scripts/effects/effect_script_0024.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0025.s
+++ b/res/battle/scripts/effects/effect_script_0025.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0026.s
+++ b/res/battle/scripts/effects/effect_script_0026.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0027.s
+++ b/res/battle/scripts/effects/effect_script_0027.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0028.s
+++ b/res/battle/scripts/effects/effect_script_0028.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0029.s
+++ b/res/battle/scripts/effects/effect_script_0029.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0030.s
+++ b/res/battle/scripts/effects/effect_script_0030.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0031.s
+++ b/res/battle/scripts/effects/effect_script_0031.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0032.s
+++ b/res/battle/scripts/effects/effect_script_0032.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0033.s
+++ b/res/battle/scripts/effects/effect_script_0033.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0034.s
+++ b/res/battle/scripts/effects/effect_script_0034.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0035.s
+++ b/res/battle/scripts/effects/effect_script_0035.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0036.s
+++ b/res/battle/scripts/effects/effect_script_0036.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0037.s
+++ b/res/battle/scripts/effects/effect_script_0037.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0038.s
+++ b/res/battle/scripts/effects/effect_script_0038.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0039.s
+++ b/res/battle/scripts/effects/effect_script_0039.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0040.s
+++ b/res/battle/scripts/effects/effect_script_0040.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0041.s
+++ b/res/battle/scripts/effects/effect_script_0041.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0042.s
+++ b/res/battle/scripts/effects/effect_script_0042.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0043.s
+++ b/res/battle/scripts/effects/effect_script_0043.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0044.s
+++ b/res/battle/scripts/effects/effect_script_0044.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0045.s
+++ b/res/battle/scripts/effects/effect_script_0045.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0046.s
+++ b/res/battle/scripts/effects/effect_script_0046.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0047.s
+++ b/res/battle/scripts/effects/effect_script_0047.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0048.s
+++ b/res/battle/scripts/effects/effect_script_0048.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0049.s
+++ b/res/battle/scripts/effects/effect_script_0049.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0050.s
+++ b/res/battle/scripts/effects/effect_script_0050.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0051.s
+++ b/res/battle/scripts/effects/effect_script_0051.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0052.s
+++ b/res/battle/scripts/effects/effect_script_0052.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0053.s
+++ b/res/battle/scripts/effects/effect_script_0053.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0054.s
+++ b/res/battle/scripts/effects/effect_script_0054.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0055.s
+++ b/res/battle/scripts/effects/effect_script_0055.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0056.s
+++ b/res/battle/scripts/effects/effect_script_0056.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0057.s
+++ b/res/battle/scripts/effects/effect_script_0057.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0058.s
+++ b/res/battle/scripts/effects/effect_script_0058.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0059.s
+++ b/res/battle/scripts/effects/effect_script_0059.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0060.s
+++ b/res/battle/scripts/effects/effect_script_0060.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0061.s
+++ b/res/battle/scripts/effects/effect_script_0061.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0062.s
+++ b/res/battle/scripts/effects/effect_script_0062.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0063.s
+++ b/res/battle/scripts/effects/effect_script_0063.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0064.s
+++ b/res/battle/scripts/effects/effect_script_0064.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0065.s
+++ b/res/battle/scripts/effects/effect_script_0065.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0066.s
+++ b/res/battle/scripts/effects/effect_script_0066.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0067.s
+++ b/res/battle/scripts/effects/effect_script_0067.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0068.s
+++ b/res/battle/scripts/effects/effect_script_0068.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0069.s
+++ b/res/battle/scripts/effects/effect_script_0069.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0070.s
+++ b/res/battle/scripts/effects/effect_script_0070.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0071.s
+++ b/res/battle/scripts/effects/effect_script_0071.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0072.s
+++ b/res/battle/scripts/effects/effect_script_0072.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0073.s
+++ b/res/battle/scripts/effects/effect_script_0073.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0074.s
+++ b/res/battle/scripts/effects/effect_script_0074.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0075.s
+++ b/res/battle/scripts/effects/effect_script_0075.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0076.s
+++ b/res/battle/scripts/effects/effect_script_0076.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0077.s
+++ b/res/battle/scripts/effects/effect_script_0077.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0078.s
+++ b/res/battle/scripts/effects/effect_script_0078.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0079.s
+++ b/res/battle/scripts/effects/effect_script_0079.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0080.s
+++ b/res/battle/scripts/effects/effect_script_0080.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0081.s
+++ b/res/battle/scripts/effects/effect_script_0081.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0082.s
+++ b/res/battle/scripts/effects/effect_script_0082.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0083.s
+++ b/res/battle/scripts/effects/effect_script_0083.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0084.s
+++ b/res/battle/scripts/effects/effect_script_0084.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0085.s
+++ b/res/battle/scripts/effects/effect_script_0085.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0086.s
+++ b/res/battle/scripts/effects/effect_script_0086.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0087.s
+++ b/res/battle/scripts/effects/effect_script_0087.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0088.s
+++ b/res/battle/scripts/effects/effect_script_0088.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0089.s
+++ b/res/battle/scripts/effects/effect_script_0089.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0090.s
+++ b/res/battle/scripts/effects/effect_script_0090.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0091.s
+++ b/res/battle/scripts/effects/effect_script_0091.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0092.s
+++ b/res/battle/scripts/effects/effect_script_0092.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0093.s
+++ b/res/battle/scripts/effects/effect_script_0093.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0094.s
+++ b/res/battle/scripts/effects/effect_script_0094.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0095.s
+++ b/res/battle/scripts/effects/effect_script_0095.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0096.s
+++ b/res/battle/scripts/effects/effect_script_0096.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0097.s
+++ b/res/battle/scripts/effects/effect_script_0097.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0098.s
+++ b/res/battle/scripts/effects/effect_script_0098.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0099.s
+++ b/res/battle/scripts/effects/effect_script_0099.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0100.s
+++ b/res/battle/scripts/effects/effect_script_0100.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0101.s
+++ b/res/battle/scripts/effects/effect_script_0101.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0102.s
+++ b/res/battle/scripts/effects/effect_script_0102.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0103.s
+++ b/res/battle/scripts/effects/effect_script_0103.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0104.s
+++ b/res/battle/scripts/effects/effect_script_0104.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0105.s
+++ b/res/battle/scripts/effects/effect_script_0105.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0106.s
+++ b/res/battle/scripts/effects/effect_script_0106.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0107.s
+++ b/res/battle/scripts/effects/effect_script_0107.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0108.s
+++ b/res/battle/scripts/effects/effect_script_0108.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0109.s
+++ b/res/battle/scripts/effects/effect_script_0109.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0110.s
+++ b/res/battle/scripts/effects/effect_script_0110.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0111.s
+++ b/res/battle/scripts/effects/effect_script_0111.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0112.s
+++ b/res/battle/scripts/effects/effect_script_0112.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0113.s
+++ b/res/battle/scripts/effects/effect_script_0113.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0114.s
+++ b/res/battle/scripts/effects/effect_script_0114.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0115.s
+++ b/res/battle/scripts/effects/effect_script_0115.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0116.s
+++ b/res/battle/scripts/effects/effect_script_0116.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0117.s
+++ b/res/battle/scripts/effects/effect_script_0117.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0118.s
+++ b/res/battle/scripts/effects/effect_script_0118.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0119.s
+++ b/res/battle/scripts/effects/effect_script_0119.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0120.s
+++ b/res/battle/scripts/effects/effect_script_0120.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0121.s
+++ b/res/battle/scripts/effects/effect_script_0121.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0122.s
+++ b/res/battle/scripts/effects/effect_script_0122.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0123.s
+++ b/res/battle/scripts/effects/effect_script_0123.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0124.s
+++ b/res/battle/scripts/effects/effect_script_0124.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0125.s
+++ b/res/battle/scripts/effects/effect_script_0125.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0126.s
+++ b/res/battle/scripts/effects/effect_script_0126.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0127.s
+++ b/res/battle/scripts/effects/effect_script_0127.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0128.s
+++ b/res/battle/scripts/effects/effect_script_0128.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0129.s
+++ b/res/battle/scripts/effects/effect_script_0129.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0130.s
+++ b/res/battle/scripts/effects/effect_script_0130.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0131.s
+++ b/res/battle/scripts/effects/effect_script_0131.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0132.s
+++ b/res/battle/scripts/effects/effect_script_0132.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0133.s
+++ b/res/battle/scripts/effects/effect_script_0133.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0134.s
+++ b/res/battle/scripts/effects/effect_script_0134.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0135.s
+++ b/res/battle/scripts/effects/effect_script_0135.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0136.s
+++ b/res/battle/scripts/effects/effect_script_0136.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0137.s
+++ b/res/battle/scripts/effects/effect_script_0137.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0138.s
+++ b/res/battle/scripts/effects/effect_script_0138.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0139.s
+++ b/res/battle/scripts/effects/effect_script_0139.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0140.s
+++ b/res/battle/scripts/effects/effect_script_0140.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0141.s
+++ b/res/battle/scripts/effects/effect_script_0141.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0142.s
+++ b/res/battle/scripts/effects/effect_script_0142.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0143.s
+++ b/res/battle/scripts/effects/effect_script_0143.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0144.s
+++ b/res/battle/scripts/effects/effect_script_0144.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0145.s
+++ b/res/battle/scripts/effects/effect_script_0145.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0146.s
+++ b/res/battle/scripts/effects/effect_script_0146.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0147.s
+++ b/res/battle/scripts/effects/effect_script_0147.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0148.s
+++ b/res/battle/scripts/effects/effect_script_0148.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0149.s
+++ b/res/battle/scripts/effects/effect_script_0149.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0150.s
+++ b/res/battle/scripts/effects/effect_script_0150.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0151.s
+++ b/res/battle/scripts/effects/effect_script_0151.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0152.s
+++ b/res/battle/scripts/effects/effect_script_0152.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0153.s
+++ b/res/battle/scripts/effects/effect_script_0153.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0154.s
+++ b/res/battle/scripts/effects/effect_script_0154.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0155.s
+++ b/res/battle/scripts/effects/effect_script_0155.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0156.s
+++ b/res/battle/scripts/effects/effect_script_0156.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0157.s
+++ b/res/battle/scripts/effects/effect_script_0157.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0158.s
+++ b/res/battle/scripts/effects/effect_script_0158.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0159.s
+++ b/res/battle/scripts/effects/effect_script_0159.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0160.s
+++ b/res/battle/scripts/effects/effect_script_0160.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0161.s
+++ b/res/battle/scripts/effects/effect_script_0161.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0162.s
+++ b/res/battle/scripts/effects/effect_script_0162.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0163.s
+++ b/res/battle/scripts/effects/effect_script_0163.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0164.s
+++ b/res/battle/scripts/effects/effect_script_0164.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0165.s
+++ b/res/battle/scripts/effects/effect_script_0165.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0166.s
+++ b/res/battle/scripts/effects/effect_script_0166.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0167.s
+++ b/res/battle/scripts/effects/effect_script_0167.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0168.s
+++ b/res/battle/scripts/effects/effect_script_0168.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0169.s
+++ b/res/battle/scripts/effects/effect_script_0169.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0170.s
+++ b/res/battle/scripts/effects/effect_script_0170.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0171.s
+++ b/res/battle/scripts/effects/effect_script_0171.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0172.s
+++ b/res/battle/scripts/effects/effect_script_0172.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0173.s
+++ b/res/battle/scripts/effects/effect_script_0173.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0174.s
+++ b/res/battle/scripts/effects/effect_script_0174.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0175.s
+++ b/res/battle/scripts/effects/effect_script_0175.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0176.s
+++ b/res/battle/scripts/effects/effect_script_0176.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0177.s
+++ b/res/battle/scripts/effects/effect_script_0177.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0178.s
+++ b/res/battle/scripts/effects/effect_script_0178.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0179.s
+++ b/res/battle/scripts/effects/effect_script_0179.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0180.s
+++ b/res/battle/scripts/effects/effect_script_0180.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0181.s
+++ b/res/battle/scripts/effects/effect_script_0181.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0182.s
+++ b/res/battle/scripts/effects/effect_script_0182.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0183.s
+++ b/res/battle/scripts/effects/effect_script_0183.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0184.s
+++ b/res/battle/scripts/effects/effect_script_0184.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0185.s
+++ b/res/battle/scripts/effects/effect_script_0185.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0186.s
+++ b/res/battle/scripts/effects/effect_script_0186.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0187.s
+++ b/res/battle/scripts/effects/effect_script_0187.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0188.s
+++ b/res/battle/scripts/effects/effect_script_0188.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0189.s
+++ b/res/battle/scripts/effects/effect_script_0189.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0190.s
+++ b/res/battle/scripts/effects/effect_script_0190.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0191.s
+++ b/res/battle/scripts/effects/effect_script_0191.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0192.s
+++ b/res/battle/scripts/effects/effect_script_0192.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0193.s
+++ b/res/battle/scripts/effects/effect_script_0193.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0194.s
+++ b/res/battle/scripts/effects/effect_script_0194.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0195.s
+++ b/res/battle/scripts/effects/effect_script_0195.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0196.s
+++ b/res/battle/scripts/effects/effect_script_0196.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0197.s
+++ b/res/battle/scripts/effects/effect_script_0197.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0198.s
+++ b/res/battle/scripts/effects/effect_script_0198.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0199.s
+++ b/res/battle/scripts/effects/effect_script_0199.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0200.s
+++ b/res/battle/scripts/effects/effect_script_0200.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0201.s
+++ b/res/battle/scripts/effects/effect_script_0201.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0202.s
+++ b/res/battle/scripts/effects/effect_script_0202.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0203.s
+++ b/res/battle/scripts/effects/effect_script_0203.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0204.s
+++ b/res/battle/scripts/effects/effect_script_0204.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0205.s
+++ b/res/battle/scripts/effects/effect_script_0205.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0206.s
+++ b/res/battle/scripts/effects/effect_script_0206.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0207.s
+++ b/res/battle/scripts/effects/effect_script_0207.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0208.s
+++ b/res/battle/scripts/effects/effect_script_0208.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0209.s
+++ b/res/battle/scripts/effects/effect_script_0209.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0210.s
+++ b/res/battle/scripts/effects/effect_script_0210.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0211.s
+++ b/res/battle/scripts/effects/effect_script_0211.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0212.s
+++ b/res/battle/scripts/effects/effect_script_0212.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0213.s
+++ b/res/battle/scripts/effects/effect_script_0213.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0214.s
+++ b/res/battle/scripts/effects/effect_script_0214.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0215.s
+++ b/res/battle/scripts/effects/effect_script_0215.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0216.s
+++ b/res/battle/scripts/effects/effect_script_0216.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0217.s
+++ b/res/battle/scripts/effects/effect_script_0217.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0218.s
+++ b/res/battle/scripts/effects/effect_script_0218.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0219.s
+++ b/res/battle/scripts/effects/effect_script_0219.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0220.s
+++ b/res/battle/scripts/effects/effect_script_0220.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0221.s
+++ b/res/battle/scripts/effects/effect_script_0221.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0222.s
+++ b/res/battle/scripts/effects/effect_script_0222.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0223.s
+++ b/res/battle/scripts/effects/effect_script_0223.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0224.s
+++ b/res/battle/scripts/effects/effect_script_0224.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0225.s
+++ b/res/battle/scripts/effects/effect_script_0225.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0226.s
+++ b/res/battle/scripts/effects/effect_script_0226.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0227.s
+++ b/res/battle/scripts/effects/effect_script_0227.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0228.s
+++ b/res/battle/scripts/effects/effect_script_0228.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0229.s
+++ b/res/battle/scripts/effects/effect_script_0229.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0230.s
+++ b/res/battle/scripts/effects/effect_script_0230.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0231.s
+++ b/res/battle/scripts/effects/effect_script_0231.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0232.s
+++ b/res/battle/scripts/effects/effect_script_0232.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0233.s
+++ b/res/battle/scripts/effects/effect_script_0233.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0234.s
+++ b/res/battle/scripts/effects/effect_script_0234.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0235.s
+++ b/res/battle/scripts/effects/effect_script_0235.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0236.s
+++ b/res/battle/scripts/effects/effect_script_0236.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0237.s
+++ b/res/battle/scripts/effects/effect_script_0237.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0238.s
+++ b/res/battle/scripts/effects/effect_script_0238.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0239.s
+++ b/res/battle/scripts/effects/effect_script_0239.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0240.s
+++ b/res/battle/scripts/effects/effect_script_0240.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0241.s
+++ b/res/battle/scripts/effects/effect_script_0241.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0242.s
+++ b/res/battle/scripts/effects/effect_script_0242.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0243.s
+++ b/res/battle/scripts/effects/effect_script_0243.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0244.s
+++ b/res/battle/scripts/effects/effect_script_0244.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0245.s
+++ b/res/battle/scripts/effects/effect_script_0245.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0246.s
+++ b/res/battle/scripts/effects/effect_script_0246.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0247.s
+++ b/res/battle/scripts/effects/effect_script_0247.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0248.s
+++ b/res/battle/scripts/effects/effect_script_0248.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0249.s
+++ b/res/battle/scripts/effects/effect_script_0249.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0250.s
+++ b/res/battle/scripts/effects/effect_script_0250.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0251.s
+++ b/res/battle/scripts/effects/effect_script_0251.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0252.s
+++ b/res/battle/scripts/effects/effect_script_0252.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0253.s
+++ b/res/battle/scripts/effects/effect_script_0253.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0254.s
+++ b/res/battle/scripts/effects/effect_script_0254.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0255.s
+++ b/res/battle/scripts/effects/effect_script_0255.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0256.s
+++ b/res/battle/scripts/effects/effect_script_0256.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0257.s
+++ b/res/battle/scripts/effects/effect_script_0257.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0258.s
+++ b/res/battle/scripts/effects/effect_script_0258.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0259.s
+++ b/res/battle/scripts/effects/effect_script_0259.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0260.s
+++ b/res/battle/scripts/effects/effect_script_0260.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0261.s
+++ b/res/battle/scripts/effects/effect_script_0261.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0262.s
+++ b/res/battle/scripts/effects/effect_script_0262.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0263.s
+++ b/res/battle/scripts/effects/effect_script_0263.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0264.s
+++ b/res/battle/scripts/effects/effect_script_0264.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0265.s
+++ b/res/battle/scripts/effects/effect_script_0265.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0266.s
+++ b/res/battle/scripts/effects/effect_script_0266.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0267.s
+++ b/res/battle/scripts/effects/effect_script_0267.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0268.s
+++ b/res/battle/scripts/effects/effect_script_0268.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0269.s
+++ b/res/battle/scripts/effects/effect_script_0269.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0270.s
+++ b/res/battle/scripts/effects/effect_script_0270.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0271.s
+++ b/res/battle/scripts/effects/effect_script_0271.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0272.s
+++ b/res/battle/scripts/effects/effect_script_0272.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0273.s
+++ b/res/battle/scripts/effects/effect_script_0273.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0274.s
+++ b/res/battle/scripts/effects/effect_script_0274.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0275.s
+++ b/res/battle/scripts/effects/effect_script_0275.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/effects/effect_script_0276.s
+++ b/res/battle/scripts/effects/effect_script_0276.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/meson.build
+++ b/res/battle/scripts/meson.build
@@ -2,35 +2,12 @@ subdir('effects')
 subdir('moves')
 subdir('subscripts')
 
-relative_source_root = fs.relative_to(meson.project_source_root(), meson.project_build_root())
 relative_build_dir = fs.relative_to(meson.current_build_dir(), meson.project_build_root())
-
-s_to_bin_gen = generator(make_script_bin_sh,
-    arguments: [
-        '--mwrap',
-        '-i', relative_source_root / 'include',
-        '-i', relative_source_root / 'asm',
-        '-i', '.' / 'res' / 'text',
-        '-i', '.' / 'res',
-        '-i', '.',
-        '--assembler', mwrap_exe.full_path(),
-        '--objcopy', arm_none_eabi_objcopy_exe.full_path(),
-        '@EXTRA_ARGS@',
-        '@INPUT@',
-    ],
-    depends: [
-        message_banks_narc, # for GMM headers
-        asm_consts_generators, # for ASM headers
-        c_consts_generators, # for C headers
-    ],
-    output: '@BASENAME@'
-)
-
-sub_seq_basename = 'sub_seq'
 
 be_seq_target_name = 'be_seq.narc'
 waza_seq_target_name = 'waza_seq.narc'
 
+sub_seq_basename = 'sub_seq'
 sub_seq_narc_name = sub_seq_basename + '.narc'
 sub_seq_naix_name = sub_seq_basename + '.naix'
 

--- a/res/battle/scripts/moves/move_script_0000.s
+++ b/res/battle/scripts/moves/move_script_0000.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0001.s
+++ b/res/battle/scripts/moves/move_script_0001.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0002.s
+++ b/res/battle/scripts/moves/move_script_0002.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0003.s
+++ b/res/battle/scripts/moves/move_script_0003.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0004.s
+++ b/res/battle/scripts/moves/move_script_0004.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0005.s
+++ b/res/battle/scripts/moves/move_script_0005.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0006.s
+++ b/res/battle/scripts/moves/move_script_0006.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0007.s
+++ b/res/battle/scripts/moves/move_script_0007.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0008.s
+++ b/res/battle/scripts/moves/move_script_0008.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0009.s
+++ b/res/battle/scripts/moves/move_script_0009.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0010.s
+++ b/res/battle/scripts/moves/move_script_0010.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0011.s
+++ b/res/battle/scripts/moves/move_script_0011.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0012.s
+++ b/res/battle/scripts/moves/move_script_0012.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0013.s
+++ b/res/battle/scripts/moves/move_script_0013.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0014.s
+++ b/res/battle/scripts/moves/move_script_0014.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0015.s
+++ b/res/battle/scripts/moves/move_script_0015.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0016.s
+++ b/res/battle/scripts/moves/move_script_0016.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0017.s
+++ b/res/battle/scripts/moves/move_script_0017.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0018.s
+++ b/res/battle/scripts/moves/move_script_0018.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0019.s
+++ b/res/battle/scripts/moves/move_script_0019.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0020.s
+++ b/res/battle/scripts/moves/move_script_0020.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0021.s
+++ b/res/battle/scripts/moves/move_script_0021.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0022.s
+++ b/res/battle/scripts/moves/move_script_0022.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0023.s
+++ b/res/battle/scripts/moves/move_script_0023.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0024.s
+++ b/res/battle/scripts/moves/move_script_0024.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0025.s
+++ b/res/battle/scripts/moves/move_script_0025.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0026.s
+++ b/res/battle/scripts/moves/move_script_0026.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0027.s
+++ b/res/battle/scripts/moves/move_script_0027.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0028.s
+++ b/res/battle/scripts/moves/move_script_0028.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0029.s
+++ b/res/battle/scripts/moves/move_script_0029.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0030.s
+++ b/res/battle/scripts/moves/move_script_0030.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0031.s
+++ b/res/battle/scripts/moves/move_script_0031.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0032.s
+++ b/res/battle/scripts/moves/move_script_0032.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0033.s
+++ b/res/battle/scripts/moves/move_script_0033.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0034.s
+++ b/res/battle/scripts/moves/move_script_0034.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0035.s
+++ b/res/battle/scripts/moves/move_script_0035.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0036.s
+++ b/res/battle/scripts/moves/move_script_0036.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0037.s
+++ b/res/battle/scripts/moves/move_script_0037.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0038.s
+++ b/res/battle/scripts/moves/move_script_0038.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0039.s
+++ b/res/battle/scripts/moves/move_script_0039.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0040.s
+++ b/res/battle/scripts/moves/move_script_0040.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0041.s
+++ b/res/battle/scripts/moves/move_script_0041.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0042.s
+++ b/res/battle/scripts/moves/move_script_0042.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0043.s
+++ b/res/battle/scripts/moves/move_script_0043.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0044.s
+++ b/res/battle/scripts/moves/move_script_0044.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0045.s
+++ b/res/battle/scripts/moves/move_script_0045.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0046.s
+++ b/res/battle/scripts/moves/move_script_0046.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0047.s
+++ b/res/battle/scripts/moves/move_script_0047.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0048.s
+++ b/res/battle/scripts/moves/move_script_0048.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0049.s
+++ b/res/battle/scripts/moves/move_script_0049.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0050.s
+++ b/res/battle/scripts/moves/move_script_0050.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0051.s
+++ b/res/battle/scripts/moves/move_script_0051.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0052.s
+++ b/res/battle/scripts/moves/move_script_0052.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0053.s
+++ b/res/battle/scripts/moves/move_script_0053.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0054.s
+++ b/res/battle/scripts/moves/move_script_0054.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0055.s
+++ b/res/battle/scripts/moves/move_script_0055.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0056.s
+++ b/res/battle/scripts/moves/move_script_0056.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0057.s
+++ b/res/battle/scripts/moves/move_script_0057.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0058.s
+++ b/res/battle/scripts/moves/move_script_0058.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0059.s
+++ b/res/battle/scripts/moves/move_script_0059.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0060.s
+++ b/res/battle/scripts/moves/move_script_0060.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0061.s
+++ b/res/battle/scripts/moves/move_script_0061.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0062.s
+++ b/res/battle/scripts/moves/move_script_0062.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0063.s
+++ b/res/battle/scripts/moves/move_script_0063.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0064.s
+++ b/res/battle/scripts/moves/move_script_0064.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0065.s
+++ b/res/battle/scripts/moves/move_script_0065.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0066.s
+++ b/res/battle/scripts/moves/move_script_0066.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0067.s
+++ b/res/battle/scripts/moves/move_script_0067.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0068.s
+++ b/res/battle/scripts/moves/move_script_0068.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0069.s
+++ b/res/battle/scripts/moves/move_script_0069.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0070.s
+++ b/res/battle/scripts/moves/move_script_0070.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0071.s
+++ b/res/battle/scripts/moves/move_script_0071.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0072.s
+++ b/res/battle/scripts/moves/move_script_0072.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0073.s
+++ b/res/battle/scripts/moves/move_script_0073.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0074.s
+++ b/res/battle/scripts/moves/move_script_0074.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0075.s
+++ b/res/battle/scripts/moves/move_script_0075.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0076.s
+++ b/res/battle/scripts/moves/move_script_0076.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0077.s
+++ b/res/battle/scripts/moves/move_script_0077.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0078.s
+++ b/res/battle/scripts/moves/move_script_0078.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0079.s
+++ b/res/battle/scripts/moves/move_script_0079.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0080.s
+++ b/res/battle/scripts/moves/move_script_0080.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0081.s
+++ b/res/battle/scripts/moves/move_script_0081.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0082.s
+++ b/res/battle/scripts/moves/move_script_0082.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0083.s
+++ b/res/battle/scripts/moves/move_script_0083.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0084.s
+++ b/res/battle/scripts/moves/move_script_0084.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0085.s
+++ b/res/battle/scripts/moves/move_script_0085.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0086.s
+++ b/res/battle/scripts/moves/move_script_0086.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0087.s
+++ b/res/battle/scripts/moves/move_script_0087.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0088.s
+++ b/res/battle/scripts/moves/move_script_0088.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0089.s
+++ b/res/battle/scripts/moves/move_script_0089.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0090.s
+++ b/res/battle/scripts/moves/move_script_0090.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0091.s
+++ b/res/battle/scripts/moves/move_script_0091.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0092.s
+++ b/res/battle/scripts/moves/move_script_0092.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0093.s
+++ b/res/battle/scripts/moves/move_script_0093.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0094.s
+++ b/res/battle/scripts/moves/move_script_0094.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0095.s
+++ b/res/battle/scripts/moves/move_script_0095.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0096.s
+++ b/res/battle/scripts/moves/move_script_0096.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0097.s
+++ b/res/battle/scripts/moves/move_script_0097.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0098.s
+++ b/res/battle/scripts/moves/move_script_0098.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0099.s
+++ b/res/battle/scripts/moves/move_script_0099.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0100.s
+++ b/res/battle/scripts/moves/move_script_0100.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0101.s
+++ b/res/battle/scripts/moves/move_script_0101.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0102.s
+++ b/res/battle/scripts/moves/move_script_0102.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0103.s
+++ b/res/battle/scripts/moves/move_script_0103.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0104.s
+++ b/res/battle/scripts/moves/move_script_0104.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0105.s
+++ b/res/battle/scripts/moves/move_script_0105.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0106.s
+++ b/res/battle/scripts/moves/move_script_0106.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0107.s
+++ b/res/battle/scripts/moves/move_script_0107.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0108.s
+++ b/res/battle/scripts/moves/move_script_0108.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0109.s
+++ b/res/battle/scripts/moves/move_script_0109.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0110.s
+++ b/res/battle/scripts/moves/move_script_0110.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0111.s
+++ b/res/battle/scripts/moves/move_script_0111.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0112.s
+++ b/res/battle/scripts/moves/move_script_0112.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0113.s
+++ b/res/battle/scripts/moves/move_script_0113.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0114.s
+++ b/res/battle/scripts/moves/move_script_0114.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0115.s
+++ b/res/battle/scripts/moves/move_script_0115.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0116.s
+++ b/res/battle/scripts/moves/move_script_0116.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0117.s
+++ b/res/battle/scripts/moves/move_script_0117.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0118.s
+++ b/res/battle/scripts/moves/move_script_0118.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0119.s
+++ b/res/battle/scripts/moves/move_script_0119.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0120.s
+++ b/res/battle/scripts/moves/move_script_0120.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0121.s
+++ b/res/battle/scripts/moves/move_script_0121.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0122.s
+++ b/res/battle/scripts/moves/move_script_0122.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0123.s
+++ b/res/battle/scripts/moves/move_script_0123.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0124.s
+++ b/res/battle/scripts/moves/move_script_0124.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0125.s
+++ b/res/battle/scripts/moves/move_script_0125.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0126.s
+++ b/res/battle/scripts/moves/move_script_0126.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0127.s
+++ b/res/battle/scripts/moves/move_script_0127.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0128.s
+++ b/res/battle/scripts/moves/move_script_0128.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0129.s
+++ b/res/battle/scripts/moves/move_script_0129.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0130.s
+++ b/res/battle/scripts/moves/move_script_0130.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0131.s
+++ b/res/battle/scripts/moves/move_script_0131.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0132.s
+++ b/res/battle/scripts/moves/move_script_0132.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0133.s
+++ b/res/battle/scripts/moves/move_script_0133.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0134.s
+++ b/res/battle/scripts/moves/move_script_0134.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0135.s
+++ b/res/battle/scripts/moves/move_script_0135.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0136.s
+++ b/res/battle/scripts/moves/move_script_0136.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0137.s
+++ b/res/battle/scripts/moves/move_script_0137.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0138.s
+++ b/res/battle/scripts/moves/move_script_0138.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0139.s
+++ b/res/battle/scripts/moves/move_script_0139.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0140.s
+++ b/res/battle/scripts/moves/move_script_0140.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0141.s
+++ b/res/battle/scripts/moves/move_script_0141.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0142.s
+++ b/res/battle/scripts/moves/move_script_0142.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0143.s
+++ b/res/battle/scripts/moves/move_script_0143.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0144.s
+++ b/res/battle/scripts/moves/move_script_0144.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0145.s
+++ b/res/battle/scripts/moves/move_script_0145.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0146.s
+++ b/res/battle/scripts/moves/move_script_0146.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0147.s
+++ b/res/battle/scripts/moves/move_script_0147.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0148.s
+++ b/res/battle/scripts/moves/move_script_0148.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0149.s
+++ b/res/battle/scripts/moves/move_script_0149.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0150.s
+++ b/res/battle/scripts/moves/move_script_0150.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0151.s
+++ b/res/battle/scripts/moves/move_script_0151.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0152.s
+++ b/res/battle/scripts/moves/move_script_0152.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0153.s
+++ b/res/battle/scripts/moves/move_script_0153.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0154.s
+++ b/res/battle/scripts/moves/move_script_0154.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0155.s
+++ b/res/battle/scripts/moves/move_script_0155.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0156.s
+++ b/res/battle/scripts/moves/move_script_0156.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0157.s
+++ b/res/battle/scripts/moves/move_script_0157.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0158.s
+++ b/res/battle/scripts/moves/move_script_0158.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0159.s
+++ b/res/battle/scripts/moves/move_script_0159.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0160.s
+++ b/res/battle/scripts/moves/move_script_0160.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0161.s
+++ b/res/battle/scripts/moves/move_script_0161.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0162.s
+++ b/res/battle/scripts/moves/move_script_0162.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0163.s
+++ b/res/battle/scripts/moves/move_script_0163.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0164.s
+++ b/res/battle/scripts/moves/move_script_0164.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0165.s
+++ b/res/battle/scripts/moves/move_script_0165.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0166.s
+++ b/res/battle/scripts/moves/move_script_0166.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0167.s
+++ b/res/battle/scripts/moves/move_script_0167.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0168.s
+++ b/res/battle/scripts/moves/move_script_0168.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0169.s
+++ b/res/battle/scripts/moves/move_script_0169.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0170.s
+++ b/res/battle/scripts/moves/move_script_0170.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0171.s
+++ b/res/battle/scripts/moves/move_script_0171.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0172.s
+++ b/res/battle/scripts/moves/move_script_0172.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0173.s
+++ b/res/battle/scripts/moves/move_script_0173.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0174.s
+++ b/res/battle/scripts/moves/move_script_0174.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0175.s
+++ b/res/battle/scripts/moves/move_script_0175.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0176.s
+++ b/res/battle/scripts/moves/move_script_0176.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0177.s
+++ b/res/battle/scripts/moves/move_script_0177.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0178.s
+++ b/res/battle/scripts/moves/move_script_0178.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0179.s
+++ b/res/battle/scripts/moves/move_script_0179.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0180.s
+++ b/res/battle/scripts/moves/move_script_0180.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0181.s
+++ b/res/battle/scripts/moves/move_script_0181.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0182.s
+++ b/res/battle/scripts/moves/move_script_0182.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0183.s
+++ b/res/battle/scripts/moves/move_script_0183.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0184.s
+++ b/res/battle/scripts/moves/move_script_0184.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0185.s
+++ b/res/battle/scripts/moves/move_script_0185.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0186.s
+++ b/res/battle/scripts/moves/move_script_0186.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0187.s
+++ b/res/battle/scripts/moves/move_script_0187.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0188.s
+++ b/res/battle/scripts/moves/move_script_0188.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0189.s
+++ b/res/battle/scripts/moves/move_script_0189.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0190.s
+++ b/res/battle/scripts/moves/move_script_0190.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0191.s
+++ b/res/battle/scripts/moves/move_script_0191.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0192.s
+++ b/res/battle/scripts/moves/move_script_0192.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0193.s
+++ b/res/battle/scripts/moves/move_script_0193.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0194.s
+++ b/res/battle/scripts/moves/move_script_0194.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0195.s
+++ b/res/battle/scripts/moves/move_script_0195.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0196.s
+++ b/res/battle/scripts/moves/move_script_0196.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0197.s
+++ b/res/battle/scripts/moves/move_script_0197.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0198.s
+++ b/res/battle/scripts/moves/move_script_0198.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0199.s
+++ b/res/battle/scripts/moves/move_script_0199.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0200.s
+++ b/res/battle/scripts/moves/move_script_0200.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0201.s
+++ b/res/battle/scripts/moves/move_script_0201.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0202.s
+++ b/res/battle/scripts/moves/move_script_0202.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0203.s
+++ b/res/battle/scripts/moves/move_script_0203.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0204.s
+++ b/res/battle/scripts/moves/move_script_0204.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0205.s
+++ b/res/battle/scripts/moves/move_script_0205.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0206.s
+++ b/res/battle/scripts/moves/move_script_0206.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0207.s
+++ b/res/battle/scripts/moves/move_script_0207.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0208.s
+++ b/res/battle/scripts/moves/move_script_0208.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0209.s
+++ b/res/battle/scripts/moves/move_script_0209.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0210.s
+++ b/res/battle/scripts/moves/move_script_0210.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0211.s
+++ b/res/battle/scripts/moves/move_script_0211.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0212.s
+++ b/res/battle/scripts/moves/move_script_0212.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0213.s
+++ b/res/battle/scripts/moves/move_script_0213.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0214.s
+++ b/res/battle/scripts/moves/move_script_0214.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0215.s
+++ b/res/battle/scripts/moves/move_script_0215.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0216.s
+++ b/res/battle/scripts/moves/move_script_0216.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0217.s
+++ b/res/battle/scripts/moves/move_script_0217.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0218.s
+++ b/res/battle/scripts/moves/move_script_0218.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0219.s
+++ b/res/battle/scripts/moves/move_script_0219.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0220.s
+++ b/res/battle/scripts/moves/move_script_0220.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0221.s
+++ b/res/battle/scripts/moves/move_script_0221.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0222.s
+++ b/res/battle/scripts/moves/move_script_0222.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0223.s
+++ b/res/battle/scripts/moves/move_script_0223.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0224.s
+++ b/res/battle/scripts/moves/move_script_0224.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0225.s
+++ b/res/battle/scripts/moves/move_script_0225.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0226.s
+++ b/res/battle/scripts/moves/move_script_0226.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0227.s
+++ b/res/battle/scripts/moves/move_script_0227.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0228.s
+++ b/res/battle/scripts/moves/move_script_0228.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0229.s
+++ b/res/battle/scripts/moves/move_script_0229.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0230.s
+++ b/res/battle/scripts/moves/move_script_0230.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0231.s
+++ b/res/battle/scripts/moves/move_script_0231.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0232.s
+++ b/res/battle/scripts/moves/move_script_0232.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0233.s
+++ b/res/battle/scripts/moves/move_script_0233.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0234.s
+++ b/res/battle/scripts/moves/move_script_0234.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0235.s
+++ b/res/battle/scripts/moves/move_script_0235.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0236.s
+++ b/res/battle/scripts/moves/move_script_0236.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0237.s
+++ b/res/battle/scripts/moves/move_script_0237.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0238.s
+++ b/res/battle/scripts/moves/move_script_0238.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0239.s
+++ b/res/battle/scripts/moves/move_script_0239.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0240.s
+++ b/res/battle/scripts/moves/move_script_0240.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0241.s
+++ b/res/battle/scripts/moves/move_script_0241.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0242.s
+++ b/res/battle/scripts/moves/move_script_0242.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0243.s
+++ b/res/battle/scripts/moves/move_script_0243.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0244.s
+++ b/res/battle/scripts/moves/move_script_0244.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0245.s
+++ b/res/battle/scripts/moves/move_script_0245.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0246.s
+++ b/res/battle/scripts/moves/move_script_0246.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0247.s
+++ b/res/battle/scripts/moves/move_script_0247.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0248.s
+++ b/res/battle/scripts/moves/move_script_0248.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0249.s
+++ b/res/battle/scripts/moves/move_script_0249.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0250.s
+++ b/res/battle/scripts/moves/move_script_0250.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0251.s
+++ b/res/battle/scripts/moves/move_script_0251.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0252.s
+++ b/res/battle/scripts/moves/move_script_0252.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0253.s
+++ b/res/battle/scripts/moves/move_script_0253.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0254.s
+++ b/res/battle/scripts/moves/move_script_0254.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0255.s
+++ b/res/battle/scripts/moves/move_script_0255.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0256.s
+++ b/res/battle/scripts/moves/move_script_0256.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0257.s
+++ b/res/battle/scripts/moves/move_script_0257.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0258.s
+++ b/res/battle/scripts/moves/move_script_0258.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0259.s
+++ b/res/battle/scripts/moves/move_script_0259.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0260.s
+++ b/res/battle/scripts/moves/move_script_0260.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0261.s
+++ b/res/battle/scripts/moves/move_script_0261.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0262.s
+++ b/res/battle/scripts/moves/move_script_0262.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0263.s
+++ b/res/battle/scripts/moves/move_script_0263.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0264.s
+++ b/res/battle/scripts/moves/move_script_0264.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0265.s
+++ b/res/battle/scripts/moves/move_script_0265.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0266.s
+++ b/res/battle/scripts/moves/move_script_0266.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0267.s
+++ b/res/battle/scripts/moves/move_script_0267.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0268.s
+++ b/res/battle/scripts/moves/move_script_0268.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0269.s
+++ b/res/battle/scripts/moves/move_script_0269.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0270.s
+++ b/res/battle/scripts/moves/move_script_0270.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0271.s
+++ b/res/battle/scripts/moves/move_script_0271.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0272.s
+++ b/res/battle/scripts/moves/move_script_0272.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0273.s
+++ b/res/battle/scripts/moves/move_script_0273.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0274.s
+++ b/res/battle/scripts/moves/move_script_0274.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0275.s
+++ b/res/battle/scripts/moves/move_script_0275.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0276.s
+++ b/res/battle/scripts/moves/move_script_0276.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0277.s
+++ b/res/battle/scripts/moves/move_script_0277.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0278.s
+++ b/res/battle/scripts/moves/move_script_0278.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0279.s
+++ b/res/battle/scripts/moves/move_script_0279.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0280.s
+++ b/res/battle/scripts/moves/move_script_0280.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0281.s
+++ b/res/battle/scripts/moves/move_script_0281.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0282.s
+++ b/res/battle/scripts/moves/move_script_0282.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0283.s
+++ b/res/battle/scripts/moves/move_script_0283.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0284.s
+++ b/res/battle/scripts/moves/move_script_0284.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0285.s
+++ b/res/battle/scripts/moves/move_script_0285.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0286.s
+++ b/res/battle/scripts/moves/move_script_0286.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0287.s
+++ b/res/battle/scripts/moves/move_script_0287.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0288.s
+++ b/res/battle/scripts/moves/move_script_0288.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0289.s
+++ b/res/battle/scripts/moves/move_script_0289.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0290.s
+++ b/res/battle/scripts/moves/move_script_0290.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0291.s
+++ b/res/battle/scripts/moves/move_script_0291.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0292.s
+++ b/res/battle/scripts/moves/move_script_0292.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0293.s
+++ b/res/battle/scripts/moves/move_script_0293.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0294.s
+++ b/res/battle/scripts/moves/move_script_0294.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0295.s
+++ b/res/battle/scripts/moves/move_script_0295.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0296.s
+++ b/res/battle/scripts/moves/move_script_0296.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0297.s
+++ b/res/battle/scripts/moves/move_script_0297.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0298.s
+++ b/res/battle/scripts/moves/move_script_0298.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0299.s
+++ b/res/battle/scripts/moves/move_script_0299.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0300.s
+++ b/res/battle/scripts/moves/move_script_0300.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0301.s
+++ b/res/battle/scripts/moves/move_script_0301.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0302.s
+++ b/res/battle/scripts/moves/move_script_0302.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0303.s
+++ b/res/battle/scripts/moves/move_script_0303.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0304.s
+++ b/res/battle/scripts/moves/move_script_0304.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0305.s
+++ b/res/battle/scripts/moves/move_script_0305.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0306.s
+++ b/res/battle/scripts/moves/move_script_0306.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0307.s
+++ b/res/battle/scripts/moves/move_script_0307.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0308.s
+++ b/res/battle/scripts/moves/move_script_0308.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0309.s
+++ b/res/battle/scripts/moves/move_script_0309.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0310.s
+++ b/res/battle/scripts/moves/move_script_0310.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0311.s
+++ b/res/battle/scripts/moves/move_script_0311.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0312.s
+++ b/res/battle/scripts/moves/move_script_0312.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0313.s
+++ b/res/battle/scripts/moves/move_script_0313.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0314.s
+++ b/res/battle/scripts/moves/move_script_0314.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0315.s
+++ b/res/battle/scripts/moves/move_script_0315.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0316.s
+++ b/res/battle/scripts/moves/move_script_0316.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0317.s
+++ b/res/battle/scripts/moves/move_script_0317.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0318.s
+++ b/res/battle/scripts/moves/move_script_0318.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0319.s
+++ b/res/battle/scripts/moves/move_script_0319.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0320.s
+++ b/res/battle/scripts/moves/move_script_0320.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0321.s
+++ b/res/battle/scripts/moves/move_script_0321.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0322.s
+++ b/res/battle/scripts/moves/move_script_0322.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0323.s
+++ b/res/battle/scripts/moves/move_script_0323.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0324.s
+++ b/res/battle/scripts/moves/move_script_0324.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0325.s
+++ b/res/battle/scripts/moves/move_script_0325.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0326.s
+++ b/res/battle/scripts/moves/move_script_0326.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0327.s
+++ b/res/battle/scripts/moves/move_script_0327.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0328.s
+++ b/res/battle/scripts/moves/move_script_0328.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0329.s
+++ b/res/battle/scripts/moves/move_script_0329.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0330.s
+++ b/res/battle/scripts/moves/move_script_0330.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0331.s
+++ b/res/battle/scripts/moves/move_script_0331.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0332.s
+++ b/res/battle/scripts/moves/move_script_0332.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0333.s
+++ b/res/battle/scripts/moves/move_script_0333.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0334.s
+++ b/res/battle/scripts/moves/move_script_0334.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0335.s
+++ b/res/battle/scripts/moves/move_script_0335.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0336.s
+++ b/res/battle/scripts/moves/move_script_0336.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0337.s
+++ b/res/battle/scripts/moves/move_script_0337.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0338.s
+++ b/res/battle/scripts/moves/move_script_0338.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0339.s
+++ b/res/battle/scripts/moves/move_script_0339.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0340.s
+++ b/res/battle/scripts/moves/move_script_0340.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0341.s
+++ b/res/battle/scripts/moves/move_script_0341.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0342.s
+++ b/res/battle/scripts/moves/move_script_0342.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0343.s
+++ b/res/battle/scripts/moves/move_script_0343.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0344.s
+++ b/res/battle/scripts/moves/move_script_0344.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0345.s
+++ b/res/battle/scripts/moves/move_script_0345.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0346.s
+++ b/res/battle/scripts/moves/move_script_0346.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0347.s
+++ b/res/battle/scripts/moves/move_script_0347.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0348.s
+++ b/res/battle/scripts/moves/move_script_0348.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0349.s
+++ b/res/battle/scripts/moves/move_script_0349.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0350.s
+++ b/res/battle/scripts/moves/move_script_0350.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0351.s
+++ b/res/battle/scripts/moves/move_script_0351.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0352.s
+++ b/res/battle/scripts/moves/move_script_0352.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0353.s
+++ b/res/battle/scripts/moves/move_script_0353.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0354.s
+++ b/res/battle/scripts/moves/move_script_0354.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0355.s
+++ b/res/battle/scripts/moves/move_script_0355.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0356.s
+++ b/res/battle/scripts/moves/move_script_0356.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0357.s
+++ b/res/battle/scripts/moves/move_script_0357.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0358.s
+++ b/res/battle/scripts/moves/move_script_0358.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0359.s
+++ b/res/battle/scripts/moves/move_script_0359.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0360.s
+++ b/res/battle/scripts/moves/move_script_0360.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0361.s
+++ b/res/battle/scripts/moves/move_script_0361.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0362.s
+++ b/res/battle/scripts/moves/move_script_0362.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0363.s
+++ b/res/battle/scripts/moves/move_script_0363.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0364.s
+++ b/res/battle/scripts/moves/move_script_0364.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0365.s
+++ b/res/battle/scripts/moves/move_script_0365.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0366.s
+++ b/res/battle/scripts/moves/move_script_0366.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0367.s
+++ b/res/battle/scripts/moves/move_script_0367.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0368.s
+++ b/res/battle/scripts/moves/move_script_0368.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0369.s
+++ b/res/battle/scripts/moves/move_script_0369.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0370.s
+++ b/res/battle/scripts/moves/move_script_0370.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0371.s
+++ b/res/battle/scripts/moves/move_script_0371.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0372.s
+++ b/res/battle/scripts/moves/move_script_0372.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0373.s
+++ b/res/battle/scripts/moves/move_script_0373.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0374.s
+++ b/res/battle/scripts/moves/move_script_0374.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0375.s
+++ b/res/battle/scripts/moves/move_script_0375.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0376.s
+++ b/res/battle/scripts/moves/move_script_0376.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0377.s
+++ b/res/battle/scripts/moves/move_script_0377.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0378.s
+++ b/res/battle/scripts/moves/move_script_0378.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0379.s
+++ b/res/battle/scripts/moves/move_script_0379.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0380.s
+++ b/res/battle/scripts/moves/move_script_0380.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0381.s
+++ b/res/battle/scripts/moves/move_script_0381.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0382.s
+++ b/res/battle/scripts/moves/move_script_0382.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0383.s
+++ b/res/battle/scripts/moves/move_script_0383.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0384.s
+++ b/res/battle/scripts/moves/move_script_0384.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0385.s
+++ b/res/battle/scripts/moves/move_script_0385.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0386.s
+++ b/res/battle/scripts/moves/move_script_0386.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0387.s
+++ b/res/battle/scripts/moves/move_script_0387.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0388.s
+++ b/res/battle/scripts/moves/move_script_0388.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0389.s
+++ b/res/battle/scripts/moves/move_script_0389.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0390.s
+++ b/res/battle/scripts/moves/move_script_0390.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0391.s
+++ b/res/battle/scripts/moves/move_script_0391.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0392.s
+++ b/res/battle/scripts/moves/move_script_0392.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0393.s
+++ b/res/battle/scripts/moves/move_script_0393.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0394.s
+++ b/res/battle/scripts/moves/move_script_0394.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0395.s
+++ b/res/battle/scripts/moves/move_script_0395.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0396.s
+++ b/res/battle/scripts/moves/move_script_0396.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0397.s
+++ b/res/battle/scripts/moves/move_script_0397.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0398.s
+++ b/res/battle/scripts/moves/move_script_0398.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0399.s
+++ b/res/battle/scripts/moves/move_script_0399.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0400.s
+++ b/res/battle/scripts/moves/move_script_0400.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0401.s
+++ b/res/battle/scripts/moves/move_script_0401.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0402.s
+++ b/res/battle/scripts/moves/move_script_0402.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0403.s
+++ b/res/battle/scripts/moves/move_script_0403.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0404.s
+++ b/res/battle/scripts/moves/move_script_0404.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0405.s
+++ b/res/battle/scripts/moves/move_script_0405.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0406.s
+++ b/res/battle/scripts/moves/move_script_0406.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0407.s
+++ b/res/battle/scripts/moves/move_script_0407.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0408.s
+++ b/res/battle/scripts/moves/move_script_0408.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0409.s
+++ b/res/battle/scripts/moves/move_script_0409.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0410.s
+++ b/res/battle/scripts/moves/move_script_0410.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0411.s
+++ b/res/battle/scripts/moves/move_script_0411.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0412.s
+++ b/res/battle/scripts/moves/move_script_0412.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0413.s
+++ b/res/battle/scripts/moves/move_script_0413.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0414.s
+++ b/res/battle/scripts/moves/move_script_0414.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0415.s
+++ b/res/battle/scripts/moves/move_script_0415.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0416.s
+++ b/res/battle/scripts/moves/move_script_0416.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0417.s
+++ b/res/battle/scripts/moves/move_script_0417.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0418.s
+++ b/res/battle/scripts/moves/move_script_0418.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0419.s
+++ b/res/battle/scripts/moves/move_script_0419.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0420.s
+++ b/res/battle/scripts/moves/move_script_0420.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0421.s
+++ b/res/battle/scripts/moves/move_script_0421.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0422.s
+++ b/res/battle/scripts/moves/move_script_0422.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0423.s
+++ b/res/battle/scripts/moves/move_script_0423.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0424.s
+++ b/res/battle/scripts/moves/move_script_0424.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0425.s
+++ b/res/battle/scripts/moves/move_script_0425.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0426.s
+++ b/res/battle/scripts/moves/move_script_0426.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0427.s
+++ b/res/battle/scripts/moves/move_script_0427.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0428.s
+++ b/res/battle/scripts/moves/move_script_0428.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0429.s
+++ b/res/battle/scripts/moves/move_script_0429.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0430.s
+++ b/res/battle/scripts/moves/move_script_0430.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0431.s
+++ b/res/battle/scripts/moves/move_script_0431.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0432.s
+++ b/res/battle/scripts/moves/move_script_0432.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0433.s
+++ b/res/battle/scripts/moves/move_script_0433.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0434.s
+++ b/res/battle/scripts/moves/move_script_0434.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0435.s
+++ b/res/battle/scripts/moves/move_script_0435.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0436.s
+++ b/res/battle/scripts/moves/move_script_0436.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0437.s
+++ b/res/battle/scripts/moves/move_script_0437.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0438.s
+++ b/res/battle/scripts/moves/move_script_0438.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0439.s
+++ b/res/battle/scripts/moves/move_script_0439.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0440.s
+++ b/res/battle/scripts/moves/move_script_0440.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0441.s
+++ b/res/battle/scripts/moves/move_script_0441.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0442.s
+++ b/res/battle/scripts/moves/move_script_0442.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0443.s
+++ b/res/battle/scripts/moves/move_script_0443.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0444.s
+++ b/res/battle/scripts/moves/move_script_0444.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0445.s
+++ b/res/battle/scripts/moves/move_script_0445.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0446.s
+++ b/res/battle/scripts/moves/move_script_0446.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0447.s
+++ b/res/battle/scripts/moves/move_script_0447.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0448.s
+++ b/res/battle/scripts/moves/move_script_0448.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0449.s
+++ b/res/battle/scripts/moves/move_script_0449.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0450.s
+++ b/res/battle/scripts/moves/move_script_0450.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0451.s
+++ b/res/battle/scripts/moves/move_script_0451.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0452.s
+++ b/res/battle/scripts/moves/move_script_0452.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0453.s
+++ b/res/battle/scripts/moves/move_script_0453.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0454.s
+++ b/res/battle/scripts/moves/move_script_0454.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0455.s
+++ b/res/battle/scripts/moves/move_script_0455.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0456.s
+++ b/res/battle/scripts/moves/move_script_0456.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0457.s
+++ b/res/battle/scripts/moves/move_script_0457.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0458.s
+++ b/res/battle/scripts/moves/move_script_0458.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0459.s
+++ b/res/battle/scripts/moves/move_script_0459.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0460.s
+++ b/res/battle/scripts/moves/move_script_0460.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0461.s
+++ b/res/battle/scripts/moves/move_script_0461.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0462.s
+++ b/res/battle/scripts/moves/move_script_0462.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0463.s
+++ b/res/battle/scripts/moves/move_script_0463.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0464.s
+++ b/res/battle/scripts/moves/move_script_0464.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0465.s
+++ b/res/battle/scripts/moves/move_script_0465.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0466.s
+++ b/res/battle/scripts/moves/move_script_0466.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0467.s
+++ b/res/battle/scripts/moves/move_script_0467.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0468.s
+++ b/res/battle/scripts/moves/move_script_0468.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0469.s
+++ b/res/battle/scripts/moves/move_script_0469.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0470.s
+++ b/res/battle/scripts/moves/move_script_0470.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0471.s
+++ b/res/battle/scripts/moves/move_script_0471.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0472.s
+++ b/res/battle/scripts/moves/move_script_0472.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0473.s
+++ b/res/battle/scripts/moves/move_script_0473.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0474.s
+++ b/res/battle/scripts/moves/move_script_0474.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0475.s
+++ b/res/battle/scripts/moves/move_script_0475.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0476.s
+++ b/res/battle/scripts/moves/move_script_0476.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0477.s
+++ b/res/battle/scripts/moves/move_script_0477.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0478.s
+++ b/res/battle/scripts/moves/move_script_0478.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0479.s
+++ b/res/battle/scripts/moves/move_script_0479.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0480.s
+++ b/res/battle/scripts/moves/move_script_0480.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0481.s
+++ b/res/battle/scripts/moves/move_script_0481.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0482.s
+++ b/res/battle/scripts/moves/move_script_0482.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0483.s
+++ b/res/battle/scripts/moves/move_script_0483.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0484.s
+++ b/res/battle/scripts/moves/move_script_0484.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0485.s
+++ b/res/battle/scripts/moves/move_script_0485.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0486.s
+++ b/res/battle/scripts/moves/move_script_0486.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0487.s
+++ b/res/battle/scripts/moves/move_script_0487.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0488.s
+++ b/res/battle/scripts/moves/move_script_0488.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0489.s
+++ b/res/battle/scripts/moves/move_script_0489.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0490.s
+++ b/res/battle/scripts/moves/move_script_0490.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0491.s
+++ b/res/battle/scripts/moves/move_script_0491.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0492.s
+++ b/res/battle/scripts/moves/move_script_0492.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0493.s
+++ b/res/battle/scripts/moves/move_script_0493.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0494.s
+++ b/res/battle/scripts/moves/move_script_0494.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0495.s
+++ b/res/battle/scripts/moves/move_script_0495.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0496.s
+++ b/res/battle/scripts/moves/move_script_0496.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0497.s
+++ b/res/battle/scripts/moves/move_script_0497.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0498.s
+++ b/res/battle/scripts/moves/move_script_0498.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0499.s
+++ b/res/battle/scripts/moves/move_script_0499.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/moves/move_script_0500.s
+++ b/res/battle/scripts/moves/move_script_0500.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_ability_forbids_status.s
+++ b/res/battle/scripts/subscripts/subscript_ability_forbids_status.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_ability_hp_restore_gradual.s
+++ b/res/battle/scripts/subscripts/subscript_ability_hp_restore_gradual.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_ability_restore_status.s
+++ b/res/battle/scripts/subscripts/subscript_ability_restore_status.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_ability_restores_hp.s
+++ b/res/battle/scripts/subscripts/subscript_ability_restores_hp.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_absorb_and_boost_fire_type_moves.s
+++ b/res/battle/scripts/subscripts/subscript_absorb_and_boost_fire_type_moves.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_absorb_and_speed_up_1_stage.s
+++ b/res/battle/scripts/subscripts/subscript_absorb_and_speed_up_1_stage.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_after_selfdestruct.s
+++ b/res/battle/scripts/subscripts/subscript_after_selfdestruct.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_aftermath.s
+++ b/res/battle/scripts/subscripts/subscript_aftermath.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_animation_prepared_message.s
+++ b/res/battle/scripts/subscripts/subscript_animation_prepared_message.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_anticipation.s
+++ b/res/battle/scripts/subscripts/subscript_anticipation.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_aqua_ring_heal.s
+++ b/res/battle/scripts/subscripts/subscript_aqua_ring_heal.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_attack_message_and_animation.s
+++ b/res/battle/scripts/subscripts/subscript_attack_message_and_animation.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_attack_then_switch_out.s
+++ b/res/battle/scripts/subscripts/subscript_attack_then_switch_out.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_bad_dreams.s
+++ b/res/battle/scripts/subscripts/subscript_bad_dreams.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_badly_poison.s
+++ b/res/battle/scripts/subscripts/subscript_badly_poison.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_bag_item_hp_restore.s
+++ b/res/battle/scripts/subscripts/subscript_bag_item_hp_restore.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_bag_item_pp_restore.s
+++ b/res/battle/scripts/subscripts/subscript_bag_item_pp_restore.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_baton_pass.s
+++ b/res/battle/scripts/subscripts/subscript_baton_pass.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_battle_item.s
+++ b/res/battle/scripts/subscripts/subscript_battle_item.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_battle_lost.s
+++ b/res/battle/scripts/subscripts/subscript_battle_lost.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_battle_won.s
+++ b/res/battle/scripts/subscripts/subscript_battle_won.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_belly_drum.s
+++ b/res/battle/scripts/subscripts/subscript_belly_drum.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_bide_end.s
+++ b/res/battle/scripts/subscripts/subscript_bide_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_bide_no_target.s
+++ b/res/battle/scripts/subscripts/subscript_bide_no_target.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_bide_start.s
+++ b/res/battle/scripts/subscripts/subscript_bide_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_bind_effect.s
+++ b/res/battle/scripts/subscripts/subscript_bind_effect.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_bind_end.s
+++ b/res/battle/scripts/subscripts/subscript_bind_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_bind_start.s
+++ b/res/battle/scripts/subscripts/subscript_bind_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_blocked_by_soundproof.s
+++ b/res/battle/scripts/subscripts/subscript_blocked_by_soundproof.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_blow_away_hazards.s
+++ b/res/battle/scripts/subscripts/subscript_blow_away_hazards.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_boost_all_stats.s
+++ b/res/battle/scripts/subscripts/subscript_boost_all_stats.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_break_bind_effect.s
+++ b/res/battle/scripts/subscripts/subscript_break_bind_effect.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_break_screens.s
+++ b/res/battle/scripts/subscripts/subscript_break_screens.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_burn.s
+++ b/res/battle/scripts/subscripts/subscript_burn.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_burn_damage.s
+++ b/res/battle/scripts/subscripts/subscript_burn_damage.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_burn_or_flinch.s
+++ b/res/battle/scripts/subscripts/subscript_burn_or_flinch.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_but_it_failed.s
+++ b/res/battle/scripts/subscripts/subscript_but_it_failed.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_cannot_heal.s
+++ b/res/battle/scripts/subscripts/subscript_cannot_heal.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_charge.s
+++ b/res/battle/scripts/subscripts/subscript_charge.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_charge_move_cleanup.s
+++ b/res/battle/scripts/subscripts/subscript_charge_move_cleanup.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_chatter.s
+++ b/res/battle/scripts/subscripts/subscript_chatter.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_check_quick_claw.s
+++ b/res/battle/scripts/subscripts/subscript_check_quick_claw.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_check_shaymin_form.s
+++ b/res/battle/scripts/subscripts/subscript_check_shaymin_form.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_color_change.s
+++ b/res/battle/scripts/subscripts/subscript_color_change.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_confuse.s
+++ b/res/battle/scripts/subscripts/subscript_confuse.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_confused.s
+++ b/res/battle/scripts/subscripts/subscript_confused.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_continue_perish_song.s
+++ b/res/battle/scripts/subscripts/subscript_continue_perish_song.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_conversion.s
+++ b/res/battle/scripts/subscripts/subscript_conversion.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_conversion_2.s
+++ b/res/battle/scripts/subscripts/subscript_conversion_2.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_copy_ability.s
+++ b/res/battle/scripts/subscripts/subscript_copy_ability.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_crash_on_miss.s
+++ b/res/battle/scripts/subscripts/subscript_crash_on_miss.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_critical_hit.s
+++ b/res/battle/scripts/subscripts/subscript_critical_hit.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_curse_damage.s
+++ b/res/battle/scripts/subscripts/subscript_curse_damage.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_curse_ghost.s
+++ b/res/battle/scripts/subscripts/subscript_curse_ghost.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_curse_normal.s
+++ b/res/battle/scripts/subscripts/subscript_curse_normal.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_defog.s
+++ b/res/battle/scripts/subscripts/subscript_defog.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_defog_message.s
+++ b/res/battle/scripts/subscripts/subscript_defog_message.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_defrosted_by_move.s
+++ b/res/battle/scripts/subscripts/subscript_defrosted_by_move.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_destiny_bond.s
+++ b/res/battle/scripts/subscripts/subscript_destiny_bond.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_disable_end.s
+++ b/res/battle/scripts/subscripts/subscript_disable_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_disable_start.s
+++ b/res/battle/scripts/subscripts/subscript_disable_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_disobey_do_nothing.s
+++ b/res/battle/scripts/subscripts/subscript_disobey_do_nothing.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_disobey_hit_self.s
+++ b/res/battle/scripts/subscripts/subscript_disobey_hit_self.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_disobey_orders.s
+++ b/res/battle/scripts/subscripts/subscript_disobey_orders.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_disobey_sleep.s
+++ b/res/battle/scripts/subscripts/subscript_disobey_sleep.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_disobey_while_asleep.s
+++ b/res/battle/scripts/subscripts/subscript_disobey_while_asleep.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_drain_half_damage_dealt.s
+++ b/res/battle/scripts/subscripts/subscript_drain_half_damage_dealt.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_dream_eater.s
+++ b/res/battle/scripts/subscripts/subscript_dream_eater.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_drizzle.s
+++ b/res/battle/scripts/subscripts/subscript_drizzle.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_drought.s
+++ b/res/battle/scripts/subscripts/subscript_drought.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_embargo_end.s
+++ b/res/battle/scripts/subscripts/subscript_embargo_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_embargo_start.s
+++ b/res/battle/scripts/subscripts/subscript_embargo_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_encore_end.s
+++ b/res/battle/scripts/subscripts/subscript_encore_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_encore_start.s
+++ b/res/battle/scripts/subscripts/subscript_encore_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_enemy_escape.s
+++ b/res/battle/scripts/subscripts/subscript_enemy_escape.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_enemy_escape_failed.s
+++ b/res/battle/scripts/subscripts/subscript_enemy_escape_failed.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_escape.s
+++ b/res/battle/scripts/subscripts/subscript_escape.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_escape_failed.s
+++ b/res/battle/scripts/subscripts/subscript_escape_failed.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_escape_item.s
+++ b/res/battle/scripts/subscripts/subscript_escape_item.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_escape_success.s
+++ b/res/battle/scripts/subscripts/subscript_escape_success.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_exchange_abilities.s
+++ b/res/battle/scripts/subscripts/subscript_exchange_abilities.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_exchange_all_stat_stages.s
+++ b/res/battle/scripts/subscripts/subscript_exchange_all_stat_stages.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_exchange_atk_and_spatk_stages.s
+++ b/res/battle/scripts/subscripts/subscript_exchange_atk_and_spatk_stages.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_exchange_def_and_spdef_stages.s
+++ b/res/battle/scripts/subscripts/subscript_exchange_def_and_spdef_stages.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_exchange_items.s
+++ b/res/battle/scripts/subscripts/subscript_exchange_items.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_faint_check_destiny_bond.s
+++ b/res/battle/scripts/subscripts/subscript_faint_check_destiny_bond.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_faint_mon.s
+++ b/res/battle/scripts/subscripts/subscript_faint_mon.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_fall_asleep.s
+++ b/res/battle/scripts/subscripts/subscript_fall_asleep.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_feint.s
+++ b/res/battle/scripts/subscripts/subscript_feint.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_flatter.s
+++ b/res/battle/scripts/subscripts/subscript_flatter.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_flinch_mon.s
+++ b/res/battle/scripts/subscripts/subscript_flinch_mon.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_flinched.s
+++ b/res/battle/scripts/subscripts/subscript_flinched.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_fling.s
+++ b/res/battle/scripts/subscripts/subscript_fling.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_focus_energy.s
+++ b/res/battle/scripts/subscripts/subscript_focus_energy.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_force_target_to_switch_or_flee.s
+++ b/res/battle/scripts/subscripts/subscript_force_target_to_switch_or_flee.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_foresight.s
+++ b/res/battle/scripts/subscripts/subscript_foresight.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_forewarn.s
+++ b/res/battle/scripts/subscripts/subscript_forewarn.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_form_change.s
+++ b/res/battle/scripts/subscripts/subscript_form_change.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_freeze.s
+++ b/res/battle/scripts/subscripts/subscript_freeze.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_freeze_or_flinch.s
+++ b/res/battle/scripts/subscripts/subscript_freeze_or_flinch.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_frisk.s
+++ b/res/battle/scripts/subscripts/subscript_frisk.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_frozen.s
+++ b/res/battle/scripts/subscripts/subscript_frozen.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_fully_paralyzed.s
+++ b/res/battle/scripts/subscripts/subscript_fully_paralyzed.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_future_sight_damage.s
+++ b/res/battle/scripts/subscripts/subscript_future_sight_damage.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_future_sight_start.s
+++ b/res/battle/scripts/subscripts/subscript_future_sight_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_giratina_form_change.s
+++ b/res/battle/scripts/subscripts/subscript_giratina_form_change.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_give_target_insomnia.s
+++ b/res/battle/scripts/subscripts/subscript_give_target_insomnia.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_give_target_own_status.s
+++ b/res/battle/scripts/subscripts/subscript_give_target_own_status.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_grant_exp.s
+++ b/res/battle/scripts/subscripts/subscript_grant_exp.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_gravity_end.s
+++ b/res/battle/scripts/subscripts/subscript_gravity_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_gravity_start.s
+++ b/res/battle/scripts/subscripts/subscript_gravity_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_hailing_end.s
+++ b/res/battle/scripts/subscripts/subscript_hailing_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_hazards_check.s
+++ b/res/battle/scripts/subscripts/subscript_hazards_check.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_heal_bell.s
+++ b/res/battle/scripts/subscripts/subscript_heal_bell.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_heal_block_end.s
+++ b/res/battle/scripts/subscripts/subscript_heal_block_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_heal_block_start.s
+++ b/res/battle/scripts/subscripts/subscript_heal_block_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_heal_target_paralysis.s
+++ b/res/battle/scripts/subscripts/subscript_heal_target_paralysis.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_heal_target_sleep.s
+++ b/res/battle/scripts/subscripts/subscript_heal_target_sleep.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_healing_wish.s
+++ b/res/battle/scripts/subscripts/subscript_healing_wish.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_brn_restore.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_brn_restore.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_cnf_restore.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_cnf_restore.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_dislike_flavor.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_dislike_flavor.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_frz_restore.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_frz_restore.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_heal_infatuation.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_heal_infatuation.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_hp_restore.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_hp_restore.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_multi_restore.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_multi_restore.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_pp_restore.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_pp_restore.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_prz_restore.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_prz_restore.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_psn_restore.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_psn_restore.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_raise_crit.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_raise_crit.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_raise_stat.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_raise_stat.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_recoil_when_hit.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_recoil_when_hit.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_sharply_raise_stat.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_sharply_raise_stat.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_slp_restore.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_slp_restore.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_statdown_restore.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_statdown_restore.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_held_item_temp_acc_up.s
+++ b/res/battle/scripts/subscripts/subscript_held_item_temp_acc_up.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_hit_substitute.s
+++ b/res/battle/scripts/subscripts/subscript_hit_substitute.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_hit_x_times.s
+++ b/res/battle/scripts/subscripts/subscript_hit_x_times.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_hurt_self_in_confusion.s
+++ b/res/battle/scripts/subscripts/subscript_hurt_self_in_confusion.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_immobilized_by_love.s
+++ b/res/battle/scripts/subscripts/subscript_immobilized_by_love.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_infatuate.s
+++ b/res/battle/scripts/subscripts/subscript_infatuate.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_infatuated.s
+++ b/res/battle/scripts/subscripts/subscript_infatuated.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_ingrain_heal.s
+++ b/res/battle/scripts/subscripts/subscript_ingrain_heal.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_intimidate.s
+++ b/res/battle/scripts/subscripts/subscript_intimidate.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_item_skip_charge_turn.s
+++ b/res/battle/scripts/subscripts/subscript_item_skip_charge_turn.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_knock_off.s
+++ b/res/battle/scripts/subscripts/subscript_knock_off.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_leech_seed_effect.s
+++ b/res/battle/scripts/subscripts/subscript_leech_seed_effect.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_leech_seed_start.s
+++ b/res/battle/scripts/subscripts/subscript_leech_seed_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_light_screen.s
+++ b/res/battle/scripts/subscripts/subscript_light_screen.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_lightning_rod_redirected.s
+++ b/res/battle/scripts/subscripts/subscript_lightning_rod_redirected.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_link_win_lose.s
+++ b/res/battle/scripts/subscripts/subscript_link_win_lose.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_loafing_around.s
+++ b/res/battle/scripts/subscripts/subscript_loafing_around.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_lock_on.s
+++ b/res/battle/scripts/subscripts/subscript_lock_on.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_lose_hp_from_item.s
+++ b/res/battle/scripts/subscripts/subscript_lose_hp_from_item.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_lose_hp_from_item_with_message.s
+++ b/res/battle/scripts/subscripts/subscript_lose_hp_from_item_with_message.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_lucky_chant_end.s
+++ b/res/battle/scripts/subscripts/subscript_lucky_chant_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_lucky_chant_start.s
+++ b/res/battle/scripts/subscripts/subscript_lucky_chant_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_lunar_dance.s
+++ b/res/battle/scripts/subscripts/subscript_lunar_dance.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_magic_coat.s
+++ b/res/battle/scripts/subscripts/subscript_magic_coat.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_magnet_rise_end.s
+++ b/res/battle/scripts/subscripts/subscript_magnet_rise_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_magnitude.s
+++ b/res/battle/scripts/subscripts/subscript_magnitude.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_mean_look.s
+++ b/res/battle/scripts/subscripts/subscript_mean_look.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_memento.s
+++ b/res/battle/scripts/subscripts/subscript_memento.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_mimic.s
+++ b/res/battle/scripts/subscripts/subscript_mimic.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_minimize.s
+++ b/res/battle/scripts/subscripts/subscript_minimize.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_miracle_eye.s
+++ b/res/battle/scripts/subscripts/subscript_miracle_eye.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_missed.s
+++ b/res/battle/scripts/subscripts/subscript_missed.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_mist.s
+++ b/res/battle/scripts/subscripts/subscript_mist.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_mold_breaker.s
+++ b/res/battle/scripts/subscripts/subscript_mold_breaker.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_move_effect_end.s
+++ b/res/battle/scripts/subscripts/subscript_move_effect_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_move_fail_gravity.s
+++ b/res/battle/scripts/subscripts/subscript_move_fail_gravity.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_move_fail_missed.s
+++ b/res/battle/scripts/subscripts/subscript_move_fail_missed.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_move_fail_taunted.s
+++ b/res/battle/scripts/subscripts/subscript_move_fail_taunted.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_move_followup_message.s
+++ b/res/battle/scripts/subscripts/subscript_move_followup_message.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_move_is_disabled.s
+++ b/res/battle/scripts/subscripts/subscript_move_is_disabled.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_move_is_heal_blocked.s
+++ b/res/battle/scripts/subscripts/subscript_move_is_heal_blocked.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_move_is_imprisoned.s
+++ b/res/battle/scripts/subscripts/subscript_move_is_imprisoned.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_nightmare_effect.s
+++ b/res/battle/scripts/subscripts/subscript_nightmare_effect.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_nightmare_start.s
+++ b/res/battle/scripts/subscripts/subscript_nightmare_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_no_pp.s
+++ b/res/battle/scripts/subscripts/subscript_no_pp.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_no_target.s
+++ b/res/battle/scripts/subscripts/subscript_no_target.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_overworld_fog.s
+++ b/res/battle/scripts/subscripts/subscript_overworld_fog.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_overworld_hail.s
+++ b/res/battle/scripts/subscripts/subscript_overworld_hail.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_overworld_rain.s
+++ b/res/battle/scripts/subscripts/subscript_overworld_rain.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_overworld_sand.s
+++ b/res/battle/scripts/subscripts/subscript_overworld_sand.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_overworld_sun.s
+++ b/res/battle/scripts/subscripts/subscript_overworld_sun.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_overworld_trick_room.s
+++ b/res/battle/scripts/subscripts/subscript_overworld_trick_room.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_pain_split.s
+++ b/res/battle/scripts/subscripts/subscript_pain_split.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_paralyze.s
+++ b/res/battle/scripts/subscripts/subscript_paralyze.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_paralyze_or_flinch.s
+++ b/res/battle/scripts/subscripts/subscript_paralyze_or_flinch.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_pay_day.s
+++ b/res/battle/scripts/subscripts/subscript_pay_day.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_perish_song_start.s
+++ b/res/battle/scripts/subscripts/subscript_perish_song_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_pluck.s
+++ b/res/battle/scripts/subscripts/subscript_pluck.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_pluck_check.s
+++ b/res/battle/scripts/subscripts/subscript_pluck_check.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_poison.s
+++ b/res/battle/scripts/subscripts/subscript_poison.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_poison_damage.s
+++ b/res/battle/scripts/subscripts/subscript_poison_damage.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_pop_attacker_and_defender.s
+++ b/res/battle/scripts/subscripts/subscript_pop_attacker_and_defender.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_power_herb_skull_bash.s
+++ b/res/battle/scripts/subscripts/subscript_power_herb_skull_bash.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_present_heal.s
+++ b/res/battle/scripts/subscripts/subscript_present_heal.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_pressure.s
+++ b/res/battle/scripts/subscripts/subscript_pressure.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_print_message_and_play_animation.s
+++ b/res/battle/scripts/subscripts/subscript_print_message_and_play_animation.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_protect.s
+++ b/res/battle/scripts/subscripts/subscript_protect.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_pursuit.s
+++ b/res/battle/scripts/subscripts/subscript_pursuit.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 
@@ -112,7 +112,7 @@ _215:
     UpdateVar OPCODE_ADD, BTLVAR_FAINTED_MON, BATTLER_ENEMY_SLOT_1
     UpdateVar OPCODE_RIGHT_SHIFT, BTLVAR_CALC_TEMP, 0x00000001
     CompareVarToValue OPCODE_NEQ, BTLVAR_CALC_TEMP, 0x00000000, _208
-    ; BUG: Acid Rain (see docs/bugs_and_glitches.md)
+    // BUG: Acid Rain (see docs/bugs_and_glitches.md)
     UpdateVarFromVar OPCODE_SUB_TO_ZERO, BTLVAR_FIELD_CONDITIONS, BTLVAR_SCRIPT_TEMP
     Call BATTLE_SUBSCRIPT_POP_ATTACKER_AND_DEFENDER
     UpdateVarFromVar OPCODE_GET, BTLVAR_MOVE_TEMP, BTLVAR_CURRENT_MOVE

--- a/res/battle/scripts/subscripts/subscript_push_attacker_and_defender.s
+++ b/res/battle/scripts/subscripts/subscript_push_attacker_and_defender.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_rage_is_building.s
+++ b/res/battle/scripts/subscripts/subscript_rage_is_building.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_raining_end.s
+++ b/res/battle/scripts/subscripts/subscript_raining_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_rapid_spin.s
+++ b/res/battle/scripts/subscripts/subscript_rapid_spin.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_recharge_turn.s
+++ b/res/battle/scripts/subscripts/subscript_recharge_turn.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_recharging.s
+++ b/res/battle/scripts/subscripts/subscript_recharging.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_recoil_1_2.s
+++ b/res/battle/scripts/subscripts/subscript_recoil_1_2.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_recoil_1_3.s
+++ b/res/battle/scripts/subscripts/subscript_recoil_1_3.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_recoil_1_3_chance_to_burn.s
+++ b/res/battle/scripts/subscripts/subscript_recoil_1_3_chance_to_burn.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_recoil_1_3_chance_to_paralyze.s
+++ b/res/battle/scripts/subscripts/subscript_recoil_1_3_chance_to_paralyze.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_recoil_1_4.s
+++ b/res/battle/scripts/subscripts/subscript_recoil_1_4.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_recover_half_max_hp.s
+++ b/res/battle/scripts/subscripts/subscript_recover_half_max_hp.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_recover_hp.s
+++ b/res/battle/scripts/subscripts/subscript_recover_hp.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_recover_psn_prz_brn.s
+++ b/res/battle/scripts/subscripts/subscript_recover_psn_prz_brn.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_reduce_target_pp.s
+++ b/res/battle/scripts/subscripts/subscript_reduce_target_pp.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_reflect.s
+++ b/res/battle/scripts/subscripts/subscript_reflect.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_replace_fainted.s
+++ b/res/battle/scripts/subscripts/subscript_replace_fainted.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_reset_all_stat_stages.s
+++ b/res/battle/scripts/subscripts/subscript_reset_all_stat_stages.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_rest.s
+++ b/res/battle/scripts/subscripts/subscript_rest.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_restore_a_little_hp.s
+++ b/res/battle/scripts/subscripts/subscript_restore_a_little_hp.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_roost.s
+++ b/res/battle/scripts/subscripts/subscript_roost.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_rough_skin.s
+++ b/res/battle/scripts/subscripts/subscript_rough_skin.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_safari_escape.s
+++ b/res/battle/scripts/subscripts/subscript_safari_escape.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_safari_throw_bait.s
+++ b/res/battle/scripts/subscripts/subscript_safari_throw_bait.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_safari_throw_rock.s
+++ b/res/battle/scripts/subscripts/subscript_safari_throw_rock.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_safeguard_end.s
+++ b/res/battle/scripts/subscripts/subscript_safeguard_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_safeguard_start.s
+++ b/res/battle/scripts/subscripts/subscript_safeguard_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_sand_stream.s
+++ b/res/battle/scripts/subscripts/subscript_sand_stream.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_sandstorm_end.s
+++ b/res/battle/scripts/subscripts/subscript_sandstorm_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_set_rage_flag.s
+++ b/res/battle/scripts/subscripts/subscript_set_rage_flag.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_show_party_list.s
+++ b/res/battle/scripts/subscripts/subscript_show_party_list.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_show_prepared_message.s
+++ b/res/battle/scripts/subscripts/subscript_show_prepared_message.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_sketch.s
+++ b/res/battle/scripts/subscripts/subscript_sketch.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_sleeping.s
+++ b/res/battle/scripts/subscripts/subscript_sleeping.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_slow_start.s
+++ b/res/battle/scripts/subscripts/subscript_slow_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_slow_start_end.s
+++ b/res/battle/scripts/subscripts/subscript_slow_start_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_snap_out_of_confusion.s
+++ b/res/battle/scripts/subscripts/subscript_snap_out_of_confusion.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_snatch.s
+++ b/res/battle/scripts/subscripts/subscript_snatch.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_snow_warning.s
+++ b/res/battle/scripts/subscripts/subscript_snow_warning.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_start_encounter.s
+++ b/res/battle/scripts/subscripts/subscript_start_encounter.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_steal_item.s
+++ b/res/battle/scripts/subscripts/subscript_steal_item.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_stockpile.s
+++ b/res/battle/scripts/subscripts/subscript_stockpile.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_struggle.s
+++ b/res/battle/scripts/subscripts/subscript_struggle.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_sunny_end.s
+++ b/res/battle/scripts/subscripts/subscript_sunny_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_suppress_target_ability.s
+++ b/res/battle/scripts/subscripts/subscript_suppress_target_ability.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_swagger.s
+++ b/res/battle/scripts/subscripts/subscript_swagger.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_swallow.s
+++ b/res/battle/scripts/subscripts/subscript_swallow.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_switch_pokemon.s
+++ b/res/battle/scripts/subscripts/subscript_switch_pokemon.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_tailwind_end.s
+++ b/res/battle/scripts/subscripts/subscript_tailwind_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_tailwind_start.s
+++ b/res/battle/scripts/subscripts/subscript_tailwind_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_target_atk_and_def_down_1_stage.s
+++ b/res/battle/scripts/subscripts/subscript_target_atk_and_def_down_1_stage.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_taunt_end.s
+++ b/res/battle/scripts/subscripts/subscript_taunt_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_taunt_start.s
+++ b/res/battle/scripts/subscripts/subscript_taunt_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_teleport.s
+++ b/res/battle/scripts/subscripts/subscript_teleport.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_thaw_out.s
+++ b/res/battle/scripts/subscripts/subscript_thaw_out.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_thrash.s
+++ b/res/battle/scripts/subscripts/subscript_thrash.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_thrash_end.s
+++ b/res/battle/scripts/subscripts/subscript_thrash_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_throw_pokeball.s
+++ b/res/battle/scripts/subscripts/subscript_throw_pokeball.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_throw_safari_ball.s
+++ b/res/battle/scripts/subscripts/subscript_throw_safari_ball.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_tighten_focus.s
+++ b/res/battle/scripts/subscripts/subscript_tighten_focus.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_torment_start.s
+++ b/res/battle/scripts/subscripts/subscript_torment_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_trace.s
+++ b/res/battle/scripts/subscripts/subscript_trace.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_trainer_message.s
+++ b/res/battle/scripts/subscripts/subscript_trainer_message.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_transfer_sticky_barb.s
+++ b/res/battle/scripts/subscripts/subscript_transfer_sticky_barb.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_transform_into_target.s
+++ b/res/battle/scripts/subscripts/subscript_transform_into_target.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_trick_room_end.s
+++ b/res/battle/scripts/subscripts/subscript_trick_room_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_try_substitute.s
+++ b/res/battle/scripts/subscripts/subscript_try_substitute.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_type_resist_berry.s
+++ b/res/battle/scripts/subscripts/subscript_type_resist_berry.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_update_hp.s
+++ b/res/battle/scripts/subscripts/subscript_update_hp.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_update_stat_stage.s
+++ b/res/battle/scripts/subscripts/subscript_update_stat_stage.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_uproar.s
+++ b/res/battle/scripts/subscripts/subscript_uproar.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_uproar_continues.s
+++ b/res/battle/scripts/subscripts/subscript_uproar_continues.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_uproar_end.s
+++ b/res/battle/scripts/subscripts/subscript_uproar_end.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_use_full_restore.s
+++ b/res/battle/scripts/subscripts/subscript_use_full_restore.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_use_guard_spec.s
+++ b/res/battle/scripts/subscripts/subscript_use_guard_spec.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_use_move.s
+++ b/res/battle/scripts/subscripts/subscript_use_move.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_use_potion.s
+++ b/res/battle/scripts/subscripts/subscript_use_potion.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_use_stat_booster.s
+++ b/res/battle/scripts/subscripts/subscript_use_stat_booster.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_use_status_recovery.s
+++ b/res/battle/scripts/subscripts/subscript_use_status_recovery.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_user_atk_and_def_down_1_stage.s
+++ b/res/battle/scripts/subscripts/subscript_user_atk_and_def_down_1_stage.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_user_atk_and_def_up_1_stage.s
+++ b/res/battle/scripts/subscripts/subscript_user_atk_and_def_up_1_stage.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_user_atk_and_speed_up_1_stage.s
+++ b/res/battle/scripts/subscripts/subscript_user_atk_and_speed_up_1_stage.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_user_def_and_spdef_down_1_stage.s
+++ b/res/battle/scripts/subscripts/subscript_user_def_and_spdef_down_1_stage.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_user_def_and_spdef_up_1_stage.s
+++ b/res/battle/scripts/subscripts/subscript_user_def_and_spdef_up_1_stage.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_user_spatk_and_spdef_up_1_stage.s
+++ b/res/battle/scripts/subscripts/subscript_user_spatk_and_spdef_up_1_stage.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_user_swap_atk_and_def.s
+++ b/res/battle/scripts/subscripts/subscript_user_swap_atk_and_def.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_vanish_off.s
+++ b/res/battle/scripts/subscripts/subscript_vanish_off.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_vanish_on_charge_turn.s
+++ b/res/battle/scripts/subscripts/subscript_vanish_on_charge_turn.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_wait_move_animation.s
+++ b/res/battle/scripts/subscripts/subscript_wait_move_animation.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_wake_up.s
+++ b/res/battle/scripts/subscripts/subscript_wake_up.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_weather_continues.s
+++ b/res/battle/scripts/subscripts/subscript_weather_continues.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_weather_start.s
+++ b/res/battle/scripts/subscripts/subscript_weather_start.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_wish_heal.s
+++ b/res/battle/scripts/subscripts/subscript_wish_heal.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/battle/scripts/subscripts/subscript_yawn.s
+++ b/res/battle/scripts/subscripts/subscript_yawn.s
@@ -1,4 +1,4 @@
-    .include "macros/btlcmd.inc"
+#include "macros/btlcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_acuity_cavern.s
+++ b/res/field/scripts/scripts_acuity_cavern.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_acuity_lakefront.s
+++ b/res/field/scripts/scripts_acuity_lakefront.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_amity_square.s
+++ b/res/field/scripts/scripts_amity_square.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_arcade.s
+++ b/res/field/scripts/scripts_battle_arcade.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_castle.s
+++ b/res/field/scripts/scripts_battle_castle.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_factory.s
+++ b/res/field/scripts/scripts_battle_factory.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_frontier.s
+++ b/res/field/scripts/scripts_battle_frontier.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_frontier_gate_to_fight_area.s
+++ b/res/field/scripts/scripts_battle_frontier_gate_to_fight_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_hall.s
+++ b/res/field/scripts/scripts_battle_hall.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_park.s
+++ b/res/field/scripts/scripts_battle_park.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_park_exchange_service_corner.s
+++ b/res/field/scripts/scripts_battle_park_exchange_service_corner.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_park_gate_to_fight_area.s
+++ b/res/field/scripts/scripts_battle_park_gate_to_fight_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_tower.s
+++ b/res/field/scripts/scripts_battle_tower.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_tower_battle_room.s
+++ b/res/field/scripts/scripts_battle_tower_battle_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_tower_battle_salon.s
+++ b/res/field/scripts/scripts_battle_tower_battle_salon.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_tower_corridor.s
+++ b/res/field/scripts/scripts_battle_tower_corridor.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_tower_corridor_multi.s
+++ b/res/field/scripts/scripts_battle_tower_corridor_multi.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_tower_elevator.s
+++ b/res/field/scripts/scripts_battle_tower_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battle_tower_multi_battle_room.s
+++ b/res/field/scripts/scripts_battle_tower_multi_battle_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_battleground.s
+++ b/res/field/scripts/scripts_battleground.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_cafe.s
+++ b/res/field/scripts/scripts_cafe.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_city.s
+++ b/res/field/scripts/scripts_canalave_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_city_east_house.s
+++ b/res/field/scripts/scripts_canalave_city_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_city_gym.s
+++ b/res/field/scripts/scripts_canalave_city_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_city_harbor_inn.s
+++ b/res/field/scripts/scripts_canalave_city_harbor_inn.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_city_mart.s
+++ b/res/field/scripts/scripts_canalave_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_canalave_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_canalave_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_canalave_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_city_sailor_eldritch_house.s
+++ b/res/field/scripts/scripts_canalave_city_sailor_eldritch_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_city_southeast_house.s
+++ b/res/field/scripts/scripts_canalave_city_southeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_city_west_house.s
+++ b/res/field/scripts/scripts_canalave_city_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_library_1f.s
+++ b/res/field/scripts/scripts_canalave_library_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_library_2f.s
+++ b/res/field/scripts/scripts_canalave_library_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_canalave_library_3f.s
+++ b/res/field/scripts/scripts_canalave_library_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_celestic_town.s
+++ b/res/field/scripts/scripts_celestic_town.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_celestic_town_cave.s
+++ b/res/field/scripts/scripts_celestic_town_cave.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_celestic_town_north_house.s
+++ b/res/field/scripts/scripts_celestic_town_north_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_celestic_town_northeast_house.s
+++ b/res/field/scripts/scripts_celestic_town_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_celestic_town_northwest_house.s
+++ b/res/field/scripts/scripts_celestic_town_northwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_celestic_town_pokecenter_1f.s
+++ b/res/field/scripts/scripts_celestic_town_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_celestic_town_pokecenter_2f.s
+++ b/res/field/scripts/scripts_celestic_town_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_celestic_town_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_celestic_town_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_celestic_town_southwest_house.s
+++ b/res/field/scripts/scripts_celestic_town_southwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_communication_club_colosseum_2p.s
+++ b/res/field/scripts/scripts_communication_club_colosseum_2p.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_communication_club_colosseum_4p.s
+++ b/res/field/scripts/scripts_communication_club_colosseum_4p.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_contest_hall_lobby.s
+++ b/res/field/scripts/scripts_contest_hall_lobby.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_contest_hall_stage_no_contest.s
+++ b/res/field/scripts/scripts_contest_hall_stage_no_contest.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_contest_hall_stage_ongoing_contest.s
+++ b/res/field/scripts/scripts_contest_hall_stage_ongoing_contest.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_cycle_shop.s
+++ b/res/field/scripts/scripts_cycle_shop.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_distortion_world_1f.s
+++ b/res/field/scripts/scripts_distortion_world_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_distortion_world_b1f.s
+++ b/res/field/scripts/scripts_distortion_world_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_distortion_world_b2f.s
+++ b/res/field/scripts/scripts_distortion_world_b2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_distortion_world_b3f.s
+++ b/res/field/scripts/scripts_distortion_world_b3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_distortion_world_b4f.s
+++ b/res/field/scripts/scripts_distortion_world_b4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_distortion_world_b5f.s
+++ b/res/field/scripts/scripts_distortion_world_b5f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_distortion_world_b6f.s
+++ b/res/field/scripts/scripts_distortion_world_b6f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_distortion_world_b7f.s
+++ b/res/field/scripts/scripts_distortion_world_b7f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_distortion_world_giratina_room.s
+++ b/res/field/scripts/scripts_distortion_world_giratina_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_distortion_world_turnback_cave_room.s
+++ b/res/field/scripts/scripts_distortion_world_turnback_cave_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_empty.s
+++ b/res/field/scripts/scripts_empty.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city.s
+++ b/res/field/scripts/scripts_eterna_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_condominiums_1f.s
+++ b/res/field/scripts/scripts_eterna_city_condominiums_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_condominiums_2f.s
+++ b/res/field/scripts/scripts_eterna_city_condominiums_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_condominiums_3f.s
+++ b/res/field/scripts/scripts_eterna_city_condominiums_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_condominiums_4f.s
+++ b/res/field/scripts/scripts_eterna_city_condominiums_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_dp_gym.s
+++ b/res/field/scripts/scripts_eterna_city_dp_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_east_house.s
+++ b/res/field/scripts/scripts_eterna_city_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_gym.s
+++ b/res/field/scripts/scripts_eterna_city_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_mart.s
+++ b/res/field/scripts/scripts_eterna_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_north_house.s
+++ b/res/field/scripts/scripts_eterna_city_north_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_eterna_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_eterna_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_eterna_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_south_house.s
+++ b/res/field/scripts/scripts_eterna_city_south_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_city_underground_man_house.s
+++ b/res/field/scripts/scripts_eterna_city_underground_man_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_forest.s
+++ b/res/field/scripts/scripts_eterna_forest.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_eterna_forest_outside.s
+++ b/res/field/scripts/scripts_eterna_forest_outside.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_fight_area.s
+++ b/res/field/scripts/scripts_fight_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_fight_area_mart.s
+++ b/res/field/scripts/scripts_fight_area_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_fight_area_middle_house.s
+++ b/res/field/scripts/scripts_fight_area_middle_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_fight_area_pokecenter_1f.s
+++ b/res/field/scripts/scripts_fight_area_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_fight_area_pokecenter_2f.s
+++ b/res/field/scripts/scripts_fight_area_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_fight_area_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_fight_area_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_fight_area_south_house.s
+++ b/res/field/scripts/scripts_fight_area_south_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_floaroma_meadow.s
+++ b/res/field/scripts/scripts_floaroma_meadow.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_floaroma_meadow_house.s
+++ b/res/field/scripts/scripts_floaroma_meadow_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_floaroma_town.s
+++ b/res/field/scripts/scripts_floaroma_town.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_floaroma_town_mart.s
+++ b/res/field/scripts/scripts_floaroma_town_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_floaroma_town_middle_house.s
+++ b/res/field/scripts/scripts_floaroma_town_middle_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_floaroma_town_pokecenter_1f.s
+++ b/res/field/scripts/scripts_floaroma_town_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_floaroma_town_pokecenter_2f.s
+++ b/res/field/scripts/scripts_floaroma_town_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_floaroma_town_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_floaroma_town_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_floaroma_town_southeast_house.s
+++ b/res/field/scripts/scripts_floaroma_town_southeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_flower_paradise.s
+++ b/res/field/scripts/scripts_flower_paradise.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_flower_shop.s
+++ b/res/field/scripts/scripts_flower_shop.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_footstep_house.s
+++ b/res/field/scripts/scripts_footstep_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_foreign_building.s
+++ b/res/field/scripts/scripts_foreign_building.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_fuego_ironworks_building.s
+++ b/res/field/scripts/scripts_fuego_ironworks_building.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_fuego_ironworks_outside.s
+++ b/res/field/scripts/scripts_fuego_ironworks_outside.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_fullmoon_island.s
+++ b/res/field/scripts/scripts_fullmoon_island.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_fullmoon_island_forest.s
+++ b/res/field/scripts/scripts_fullmoon_island_forest.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_galactic_hq_1f.s
+++ b/res/field/scripts/scripts_galactic_hq_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_galactic_hq_2f.s
+++ b/res/field/scripts/scripts_galactic_hq_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_galactic_hq_3f.s
+++ b/res/field/scripts/scripts_galactic_hq_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_galactic_hq_4f.s
+++ b/res/field/scripts/scripts_galactic_hq_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_galactic_hq_b1f.s
+++ b/res/field/scripts/scripts_galactic_hq_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_galactic_hq_b2f.s
+++ b/res/field/scripts/scripts_galactic_hq_b2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_galactic_hq_control_room.s
+++ b/res/field/scripts/scripts_galactic_hq_control_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_galactic_hq_hall.s
+++ b/res/field/scripts/scripts_galactic_hq_hall.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_galactic_hq_laboratory.s
+++ b/res/field/scripts/scripts_galactic_hq_laboratory.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_game_corner.s
+++ b/res/field/scripts/scripts_game_corner.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_gate_between_eterna_city_route_206.s
+++ b/res/field/scripts/scripts_gate_between_eterna_city_route_206.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_global_terminal_1f.s
+++ b/res/field/scripts/scripts_global_terminal_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_global_terminal_2f.s
+++ b/res/field/scripts/scripts_global_terminal_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_global_terminal_3f.s
+++ b/res/field/scripts/scripts_global_terminal_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_grand_lake_route_213_east_house.s
+++ b/res/field/scripts/scripts_grand_lake_route_213_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_grand_lake_route_213_lobby.s
+++ b/res/field/scripts/scripts_grand_lake_route_213_lobby.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_grand_lake_route_213_northeast_house.s
+++ b/res/field/scripts/scripts_grand_lake_route_213_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_grand_lake_route_213_northwest_house.s
+++ b/res/field/scripts/scripts_grand_lake_route_213_northwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_grand_lake_valor_lakefront_east_house.s
+++ b/res/field/scripts/scripts_grand_lake_valor_lakefront_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_grand_lake_valor_lakefront_west_house.s
+++ b/res/field/scripts/scripts_grand_lake_valor_lakefront_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_great_marsh_1.s
+++ b/res/field/scripts/scripts_great_marsh_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_great_marsh_2.s
+++ b/res/field/scripts/scripts_great_marsh_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_great_marsh_3.s
+++ b/res/field/scripts/scripts_great_marsh_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_great_marsh_4.s
+++ b/res/field/scripts/scripts_great_marsh_4.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_great_marsh_5.s
+++ b/res/field/scripts/scripts_great_marsh_5.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_great_marsh_6.s
+++ b/res/field/scripts/scripts_great_marsh_6.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hall_of_origin.s
+++ b/res/field/scripts/scripts_hall_of_origin.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city.s
+++ b/res/field/scripts/scripts_hearthome_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_dp_gym_elevator_room_1.s
+++ b/res/field/scripts/scripts_hearthome_city_dp_gym_elevator_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_dp_gym_elevator_room_2.s
+++ b/res/field/scripts/scripts_hearthome_city_dp_gym_elevator_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_dp_gym_leader_room.s
+++ b/res/field/scripts/scripts_hearthome_city_dp_gym_leader_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_east_gate_to_amity_square.s
+++ b/res/field/scripts/scripts_hearthome_city_east_gate_to_amity_square.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_gym_entrance_room.s
+++ b/res/field/scripts/scripts_hearthome_city_gym_entrance_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_gym_leader_room.s
+++ b/res/field/scripts/scripts_hearthome_city_gym_leader_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_gym_trainer_room_1.s
+++ b/res/field/scripts/scripts_hearthome_city_gym_trainer_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_gym_trainer_room_2.s
+++ b/res/field/scripts/scripts_hearthome_city_gym_trainer_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_mart.s
+++ b/res/field/scripts/scripts_hearthome_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_northeast_house_1f.s
+++ b/res/field/scripts/scripts_hearthome_city_northeast_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_northeast_house_2f.s
+++ b/res/field/scripts/scripts_hearthome_city_northeast_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_northeast_house_elevator.s
+++ b/res/field/scripts/scripts_hearthome_city_northeast_house_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_northwest_house.s
+++ b/res/field/scripts/scripts_hearthome_city_northwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_hearthome_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_hearthome_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_hearthome_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_pokemon_fan_club.s
+++ b/res/field/scripts/scripts_hearthome_city_pokemon_fan_club.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_southeast_house_1f.s
+++ b/res/field/scripts/scripts_hearthome_city_southeast_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_southeast_house_2f.s
+++ b/res/field/scripts/scripts_hearthome_city_southeast_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_southeast_house_elevator.s
+++ b/res/field/scripts/scripts_hearthome_city_southeast_house_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_hearthome_city_west_gate_to_amity_square.s
+++ b/res/field/scripts/scripts_hearthome_city_west_gate_to_amity_square.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_iceberg_ruins.s
+++ b/res/field/scripts/scripts_iceberg_ruins.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_acuity_cavern.s
+++ b/res/field/scripts/scripts_init_acuity_cavern.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_acuity_lakefront.s
+++ b/res/field/scripts/scripts_init_acuity_lakefront.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_amity_square.s
+++ b/res/field/scripts/scripts_init_amity_square.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_arcade.s
+++ b/res/field/scripts/scripts_init_battle_arcade.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_castle.s
+++ b/res/field/scripts/scripts_init_battle_castle.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_factory.s
+++ b/res/field/scripts/scripts_init_battle_factory.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_frontier.s
+++ b/res/field/scripts/scripts_init_battle_frontier.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_frontier_gate_to_fight_area.s
+++ b/res/field/scripts/scripts_init_battle_frontier_gate_to_fight_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_hall.s
+++ b/res/field/scripts/scripts_init_battle_hall.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_park.s
+++ b/res/field/scripts/scripts_init_battle_park.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_park_exchange_service_corner.s
+++ b/res/field/scripts/scripts_init_battle_park_exchange_service_corner.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_park_gate_to_fight_area.s
+++ b/res/field/scripts/scripts_init_battle_park_gate_to_fight_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_tower.s
+++ b/res/field/scripts/scripts_init_battle_tower.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_tower_battle_room.s
+++ b/res/field/scripts/scripts_init_battle_tower_battle_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_tower_battle_salon.s
+++ b/res/field/scripts/scripts_init_battle_tower_battle_salon.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_tower_corridor.s
+++ b/res/field/scripts/scripts_init_battle_tower_corridor.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_tower_corridor_multi.s
+++ b/res/field/scripts/scripts_init_battle_tower_corridor_multi.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_tower_elevator.s
+++ b/res/field/scripts/scripts_init_battle_tower_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battle_tower_multi_battle_room.s
+++ b/res/field/scripts/scripts_init_battle_tower_multi_battle_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_battleground.s
+++ b/res/field/scripts/scripts_init_battleground.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_cafe.s
+++ b/res/field/scripts/scripts_init_cafe.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_city.s
+++ b/res/field/scripts/scripts_init_canalave_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_city_east_house.s
+++ b/res/field/scripts/scripts_init_canalave_city_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_city_gym.s
+++ b/res/field/scripts/scripts_init_canalave_city_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_city_harbor_inn.s
+++ b/res/field/scripts/scripts_init_canalave_city_harbor_inn.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_city_mart.s
+++ b/res/field/scripts/scripts_init_canalave_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_canalave_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_canalave_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_canalave_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_city_sailor_eldritch_house.s
+++ b/res/field/scripts/scripts_init_canalave_city_sailor_eldritch_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_city_southeast_house.s
+++ b/res/field/scripts/scripts_init_canalave_city_southeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_city_west_house.s
+++ b/res/field/scripts/scripts_init_canalave_city_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_library_1f.s
+++ b/res/field/scripts/scripts_init_canalave_library_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_library_2f.s
+++ b/res/field/scripts/scripts_init_canalave_library_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_canalave_library_3f.s
+++ b/res/field/scripts/scripts_init_canalave_library_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_celestic_town.s
+++ b/res/field/scripts/scripts_init_celestic_town.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_celestic_town_cave.s
+++ b/res/field/scripts/scripts_init_celestic_town_cave.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_celestic_town_north_house.s
+++ b/res/field/scripts/scripts_init_celestic_town_north_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_celestic_town_northeast_house.s
+++ b/res/field/scripts/scripts_init_celestic_town_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_celestic_town_northwest_house.s
+++ b/res/field/scripts/scripts_init_celestic_town_northwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_celestic_town_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_celestic_town_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_celestic_town_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_celestic_town_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_celestic_town_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_celestic_town_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_celestic_town_southwest_house.s
+++ b/res/field/scripts/scripts_init_celestic_town_southwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_communication_club_colosseum_2p.s
+++ b/res/field/scripts/scripts_init_communication_club_colosseum_2p.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_communication_club_colosseum_4p.s
+++ b/res/field/scripts/scripts_init_communication_club_colosseum_4p.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_contest_hall_lobby.s
+++ b/res/field/scripts/scripts_init_contest_hall_lobby.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_contest_hall_stage_no_contest.s
+++ b/res/field/scripts/scripts_init_contest_hall_stage_no_contest.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_contest_hall_stage_ongoing_contest.s
+++ b/res/field/scripts/scripts_init_contest_hall_stage_ongoing_contest.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_cycle_shop.s
+++ b/res/field/scripts/scripts_init_cycle_shop.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_distortion_world_1f.s
+++ b/res/field/scripts/scripts_init_distortion_world_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_distortion_world_b1f.s
+++ b/res/field/scripts/scripts_init_distortion_world_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_distortion_world_b2f.s
+++ b/res/field/scripts/scripts_init_distortion_world_b2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_distortion_world_b3f.s
+++ b/res/field/scripts/scripts_init_distortion_world_b3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_distortion_world_b4f.s
+++ b/res/field/scripts/scripts_init_distortion_world_b4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_distortion_world_b5f.s
+++ b/res/field/scripts/scripts_init_distortion_world_b5f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_distortion_world_b6f.s
+++ b/res/field/scripts/scripts_init_distortion_world_b6f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_distortion_world_b7f.s
+++ b/res/field/scripts/scripts_init_distortion_world_b7f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_distortion_world_giratina_room.s
+++ b/res/field/scripts/scripts_init_distortion_world_giratina_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_distortion_world_turnback_cave_room.s
+++ b/res/field/scripts/scripts_init_distortion_world_turnback_cave_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_empty.s
+++ b/res/field/scripts/scripts_init_empty.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city.s
+++ b/res/field/scripts/scripts_init_eterna_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_condominiums_1f.s
+++ b/res/field/scripts/scripts_init_eterna_city_condominiums_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_condominiums_2f.s
+++ b/res/field/scripts/scripts_init_eterna_city_condominiums_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_condominiums_3f.s
+++ b/res/field/scripts/scripts_init_eterna_city_condominiums_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_condominiums_4f.s
+++ b/res/field/scripts/scripts_init_eterna_city_condominiums_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_dp_gym.s
+++ b/res/field/scripts/scripts_init_eterna_city_dp_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_east_house.s
+++ b/res/field/scripts/scripts_init_eterna_city_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_gym.s
+++ b/res/field/scripts/scripts_init_eterna_city_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_mart.s
+++ b/res/field/scripts/scripts_init_eterna_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_north_house.s
+++ b/res/field/scripts/scripts_init_eterna_city_north_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_eterna_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_eterna_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_eterna_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_south_house.s
+++ b/res/field/scripts/scripts_init_eterna_city_south_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_city_underground_man_house.s
+++ b/res/field/scripts/scripts_init_eterna_city_underground_man_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_forest.s
+++ b/res/field/scripts/scripts_init_eterna_forest.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_eterna_forest_outside.s
+++ b/res/field/scripts/scripts_init_eterna_forest_outside.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_fight_area.s
+++ b/res/field/scripts/scripts_init_fight_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_fight_area_mart.s
+++ b/res/field/scripts/scripts_init_fight_area_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_fight_area_middle_house.s
+++ b/res/field/scripts/scripts_init_fight_area_middle_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_fight_area_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_fight_area_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_fight_area_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_fight_area_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_fight_area_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_fight_area_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_fight_area_south_house.s
+++ b/res/field/scripts/scripts_init_fight_area_south_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_floaroma_meadow.s
+++ b/res/field/scripts/scripts_init_floaroma_meadow.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_floaroma_meadow_house.s
+++ b/res/field/scripts/scripts_init_floaroma_meadow_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_floaroma_town.s
+++ b/res/field/scripts/scripts_init_floaroma_town.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_floaroma_town_mart.s
+++ b/res/field/scripts/scripts_init_floaroma_town_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_floaroma_town_middle_house.s
+++ b/res/field/scripts/scripts_init_floaroma_town_middle_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_floaroma_town_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_floaroma_town_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_floaroma_town_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_floaroma_town_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_floaroma_town_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_floaroma_town_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_floaroma_town_southeast_house.s
+++ b/res/field/scripts/scripts_init_floaroma_town_southeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_flower_paradise.s
+++ b/res/field/scripts/scripts_init_flower_paradise.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_flower_shop.s
+++ b/res/field/scripts/scripts_init_flower_shop.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_footstep_house.s
+++ b/res/field/scripts/scripts_init_footstep_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_foreign_building.s
+++ b/res/field/scripts/scripts_init_foreign_building.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_fuego_ironworks_building.s
+++ b/res/field/scripts/scripts_init_fuego_ironworks_building.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_fuego_ironworks_outside.s
+++ b/res/field/scripts/scripts_init_fuego_ironworks_outside.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_fullmoon_island.s
+++ b/res/field/scripts/scripts_init_fullmoon_island.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_fullmoon_island_forest.s
+++ b/res/field/scripts/scripts_init_fullmoon_island_forest.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_galactic_hq_1f.s
+++ b/res/field/scripts/scripts_init_galactic_hq_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_galactic_hq_2f.s
+++ b/res/field/scripts/scripts_init_galactic_hq_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_galactic_hq_3f.s
+++ b/res/field/scripts/scripts_init_galactic_hq_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_galactic_hq_4f.s
+++ b/res/field/scripts/scripts_init_galactic_hq_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_galactic_hq_b1f.s
+++ b/res/field/scripts/scripts_init_galactic_hq_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_galactic_hq_b2f.s
+++ b/res/field/scripts/scripts_init_galactic_hq_b2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_galactic_hq_control_room.s
+++ b/res/field/scripts/scripts_init_galactic_hq_control_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_galactic_hq_hall.s
+++ b/res/field/scripts/scripts_init_galactic_hq_hall.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_galactic_hq_laboratory.s
+++ b/res/field/scripts/scripts_init_galactic_hq_laboratory.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_game_corner.s
+++ b/res/field/scripts/scripts_init_game_corner.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_gate_between_eterna_city_route_206.s
+++ b/res/field/scripts/scripts_init_gate_between_eterna_city_route_206.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_global_terminal_1f.s
+++ b/res/field/scripts/scripts_init_global_terminal_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_global_terminal_2f.s
+++ b/res/field/scripts/scripts_init_global_terminal_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_global_terminal_3f.s
+++ b/res/field/scripts/scripts_init_global_terminal_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_grand_lake_route_213_east_house.s
+++ b/res/field/scripts/scripts_init_grand_lake_route_213_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_grand_lake_route_213_lobby.s
+++ b/res/field/scripts/scripts_init_grand_lake_route_213_lobby.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_grand_lake_route_213_northeast_house.s
+++ b/res/field/scripts/scripts_init_grand_lake_route_213_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_grand_lake_route_213_northwest_house.s
+++ b/res/field/scripts/scripts_init_grand_lake_route_213_northwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_grand_lake_valor_lakefront_east_house.s
+++ b/res/field/scripts/scripts_init_grand_lake_valor_lakefront_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_grand_lake_valor_lakefront_west_house.s
+++ b/res/field/scripts/scripts_init_grand_lake_valor_lakefront_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_great_marsh_1.s
+++ b/res/field/scripts/scripts_init_great_marsh_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_great_marsh_2.s
+++ b/res/field/scripts/scripts_init_great_marsh_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_great_marsh_3.s
+++ b/res/field/scripts/scripts_init_great_marsh_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_great_marsh_4.s
+++ b/res/field/scripts/scripts_init_great_marsh_4.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_great_marsh_5.s
+++ b/res/field/scripts/scripts_init_great_marsh_5.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_great_marsh_6.s
+++ b/res/field/scripts/scripts_init_great_marsh_6.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hall_of_origin.s
+++ b/res/field/scripts/scripts_init_hall_of_origin.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city.s
+++ b/res/field/scripts/scripts_init_hearthome_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_dp_gym_elevator_room_1.s
+++ b/res/field/scripts/scripts_init_hearthome_city_dp_gym_elevator_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_dp_gym_elevator_room_2.s
+++ b/res/field/scripts/scripts_init_hearthome_city_dp_gym_elevator_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_dp_gym_leader_room.s
+++ b/res/field/scripts/scripts_init_hearthome_city_dp_gym_leader_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_east_gate_to_amity_square.s
+++ b/res/field/scripts/scripts_init_hearthome_city_east_gate_to_amity_square.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_gym_entrance_room.s
+++ b/res/field/scripts/scripts_init_hearthome_city_gym_entrance_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_gym_leader_room.s
+++ b/res/field/scripts/scripts_init_hearthome_city_gym_leader_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_gym_trainer_room_1.s
+++ b/res/field/scripts/scripts_init_hearthome_city_gym_trainer_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_gym_trainer_room_2.s
+++ b/res/field/scripts/scripts_init_hearthome_city_gym_trainer_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_mart.s
+++ b/res/field/scripts/scripts_init_hearthome_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_northeast_house_1f.s
+++ b/res/field/scripts/scripts_init_hearthome_city_northeast_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_northeast_house_2f.s
+++ b/res/field/scripts/scripts_init_hearthome_city_northeast_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_northeast_house_elevator.s
+++ b/res/field/scripts/scripts_init_hearthome_city_northeast_house_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_northwest_house.s
+++ b/res/field/scripts/scripts_init_hearthome_city_northwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_hearthome_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_hearthome_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_hearthome_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_pokemon_fan_club.s
+++ b/res/field/scripts/scripts_init_hearthome_city_pokemon_fan_club.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_southeast_house_1f.s
+++ b/res/field/scripts/scripts_init_hearthome_city_southeast_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_southeast_house_2f.s
+++ b/res/field/scripts/scripts_init_hearthome_city_southeast_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_southeast_house_elevator.s
+++ b/res/field/scripts/scripts_init_hearthome_city_southeast_house_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_hearthome_city_west_gate_to_amity_square.s
+++ b/res/field/scripts/scripts_init_hearthome_city_west_gate_to_amity_square.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_iceberg_ruins.s
+++ b/res/field/scripts/scripts_init_iceberg_ruins.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_iron_island.s
+++ b/res/field/scripts/scripts_init_iron_island.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_iron_island_1f.s
+++ b/res/field/scripts/scripts_init_iron_island_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_iron_island_b1f_right_room.s
+++ b/res/field/scripts/scripts_init_iron_island_b1f_right_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_iron_island_b2f_left_room.s
+++ b/res/field/scripts/scripts_init_iron_island_b2f_left_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_iron_island_b3f.s
+++ b/res/field/scripts/scripts_init_iron_island_b3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_iron_island_house.s
+++ b/res/field/scripts/scripts_init_iron_island_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_iron_ruins.s
+++ b/res/field/scripts/scripts_init_iron_ruins.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city.s
+++ b/res/field/scripts/scripts_init_jubilife_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_condominiums_1f.s
+++ b/res/field/scripts/scripts_init_jubilife_city_condominiums_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_condominiums_2f.s
+++ b/res/field/scripts/scripts_init_jubilife_city_condominiums_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_condominiums_3f.s
+++ b/res/field/scripts/scripts_init_jubilife_city_condominiums_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_condominiums_4f.s
+++ b/res/field/scripts/scripts_init_jubilife_city_condominiums_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_mart.s
+++ b/res/field/scripts/scripts_init_jubilife_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_jubilife_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_jubilife_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_jubilife_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_south_house_1f.s
+++ b/res/field/scripts/scripts_init_jubilife_city_south_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_south_house_2f.s
+++ b/res/field/scripts/scripts_init_jubilife_city_south_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_south_house_3f.s
+++ b/res/field/scripts/scripts_init_jubilife_city_south_house_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_southwest_house_1f.s
+++ b/res/field/scripts/scripts_init_jubilife_city_southwest_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_southwest_house_2f.s
+++ b/res/field/scripts/scripts_init_jubilife_city_southwest_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_unknown_house_1.s
+++ b/res/field/scripts/scripts_init_jubilife_city_unknown_house_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_unknown_house_2.s
+++ b/res/field/scripts/scripts_init_jubilife_city_unknown_house_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_unknown_house_3.s
+++ b/res/field/scripts/scripts_init_jubilife_city_unknown_house_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_city_unknown_house_4.s
+++ b/res/field/scripts/scripts_init_jubilife_city_unknown_house_4.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_tv_1f.s
+++ b/res/field/scripts/scripts_init_jubilife_tv_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_tv_2f.s
+++ b/res/field/scripts/scripts_init_jubilife_tv_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_tv_2f_gallery.s
+++ b/res/field/scripts/scripts_init_jubilife_tv_2f_gallery.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_tv_3f.s
+++ b/res/field/scripts/scripts_init_jubilife_tv_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_tv_3f_global_ranking_room.s
+++ b/res/field/scripts/scripts_init_jubilife_tv_3f_global_ranking_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_tv_3f_group_ranking_room.s
+++ b/res/field/scripts/scripts_init_jubilife_tv_3f_group_ranking_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_tv_4f.s
+++ b/res/field/scripts/scripts_init_jubilife_tv_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_jubilife_tv_elevator.s
+++ b/res/field/scripts/scripts_init_jubilife_tv_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_lake_acuity.s
+++ b/res/field/scripts/scripts_init_lake_acuity.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_lake_acuity_low_water.s
+++ b/res/field/scripts/scripts_init_lake_acuity_low_water.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_lake_valor.s
+++ b/res/field/scripts/scripts_init_lake_valor.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_lake_valor_drained.s
+++ b/res/field/scripts/scripts_init_lake_valor_drained.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_lake_verity.s
+++ b/res/field/scripts/scripts_init_lake_verity.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_lake_verity_low_water.s
+++ b/res/field/scripts/scripts_init_lake_verity_low_water.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_maniac_tunnel.s
+++ b/res/field/scripts/scripts_init_maniac_tunnel.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_mining_museum.s
+++ b/res/field/scripts/scripts_init_mining_museum.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_mt_coronet_1f_north_room_1.s
+++ b/res/field/scripts/scripts_init_mt_coronet_1f_north_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_mt_coronet_1f_north_room_2.s
+++ b/res/field/scripts/scripts_init_mt_coronet_1f_north_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_mt_coronet_1f_south.s
+++ b/res/field/scripts/scripts_init_mt_coronet_1f_south.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_mt_coronet_1f_tunnel_room.s
+++ b/res/field/scripts/scripts_init_mt_coronet_1f_tunnel_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_mt_coronet_2f.s
+++ b/res/field/scripts/scripts_init_mt_coronet_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_mt_coronet_6f.s
+++ b/res/field/scripts/scripts_init_mt_coronet_6f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_newmoon_island.s
+++ b/res/field/scripts/scripts_init_newmoon_island.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_newmoon_island_forest.s
+++ b/res/field/scripts/scripts_init_newmoon_island_forest.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_old_chateau.s
+++ b/res/field/scripts/scripts_init_old_chateau.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_old_chateau_back_middle_east_room.s
+++ b/res/field/scripts/scripts_init_old_chateau_back_middle_east_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_old_chateau_back_middle_west_room.s
+++ b/res/field/scripts/scripts_init_old_chateau_back_middle_west_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_old_chateau_dining_area.s
+++ b/res/field/scripts/scripts_init_old_chateau_dining_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_old_chateau_side_rooms.s
+++ b/res/field/scripts/scripts_init_old_chateau_side_rooms.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city.s
+++ b/res/field/scripts/scripts_init_oreburgh_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_east_house_1f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_east_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_east_house_2f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_east_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_east_house_3f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_east_house_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_gym.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_mart.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_middle_house.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_middle_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_north_house_1f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_north_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_north_house_2f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_north_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_north_house_3f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_north_house_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_north_house_4f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_north_house_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_northwest_house_1f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_northwest_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_northwest_house_2f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_northwest_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_northwest_house_3f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_northwest_house_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_northwest_house_4f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_northwest_house_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_south_house.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_south_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_city_west_house.s
+++ b/res/field/scripts/scripts_init_oreburgh_city_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_gate_1f.s
+++ b/res/field/scripts/scripts_init_oreburgh_gate_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_gate_b1f.s
+++ b/res/field/scripts/scripts_init_oreburgh_gate_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_mine_b1f.s
+++ b/res/field/scripts/scripts_init_oreburgh_mine_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_oreburgh_mine_b2f.s
+++ b/res/field/scripts/scripts_init_oreburgh_mine_b2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pal_park.s
+++ b/res/field/scripts/scripts_init_pal_park.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pal_park_lobby.s
+++ b/res/field/scripts/scripts_init_pal_park_lobby.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pastoria_city.s
+++ b/res/field/scripts/scripts_init_pastoria_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pastoria_city_east_house.s
+++ b/res/field/scripts/scripts_init_pastoria_city_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pastoria_city_gym.s
+++ b/res/field/scripts/scripts_init_pastoria_city_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pastoria_city_mart.s
+++ b/res/field/scripts/scripts_init_pastoria_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pastoria_city_middle_house.s
+++ b/res/field/scripts/scripts_init_pastoria_city_middle_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pastoria_city_north_house.s
+++ b/res/field/scripts/scripts_init_pastoria_city_north_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pastoria_city_northeast_house.s
+++ b/res/field/scripts/scripts_init_pastoria_city_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pastoria_city_observatory_gate_1f.s
+++ b/res/field/scripts/scripts_init_pastoria_city_observatory_gate_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pastoria_city_observatory_gate_2f.s
+++ b/res/field/scripts/scripts_init_pastoria_city_observatory_gate_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pastoria_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_pastoria_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pastoria_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_pastoria_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pastoria_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_pastoria_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pastoria_city_southwest_house.s
+++ b/res/field/scripts/scripts_init_pastoria_city_southwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_poffin_house.s
+++ b/res/field/scripts/scripts_init_poffin_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_day_care.s
+++ b/res/field/scripts/scripts_init_pokemon_day_care.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league.s
+++ b/res/field/scripts/scripts_init_pokemon_league.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_aaron_room.s
+++ b/res/field/scripts/scripts_init_pokemon_league_aaron_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_bertha_room.s
+++ b/res/field/scripts/scripts_init_pokemon_league_bertha_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_champion_room.s
+++ b/res/field/scripts/scripts_init_pokemon_league_champion_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_elevator_to_aaron_room.s
+++ b/res/field/scripts/scripts_init_pokemon_league_elevator_to_aaron_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_elevator_to_bertha_room.s
+++ b/res/field/scripts/scripts_init_pokemon_league_elevator_to_bertha_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_elevator_to_champion_room.s
+++ b/res/field/scripts/scripts_init_pokemon_league_elevator_to_champion_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_elevator_to_flint_room.s
+++ b/res/field/scripts/scripts_init_pokemon_league_elevator_to_flint_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_elevator_to_hall_of_fame.s
+++ b/res/field/scripts/scripts_init_pokemon_league_elevator_to_hall_of_fame.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_elevator_to_lucian_room.s
+++ b/res/field/scripts/scripts_init_pokemon_league_elevator_to_lucian_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_flint_room.s
+++ b/res/field/scripts/scripts_init_pokemon_league_flint_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_hall_of_fame.s
+++ b/res/field/scripts/scripts_init_pokemon_league_hall_of_fame.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_lucian_room.s
+++ b/res/field/scripts/scripts_init_pokemon_league_lucian_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_north_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_pokemon_league_north_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_north_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_pokemon_league_north_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_north_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_pokemon_league_north_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_south_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_pokemon_league_south_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_south_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_pokemon_league_south_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_league_south_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_pokemon_league_south_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_mansion.s
+++ b/res/field/scripts/scripts_init_pokemon_mansion.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_mansion_maids_room.s
+++ b/res/field/scripts/scripts_init_pokemon_mansion_maids_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_pokemon_mansion_office.s
+++ b/res/field/scripts/scripts_init_pokemon_mansion_office.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_poketch_co_1f.s
+++ b/res/field/scripts/scripts_init_poketch_co_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_poketch_co_2f.s
+++ b/res/field/scripts/scripts_init_poketch_co_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_poketch_co_3f.s
+++ b/res/field/scripts/scripts_init_poketch_co_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_ravaged_path.s
+++ b/res/field/scripts/scripts_init_ravaged_path.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_resort_area.s
+++ b/res/field/scripts/scripts_init_resort_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_resort_area_house.s
+++ b/res/field/scripts/scripts_init_resort_area_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_resort_area_mart.s
+++ b/res/field/scripts/scripts_init_resort_area_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_resort_area_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_resort_area_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_resort_area_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_resort_area_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_resort_area_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_resort_area_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_resort_area_ribbon_syndicate_1f.s
+++ b/res/field/scripts/scripts_init_resort_area_ribbon_syndicate_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_resort_area_ribbon_syndicate_2f.s
+++ b/res/field/scripts/scripts_init_resort_area_ribbon_syndicate_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_resort_area_ribbon_syndicate_elevator.s
+++ b/res/field/scripts/scripts_init_resort_area_ribbon_syndicate_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_restaurant.s
+++ b/res/field/scripts/scripts_init_restaurant.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_rock_peak_ruins.s
+++ b/res/field/scripts/scripts_init_rock_peak_ruins.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_rotoms_room.s
+++ b/res/field/scripts/scripts_init_rotoms_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_201.s
+++ b/res/field/scripts/scripts_init_route_201.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_202.s
+++ b/res/field/scripts/scripts_init_route_202.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_203.s
+++ b/res/field/scripts/scripts_init_route_203.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_204_north.s
+++ b/res/field/scripts/scripts_init_route_204_north.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_204_south.s
+++ b/res/field/scripts/scripts_init_route_204_south.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_205_house.s
+++ b/res/field/scripts/scripts_init_route_205_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_205_north.s
+++ b/res/field/scripts/scripts_init_route_205_north.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_205_south.s
+++ b/res/field/scripts/scripts_init_route_205_south.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_206.s
+++ b/res/field/scripts/scripts_init_route_206.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_206_cycling_road_north_gate.s
+++ b/res/field/scripts/scripts_init_route_206_cycling_road_north_gate.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_206_cycling_road_south_gate.s
+++ b/res/field/scripts/scripts_init_route_206_cycling_road_south_gate.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_207.s
+++ b/res/field/scripts/scripts_init_route_207.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_208.s
+++ b/res/field/scripts/scripts_init_route_208.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_208_gate_to_hearthome_city.s
+++ b/res/field/scripts/scripts_init_route_208_gate_to_hearthome_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_208_house.s
+++ b/res/field/scripts/scripts_init_route_208_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_209.s
+++ b/res/field/scripts/scripts_init_route_209.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_209_gate_to_hearthome_city.s
+++ b/res/field/scripts/scripts_init_route_209_gate_to_hearthome_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_209_lost_tower_1f.s
+++ b/res/field/scripts/scripts_init_route_209_lost_tower_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_209_lost_tower_5f.s
+++ b/res/field/scripts/scripts_init_route_209_lost_tower_5f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_210_grandma_wilma_house.s
+++ b/res/field/scripts/scripts_init_route_210_grandma_wilma_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_210_north.s
+++ b/res/field/scripts/scripts_init_route_210_north.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_210_south.s
+++ b/res/field/scripts/scripts_init_route_210_south.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_211_east.s
+++ b/res/field/scripts/scripts_init_route_211_east.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_211_west.s
+++ b/res/field/scripts/scripts_init_route_211_west.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_212_gate_to_hearthome_city.s
+++ b/res/field/scripts/scripts_init_route_212_gate_to_hearthome_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_212_house.s
+++ b/res/field/scripts/scripts_init_route_212_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_212_north.s
+++ b/res/field/scripts/scripts_init_route_212_north.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_212_south.s
+++ b/res/field/scripts/scripts_init_route_212_south.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_213.s
+++ b/res/field/scripts/scripts_init_route_213.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_213_gate_to_pastoria_city.s
+++ b/res/field/scripts/scripts_init_route_213_gate_to_pastoria_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_214.s
+++ b/res/field/scripts/scripts_init_route_214.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_214_gate_to_veilstone_city.s
+++ b/res/field/scripts/scripts_init_route_214_gate_to_veilstone_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_215.s
+++ b/res/field/scripts/scripts_init_route_215.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_215_gate_to_veilstone_city.s
+++ b/res/field/scripts/scripts_init_route_215_gate_to_veilstone_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_216.s
+++ b/res/field/scripts/scripts_init_route_216.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_216_house.s
+++ b/res/field/scripts/scripts_init_route_216_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_217.s
+++ b/res/field/scripts/scripts_init_route_217.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_217_northeast_house.s
+++ b/res/field/scripts/scripts_init_route_217_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_217_west_house.s
+++ b/res/field/scripts/scripts_init_route_217_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_218.s
+++ b/res/field/scripts/scripts_init_route_218.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_218_gate_to_canalave_city.s
+++ b/res/field/scripts/scripts_init_route_218_gate_to_canalave_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_218_gate_to_jubilife_city.s
+++ b/res/field/scripts/scripts_init_route_218_gate_to_jubilife_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_219.s
+++ b/res/field/scripts/scripts_init_route_219.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_221.s
+++ b/res/field/scripts/scripts_init_route_221.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_221_house.s
+++ b/res/field/scripts/scripts_init_route_221_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_222.s
+++ b/res/field/scripts/scripts_init_route_222.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_222_east_house.s
+++ b/res/field/scripts/scripts_init_route_222_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_222_gate_to_sunyshore_city.s
+++ b/res/field/scripts/scripts_init_route_222_gate_to_sunyshore_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_222_west_house.s
+++ b/res/field/scripts/scripts_init_route_222_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_224.s
+++ b/res/field/scripts/scripts_init_route_224.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_225.s
+++ b/res/field/scripts/scripts_init_route_225.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_225_gate_to_fight_area.s
+++ b/res/field/scripts/scripts_init_route_225_gate_to_fight_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_225_house.s
+++ b/res/field/scripts/scripts_init_route_225_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_226.s
+++ b/res/field/scripts/scripts_init_route_226.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_226_house.s
+++ b/res/field/scripts/scripts_init_route_226_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_227.s
+++ b/res/field/scripts/scripts_init_route_227.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_227_house.s
+++ b/res/field/scripts/scripts_init_route_227_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_228.s
+++ b/res/field/scripts/scripts_init_route_228.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_228_gate_to_route_226.s
+++ b/res/field/scripts/scripts_init_route_228_gate_to_route_226.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_228_north_house.s
+++ b/res/field/scripts/scripts_init_route_228_north_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_228_south_house.s
+++ b/res/field/scripts/scripts_init_route_228_south_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_229.s
+++ b/res/field/scripts/scripts_init_route_229.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_route_230.s
+++ b/res/field/scripts/scripts_init_route_230.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_ruin_maniac_cave_long.s
+++ b/res/field/scripts/scripts_init_ruin_maniac_cave_long.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_ruin_maniac_cave_short.s
+++ b/res/field/scripts/scripts_init_ruin_maniac_cave_short.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sandgem_town.s
+++ b/res/field/scripts/scripts_init_sandgem_town.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sandgem_town_counterpart_house_1f.s
+++ b/res/field/scripts/scripts_init_sandgem_town_counterpart_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sandgem_town_counterpart_house_2f.s
+++ b/res/field/scripts/scripts_init_sandgem_town_counterpart_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sandgem_town_house.s
+++ b/res/field/scripts/scripts_init_sandgem_town_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sandgem_town_mart.s
+++ b/res/field/scripts/scripts_init_sandgem_town_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sandgem_town_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_sandgem_town_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sandgem_town_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_sandgem_town_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sandgem_town_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_sandgem_town_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sandgem_town_pokemon_research_lab.s
+++ b/res/field/scripts/scripts_init_sandgem_town_pokemon_research_lab.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sendoff_spring.s
+++ b/res/field/scripts/scripts_init_sendoff_spring.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_snowpoint_city.s
+++ b/res/field/scripts/scripts_init_snowpoint_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_snowpoint_city_east_house.s
+++ b/res/field/scripts/scripts_init_snowpoint_city_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_snowpoint_city_gym.s
+++ b/res/field/scripts/scripts_init_snowpoint_city_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_snowpoint_city_mart.s
+++ b/res/field/scripts/scripts_init_snowpoint_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_snowpoint_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_snowpoint_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_snowpoint_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_snowpoint_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_snowpoint_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_snowpoint_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_snowpoint_city_west_house.s
+++ b/res/field/scripts/scripts_init_snowpoint_city_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_snowpoint_temple_1f.s
+++ b/res/field/scripts/scripts_init_snowpoint_temple_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_snowpoint_temple_b5f.s
+++ b/res/field/scripts/scripts_init_snowpoint_temple_b5f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_solaceon_ruins_maniac_tunnel_room.s
+++ b/res/field/scripts/scripts_init_solaceon_ruins_maniac_tunnel_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_solaceon_ruins_room_1.s
+++ b/res/field/scripts/scripts_init_solaceon_ruins_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_solaceon_ruins_room_2.s
+++ b/res/field/scripts/scripts_init_solaceon_ruins_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_solaceon_ruins_room_7.s
+++ b/res/field/scripts/scripts_init_solaceon_ruins_room_7.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_solaceon_town.s
+++ b/res/field/scripts/scripts_init_solaceon_town.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_solaceon_town_east_house.s
+++ b/res/field/scripts/scripts_init_solaceon_town_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_solaceon_town_mart.s
+++ b/res/field/scripts/scripts_init_solaceon_town_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_solaceon_town_north_house.s
+++ b/res/field/scripts/scripts_init_solaceon_town_north_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_solaceon_town_northeast_house.s
+++ b/res/field/scripts/scripts_init_solaceon_town_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_solaceon_town_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_solaceon_town_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_solaceon_town_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_solaceon_town_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_solaceon_town_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_solaceon_town_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_solaceon_town_pokemon_news_press.s
+++ b/res/field/scripts/scripts_init_solaceon_town_pokemon_news_press.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_spear_pillar.s
+++ b/res/field/scripts/scripts_init_spear_pillar.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_spear_pillar_dialga.s
+++ b/res/field/scripts/scripts_init_spear_pillar_dialga.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_spear_pillar_distorted.s
+++ b/res/field/scripts/scripts_init_spear_pillar_distorted.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_spear_pillar_palkia.s
+++ b/res/field/scripts/scripts_init_spear_pillar_palkia.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_stark_mountain_outside.s
+++ b/res/field/scripts/scripts_init_stark_mountain_outside.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_stark_mountain_room_1.s
+++ b/res/field/scripts/scripts_init_stark_mountain_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_stark_mountain_room_2.s
+++ b/res/field/scripts/scripts_init_stark_mountain_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_stark_mountain_room_3.s
+++ b/res/field/scripts/scripts_init_stark_mountain_room_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city.s
+++ b/res/field/scripts/scripts_init_sunyshore_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city_east_house.s
+++ b/res/field/scripts/scripts_init_sunyshore_city_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city_gym_room_1.s
+++ b/res/field/scripts/scripts_init_sunyshore_city_gym_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city_gym_room_2.s
+++ b/res/field/scripts/scripts_init_sunyshore_city_gym_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city_gym_room_3.s
+++ b/res/field/scripts/scripts_init_sunyshore_city_gym_room_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city_mart.s
+++ b/res/field/scripts/scripts_init_sunyshore_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city_northeast_house.s
+++ b/res/field/scripts/scripts_init_sunyshore_city_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city_northwest_house.s
+++ b/res/field/scripts/scripts_init_sunyshore_city_northwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_sunyshore_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_sunyshore_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_sunyshore_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city_unknown_house_1.s
+++ b/res/field/scripts/scripts_init_sunyshore_city_unknown_house_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city_unknown_house_2.s
+++ b/res/field/scripts/scripts_init_sunyshore_city_unknown_house_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_city_west_house.s
+++ b/res/field/scripts/scripts_init_sunyshore_city_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_sunyshore_market.s
+++ b/res/field/scripts/scripts_init_sunyshore_market.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_survival_area.s
+++ b/res/field/scripts/scripts_init_survival_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_survival_area_mart.s
+++ b/res/field/scripts/scripts_init_survival_area_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_survival_area_north_house.s
+++ b/res/field/scripts/scripts_init_survival_area_north_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_survival_area_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_survival_area_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_survival_area_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_survival_area_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_survival_area_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_survival_area_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_survival_area_south_house.s
+++ b/res/field/scripts/scripts_init_survival_area_south_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_team_galactic_eterna_building_1f.s
+++ b/res/field/scripts/scripts_init_team_galactic_eterna_building_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_team_galactic_eterna_building_2f.s
+++ b/res/field/scripts/scripts_init_team_galactic_eterna_building_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_team_galactic_eterna_building_3f.s
+++ b/res/field/scripts/scripts_init_team_galactic_eterna_building_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_team_galactic_eterna_building_4f.s
+++ b/res/field/scripts/scripts_init_team_galactic_eterna_building_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_trainers_school.s
+++ b/res/field/scripts/scripts_init_trainers_school.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_entrance.s
+++ b/res/field/scripts/scripts_init_turnback_cave_entrance.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_giratina_room.s
+++ b/res/field/scripts/scripts_init_turnback_cave_giratina_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_1_room_1.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_1_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_1_room_2.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_1_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_1_room_3.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_1_room_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_1_room_4.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_1_room_4.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_1_room_5.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_1_room_5.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_1_room_6.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_1_room_6.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_2_room_1.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_2_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_2_room_2.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_2_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_2_room_3.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_2_room_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_2_room_4.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_2_room_4.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_2_room_5.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_2_room_5.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_2_room_6.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_2_room_6.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_3_room_1.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_3_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_3_room_2.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_3_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_3_room_3.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_3_room_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_3_room_4.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_3_room_4.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_3_room_5.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_3_room_5.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_3_room_6.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_3_room_6.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_turnback_cave_pillar_room.s
+++ b/res/field/scripts/scripts_init_turnback_cave_pillar_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_twinleaf_town.s
+++ b/res/field/scripts/scripts_init_twinleaf_town.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_twinleaf_town_northeast_house.s
+++ b/res/field/scripts/scripts_init_twinleaf_town_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_twinleaf_town_player_house_1f.s
+++ b/res/field/scripts/scripts_init_twinleaf_town_player_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_twinleaf_town_player_house_2f.s
+++ b/res/field/scripts/scripts_init_twinleaf_town_player_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_twinleaf_town_rival_house_1f.s
+++ b/res/field/scripts/scripts_init_twinleaf_town_rival_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_twinleaf_town_rival_house_2f.s
+++ b/res/field/scripts/scripts_init_twinleaf_town_rival_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_twinleaf_town_southwest_house.s
+++ b/res/field/scripts/scripts_init_twinleaf_town_southwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_underground.s
+++ b/res/field/scripts/scripts_init_underground.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_union_room.s
+++ b/res/field/scripts/scripts_init_union_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_unknown_578.s
+++ b/res/field/scripts/scripts_init_unknown_578.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_valley_windworks_building.s
+++ b/res/field/scripts/scripts_init_valley_windworks_building.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_valley_windworks_outside.s
+++ b/res/field/scripts/scripts_init_valley_windworks_outside.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_valor_cavern.s
+++ b/res/field/scripts/scripts_init_valor_cavern.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_valor_lakefront.s
+++ b/res/field/scripts/scripts_init_valor_lakefront.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_city.s
+++ b/res/field/scripts/scripts_init_veilstone_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_city_galactic_warehouse.s
+++ b/res/field/scripts/scripts_init_veilstone_city_galactic_warehouse.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_city_gym.s
+++ b/res/field/scripts/scripts_init_veilstone_city_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_city_northeast_house.s
+++ b/res/field/scripts/scripts_init_veilstone_city_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_city_northwest_house.s
+++ b/res/field/scripts/scripts_init_veilstone_city_northwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_init_veilstone_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_init_veilstone_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_init_veilstone_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_city_prize_exchange.s
+++ b/res/field/scripts/scripts_init_veilstone_city_prize_exchange.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_city_southeast_house.s
+++ b/res/field/scripts/scripts_init_veilstone_city_southeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_city_southwest_house.s
+++ b/res/field/scripts/scripts_init_veilstone_city_southwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_store_1f.s
+++ b/res/field/scripts/scripts_init_veilstone_store_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_store_2f.s
+++ b/res/field/scripts/scripts_init_veilstone_store_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_store_3f.s
+++ b/res/field/scripts/scripts_init_veilstone_store_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_store_4f.s
+++ b/res/field/scripts/scripts_init_veilstone_store_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_store_5f.s
+++ b/res/field/scripts/scripts_init_veilstone_store_5f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_store_b1f.s
+++ b/res/field/scripts/scripts_init_veilstone_store_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_veilstone_store_elevator.s
+++ b/res/field/scripts/scripts_init_veilstone_store_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_verity_cavern.s
+++ b/res/field/scripts/scripts_init_verity_cavern.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_verity_lakefront.s
+++ b/res/field/scripts/scripts_init_verity_lakefront.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_verity_lakefront_unknown_house.s
+++ b/res/field/scripts/scripts_init_verity_lakefront_unknown_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_victory_road_1f.s
+++ b/res/field/scripts/scripts_init_victory_road_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_victory_road_1f_room_2.s
+++ b/res/field/scripts/scripts_init_victory_road_1f_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_villa.s
+++ b/res/field/scripts/scripts_init_villa.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_vista_lighthouse.s
+++ b/res/field/scripts/scripts_init_vista_lighthouse.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_vista_lighthouse_elevator.s
+++ b/res/field/scripts/scripts_init_vista_lighthouse_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_wayward_cave_1f.s
+++ b/res/field/scripts/scripts_init_wayward_cave_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_init_wifi_plaza_entrance.s
+++ b/res/field/scripts/scripts_init_wifi_plaza_entrance.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_iron_island.s
+++ b/res/field/scripts/scripts_iron_island.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_iron_island_1f.s
+++ b/res/field/scripts/scripts_iron_island_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_iron_island_b1f_right_room.s
+++ b/res/field/scripts/scripts_iron_island_b1f_right_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_iron_island_b2f_left_room.s
+++ b/res/field/scripts/scripts_iron_island_b2f_left_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_iron_island_b3f.s
+++ b/res/field/scripts/scripts_iron_island_b3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_iron_island_house.s
+++ b/res/field/scripts/scripts_iron_island_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_iron_ruins.s
+++ b/res/field/scripts/scripts_iron_ruins.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city.s
+++ b/res/field/scripts/scripts_jubilife_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_condominiums_1f.s
+++ b/res/field/scripts/scripts_jubilife_city_condominiums_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_condominiums_2f.s
+++ b/res/field/scripts/scripts_jubilife_city_condominiums_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_condominiums_3f.s
+++ b/res/field/scripts/scripts_jubilife_city_condominiums_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_condominiums_4f.s
+++ b/res/field/scripts/scripts_jubilife_city_condominiums_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_mart.s
+++ b/res/field/scripts/scripts_jubilife_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_jubilife_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_jubilife_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_jubilife_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_south_house_1f.s
+++ b/res/field/scripts/scripts_jubilife_city_south_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_south_house_2f.s
+++ b/res/field/scripts/scripts_jubilife_city_south_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_south_house_3f.s
+++ b/res/field/scripts/scripts_jubilife_city_south_house_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_southwest_house_1f.s
+++ b/res/field/scripts/scripts_jubilife_city_southwest_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_southwest_house_2f.s
+++ b/res/field/scripts/scripts_jubilife_city_southwest_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_unknown_house_1.s
+++ b/res/field/scripts/scripts_jubilife_city_unknown_house_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_unknown_house_2.s
+++ b/res/field/scripts/scripts_jubilife_city_unknown_house_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_unknown_house_3.s
+++ b/res/field/scripts/scripts_jubilife_city_unknown_house_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_city_unknown_house_4.s
+++ b/res/field/scripts/scripts_jubilife_city_unknown_house_4.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_tv_1f.s
+++ b/res/field/scripts/scripts_jubilife_tv_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_tv_2f.s
+++ b/res/field/scripts/scripts_jubilife_tv_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_tv_2f_gallery.s
+++ b/res/field/scripts/scripts_jubilife_tv_2f_gallery.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_tv_3f.s
+++ b/res/field/scripts/scripts_jubilife_tv_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_tv_3f_global_ranking_room.s
+++ b/res/field/scripts/scripts_jubilife_tv_3f_global_ranking_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_tv_3f_group_ranking_room.s
+++ b/res/field/scripts/scripts_jubilife_tv_3f_group_ranking_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_tv_4f.s
+++ b/res/field/scripts/scripts_jubilife_tv_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_jubilife_tv_elevator.s
+++ b/res/field/scripts/scripts_jubilife_tv_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_lake_acuity.s
+++ b/res/field/scripts/scripts_lake_acuity.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_lake_acuity_low_water.s
+++ b/res/field/scripts/scripts_lake_acuity_low_water.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_lake_valor.s
+++ b/res/field/scripts/scripts_lake_valor.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_lake_valor_drained.s
+++ b/res/field/scripts/scripts_lake_valor_drained.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_lake_verity.s
+++ b/res/field/scripts/scripts_lake_verity.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_lake_verity_low_water.s
+++ b/res/field/scripts/scripts_lake_verity_low_water.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_maniac_tunnel.s
+++ b/res/field/scripts/scripts_maniac_tunnel.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_map_header_unknown_578.s
+++ b/res/field/scripts/scripts_map_header_unknown_578.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_mining_museum.s
+++ b/res/field/scripts/scripts_mining_museum.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_mt_coronet_1f_north_room_1.s
+++ b/res/field/scripts/scripts_mt_coronet_1f_north_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_mt_coronet_1f_north_room_2.s
+++ b/res/field/scripts/scripts_mt_coronet_1f_north_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_mt_coronet_1f_south.s
+++ b/res/field/scripts/scripts_mt_coronet_1f_south.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_mt_coronet_1f_tunnel_room.s
+++ b/res/field/scripts/scripts_mt_coronet_1f_tunnel_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_mt_coronet_2f.s
+++ b/res/field/scripts/scripts_mt_coronet_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_mt_coronet_6f.s
+++ b/res/field/scripts/scripts_mt_coronet_6f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_newmoon_island.s
+++ b/res/field/scripts/scripts_newmoon_island.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_newmoon_island_forest.s
+++ b/res/field/scripts/scripts_newmoon_island_forest.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_old_chateau.s
+++ b/res/field/scripts/scripts_old_chateau.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_old_chateau_back_middle_east_room.s
+++ b/res/field/scripts/scripts_old_chateau_back_middle_east_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_old_chateau_back_middle_west_room.s
+++ b/res/field/scripts/scripts_old_chateau_back_middle_west_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_old_chateau_dining_area.s
+++ b/res/field/scripts/scripts_old_chateau_dining_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_old_chateau_side_rooms.s
+++ b/res/field/scripts/scripts_old_chateau_side_rooms.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city.s
+++ b/res/field/scripts/scripts_oreburgh_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_east_house_1f.s
+++ b/res/field/scripts/scripts_oreburgh_city_east_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_east_house_2f.s
+++ b/res/field/scripts/scripts_oreburgh_city_east_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_east_house_3f.s
+++ b/res/field/scripts/scripts_oreburgh_city_east_house_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_gym.s
+++ b/res/field/scripts/scripts_oreburgh_city_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_mart.s
+++ b/res/field/scripts/scripts_oreburgh_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_middle_house.s
+++ b/res/field/scripts/scripts_oreburgh_city_middle_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_north_house_1f.s
+++ b/res/field/scripts/scripts_oreburgh_city_north_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_north_house_2f.s
+++ b/res/field/scripts/scripts_oreburgh_city_north_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_north_house_3f.s
+++ b/res/field/scripts/scripts_oreburgh_city_north_house_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_north_house_4f.s
+++ b/res/field/scripts/scripts_oreburgh_city_north_house_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_northwest_house_1f.s
+++ b/res/field/scripts/scripts_oreburgh_city_northwest_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_northwest_house_2f.s
+++ b/res/field/scripts/scripts_oreburgh_city_northwest_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_northwest_house_3f.s
+++ b/res/field/scripts/scripts_oreburgh_city_northwest_house_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_northwest_house_4f.s
+++ b/res/field/scripts/scripts_oreburgh_city_northwest_house_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_oreburgh_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_oreburgh_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_oreburgh_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_south_house.s
+++ b/res/field/scripts/scripts_oreburgh_city_south_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_city_west_house.s
+++ b/res/field/scripts/scripts_oreburgh_city_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_gate_1f.s
+++ b/res/field/scripts/scripts_oreburgh_gate_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_gate_b1f.s
+++ b/res/field/scripts/scripts_oreburgh_gate_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_mine_b1f.s
+++ b/res/field/scripts/scripts_oreburgh_mine_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_oreburgh_mine_b2f.s
+++ b/res/field/scripts/scripts_oreburgh_mine_b2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pal_park.s
+++ b/res/field/scripts/scripts_pal_park.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pal_park_lobby.s
+++ b/res/field/scripts/scripts_pal_park_lobby.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pastoria_city.s
+++ b/res/field/scripts/scripts_pastoria_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pastoria_city_east_house.s
+++ b/res/field/scripts/scripts_pastoria_city_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pastoria_city_gym.s
+++ b/res/field/scripts/scripts_pastoria_city_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pastoria_city_mart.s
+++ b/res/field/scripts/scripts_pastoria_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pastoria_city_middle_house.s
+++ b/res/field/scripts/scripts_pastoria_city_middle_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pastoria_city_north_house.s
+++ b/res/field/scripts/scripts_pastoria_city_north_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pastoria_city_northeast_house.s
+++ b/res/field/scripts/scripts_pastoria_city_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pastoria_city_observatory_gate_1f.s
+++ b/res/field/scripts/scripts_pastoria_city_observatory_gate_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pastoria_city_observatory_gate_2f.s
+++ b/res/field/scripts/scripts_pastoria_city_observatory_gate_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pastoria_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_pastoria_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pastoria_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_pastoria_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pastoria_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_pastoria_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pastoria_city_southwest_house.s
+++ b/res/field/scripts/scripts_pastoria_city_southwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_poffin_house.s
+++ b/res/field/scripts/scripts_poffin_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_day_care.s
+++ b/res/field/scripts/scripts_pokemon_day_care.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league.s
+++ b/res/field/scripts/scripts_pokemon_league.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_aaron_room.s
+++ b/res/field/scripts/scripts_pokemon_league_aaron_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_bertha_room.s
+++ b/res/field/scripts/scripts_pokemon_league_bertha_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_champion_room.s
+++ b/res/field/scripts/scripts_pokemon_league_champion_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_elevator_to_aaron_room.s
+++ b/res/field/scripts/scripts_pokemon_league_elevator_to_aaron_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_elevator_to_bertha_room.s
+++ b/res/field/scripts/scripts_pokemon_league_elevator_to_bertha_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_elevator_to_champion_room.s
+++ b/res/field/scripts/scripts_pokemon_league_elevator_to_champion_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_elevator_to_flint_room.s
+++ b/res/field/scripts/scripts_pokemon_league_elevator_to_flint_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_elevator_to_hall_of_fame.s
+++ b/res/field/scripts/scripts_pokemon_league_elevator_to_hall_of_fame.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_elevator_to_lucian_room.s
+++ b/res/field/scripts/scripts_pokemon_league_elevator_to_lucian_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_flint_room.s
+++ b/res/field/scripts/scripts_pokemon_league_flint_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_hall_of_fame.s
+++ b/res/field/scripts/scripts_pokemon_league_hall_of_fame.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_lucian_room.s
+++ b/res/field/scripts/scripts_pokemon_league_lucian_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_north_pokecenter_1f.s
+++ b/res/field/scripts/scripts_pokemon_league_north_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_north_pokecenter_2f.s
+++ b/res/field/scripts/scripts_pokemon_league_north_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_north_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_pokemon_league_north_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_south_pokecenter_1f.s
+++ b/res/field/scripts/scripts_pokemon_league_south_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_south_pokecenter_2f.s
+++ b/res/field/scripts/scripts_pokemon_league_south_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_league_south_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_pokemon_league_south_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_mansion.s
+++ b/res/field/scripts/scripts_pokemon_mansion.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_mansion_maids_room.s
+++ b/res/field/scripts/scripts_pokemon_mansion_maids_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_pokemon_mansion_office.s
+++ b/res/field/scripts/scripts_pokemon_mansion_office.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_poketch_co_1f.s
+++ b/res/field/scripts/scripts_poketch_co_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_poketch_co_2f.s
+++ b/res/field/scripts/scripts_poketch_co_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_poketch_co_3f.s
+++ b/res/field/scripts/scripts_poketch_co_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_ravaged_path.s
+++ b/res/field/scripts/scripts_ravaged_path.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_resort_area.s
+++ b/res/field/scripts/scripts_resort_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_resort_area_house.s
+++ b/res/field/scripts/scripts_resort_area_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_resort_area_mart.s
+++ b/res/field/scripts/scripts_resort_area_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_resort_area_pokecenter_1f.s
+++ b/res/field/scripts/scripts_resort_area_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_resort_area_pokecenter_2f.s
+++ b/res/field/scripts/scripts_resort_area_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_resort_area_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_resort_area_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_resort_area_ribbon_syndicate_1f.s
+++ b/res/field/scripts/scripts_resort_area_ribbon_syndicate_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_resort_area_ribbon_syndicate_2f.s
+++ b/res/field/scripts/scripts_resort_area_ribbon_syndicate_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_resort_area_ribbon_syndicate_elevator.s
+++ b/res/field/scripts/scripts_resort_area_ribbon_syndicate_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_restaurant.s
+++ b/res/field/scripts/scripts_restaurant.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_rock_peak_ruins.s
+++ b/res/field/scripts/scripts_rock_peak_ruins.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_rotoms_room.s
+++ b/res/field/scripts/scripts_rotoms_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_201.s
+++ b/res/field/scripts/scripts_route_201.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_202.s
+++ b/res/field/scripts/scripts_route_202.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_203.s
+++ b/res/field/scripts/scripts_route_203.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_204_north.s
+++ b/res/field/scripts/scripts_route_204_north.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_204_south.s
+++ b/res/field/scripts/scripts_route_204_south.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_205_house.s
+++ b/res/field/scripts/scripts_route_205_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_205_north.s
+++ b/res/field/scripts/scripts_route_205_north.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_205_south.s
+++ b/res/field/scripts/scripts_route_205_south.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_206.s
+++ b/res/field/scripts/scripts_route_206.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_206_cycling_road_north_gate.s
+++ b/res/field/scripts/scripts_route_206_cycling_road_north_gate.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_206_cycling_road_south_gate.s
+++ b/res/field/scripts/scripts_route_206_cycling_road_south_gate.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_207.s
+++ b/res/field/scripts/scripts_route_207.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_208.s
+++ b/res/field/scripts/scripts_route_208.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_208_gate_to_hearthome_city.s
+++ b/res/field/scripts/scripts_route_208_gate_to_hearthome_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_208_house.s
+++ b/res/field/scripts/scripts_route_208_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_209.s
+++ b/res/field/scripts/scripts_route_209.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_209_gate_to_hearthome_city.s
+++ b/res/field/scripts/scripts_route_209_gate_to_hearthome_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_209_lost_tower_1f.s
+++ b/res/field/scripts/scripts_route_209_lost_tower_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_209_lost_tower_5f.s
+++ b/res/field/scripts/scripts_route_209_lost_tower_5f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_210_grandma_wilma_house.s
+++ b/res/field/scripts/scripts_route_210_grandma_wilma_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_210_north.s
+++ b/res/field/scripts/scripts_route_210_north.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_210_south.s
+++ b/res/field/scripts/scripts_route_210_south.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_211_east.s
+++ b/res/field/scripts/scripts_route_211_east.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_211_west.s
+++ b/res/field/scripts/scripts_route_211_west.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_212_gate_to_hearthome_city.s
+++ b/res/field/scripts/scripts_route_212_gate_to_hearthome_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_212_house.s
+++ b/res/field/scripts/scripts_route_212_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_212_north.s
+++ b/res/field/scripts/scripts_route_212_north.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_212_south.s
+++ b/res/field/scripts/scripts_route_212_south.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_213.s
+++ b/res/field/scripts/scripts_route_213.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_213_gate_to_pastoria_city.s
+++ b/res/field/scripts/scripts_route_213_gate_to_pastoria_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_214.s
+++ b/res/field/scripts/scripts_route_214.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_214_gate_to_veilstone_city.s
+++ b/res/field/scripts/scripts_route_214_gate_to_veilstone_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_215.s
+++ b/res/field/scripts/scripts_route_215.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_215_gate_to_veilstone_city.s
+++ b/res/field/scripts/scripts_route_215_gate_to_veilstone_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_216.s
+++ b/res/field/scripts/scripts_route_216.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_216_house.s
+++ b/res/field/scripts/scripts_route_216_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_217.s
+++ b/res/field/scripts/scripts_route_217.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_217_northeast_house.s
+++ b/res/field/scripts/scripts_route_217_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_217_west_house.s
+++ b/res/field/scripts/scripts_route_217_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_218.s
+++ b/res/field/scripts/scripts_route_218.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_218_gate_to_canalave_city.s
+++ b/res/field/scripts/scripts_route_218_gate_to_canalave_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_218_gate_to_jubilife_city.s
+++ b/res/field/scripts/scripts_route_218_gate_to_jubilife_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_219.s
+++ b/res/field/scripts/scripts_route_219.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_221.s
+++ b/res/field/scripts/scripts_route_221.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_221_house.s
+++ b/res/field/scripts/scripts_route_221_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_222.s
+++ b/res/field/scripts/scripts_route_222.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_222_east_house.s
+++ b/res/field/scripts/scripts_route_222_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_222_gate_to_sunyshore_city.s
+++ b/res/field/scripts/scripts_route_222_gate_to_sunyshore_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_222_west_house.s
+++ b/res/field/scripts/scripts_route_222_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_224.s
+++ b/res/field/scripts/scripts_route_224.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_225.s
+++ b/res/field/scripts/scripts_route_225.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_225_gate_to_fight_area.s
+++ b/res/field/scripts/scripts_route_225_gate_to_fight_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_225_house.s
+++ b/res/field/scripts/scripts_route_225_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_226.s
+++ b/res/field/scripts/scripts_route_226.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_226_house.s
+++ b/res/field/scripts/scripts_route_226_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_227.s
+++ b/res/field/scripts/scripts_route_227.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_227_house.s
+++ b/res/field/scripts/scripts_route_227_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_228.s
+++ b/res/field/scripts/scripts_route_228.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_228_gate_to_route_226.s
+++ b/res/field/scripts/scripts_route_228_gate_to_route_226.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_228_north_house.s
+++ b/res/field/scripts/scripts_route_228_north_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_228_south_house.s
+++ b/res/field/scripts/scripts_route_228_south_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_229.s
+++ b/res/field/scripts/scripts_route_229.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_route_230.s
+++ b/res/field/scripts/scripts_route_230.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_ruin_maniac_cave_long.s
+++ b/res/field/scripts/scripts_ruin_maniac_cave_long.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_ruin_maniac_cave_short.s
+++ b/res/field/scripts/scripts_ruin_maniac_cave_short.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sandgem_town.s
+++ b/res/field/scripts/scripts_sandgem_town.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sandgem_town_counterpart_house_1f.s
+++ b/res/field/scripts/scripts_sandgem_town_counterpart_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sandgem_town_counterpart_house_2f.s
+++ b/res/field/scripts/scripts_sandgem_town_counterpart_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sandgem_town_house.s
+++ b/res/field/scripts/scripts_sandgem_town_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sandgem_town_mart.s
+++ b/res/field/scripts/scripts_sandgem_town_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sandgem_town_pokecenter_1f.s
+++ b/res/field/scripts/scripts_sandgem_town_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sandgem_town_pokecenter_2f.s
+++ b/res/field/scripts/scripts_sandgem_town_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sandgem_town_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_sandgem_town_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sandgem_town_pokemon_research_lab.s
+++ b/res/field/scripts/scripts_sandgem_town_pokemon_research_lab.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sendoff_spring.s
+++ b/res/field/scripts/scripts_sendoff_spring.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_snowpoint_city.s
+++ b/res/field/scripts/scripts_snowpoint_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_snowpoint_city_east_house.s
+++ b/res/field/scripts/scripts_snowpoint_city_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_snowpoint_city_gym.s
+++ b/res/field/scripts/scripts_snowpoint_city_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_snowpoint_city_mart.s
+++ b/res/field/scripts/scripts_snowpoint_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_snowpoint_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_snowpoint_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_snowpoint_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_snowpoint_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_snowpoint_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_snowpoint_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_snowpoint_city_west_house.s
+++ b/res/field/scripts/scripts_snowpoint_city_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_snowpoint_temple_1f.s
+++ b/res/field/scripts/scripts_snowpoint_temple_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_snowpoint_temple_b5f.s
+++ b/res/field/scripts/scripts_snowpoint_temple_b5f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_solaceon_ruins_maniac_tunnel_room.s
+++ b/res/field/scripts/scripts_solaceon_ruins_maniac_tunnel_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_solaceon_ruins_room_1.s
+++ b/res/field/scripts/scripts_solaceon_ruins_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_solaceon_ruins_room_2.s
+++ b/res/field/scripts/scripts_solaceon_ruins_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_solaceon_ruins_room_7.s
+++ b/res/field/scripts/scripts_solaceon_ruins_room_7.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_solaceon_town.s
+++ b/res/field/scripts/scripts_solaceon_town.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_solaceon_town_east_house.s
+++ b/res/field/scripts/scripts_solaceon_town_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_solaceon_town_mart.s
+++ b/res/field/scripts/scripts_solaceon_town_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_solaceon_town_north_house.s
+++ b/res/field/scripts/scripts_solaceon_town_north_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_solaceon_town_northeast_house.s
+++ b/res/field/scripts/scripts_solaceon_town_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_solaceon_town_pokecenter_1f.s
+++ b/res/field/scripts/scripts_solaceon_town_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_solaceon_town_pokecenter_2f.s
+++ b/res/field/scripts/scripts_solaceon_town_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_solaceon_town_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_solaceon_town_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_solaceon_town_pokemon_news_press.s
+++ b/res/field/scripts/scripts_solaceon_town_pokemon_news_press.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_spear_pillar.s
+++ b/res/field/scripts/scripts_spear_pillar.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_spear_pillar_dialga.s
+++ b/res/field/scripts/scripts_spear_pillar_dialga.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_spear_pillar_distorted.s
+++ b/res/field/scripts/scripts_spear_pillar_distorted.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_spear_pillar_palkia.s
+++ b/res/field/scripts/scripts_spear_pillar_palkia.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_stark_mountain_outside.s
+++ b/res/field/scripts/scripts_stark_mountain_outside.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_stark_mountain_room_1.s
+++ b/res/field/scripts/scripts_stark_mountain_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_stark_mountain_room_2.s
+++ b/res/field/scripts/scripts_stark_mountain_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_stark_mountain_room_3.s
+++ b/res/field/scripts/scripts_stark_mountain_room_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city.s
+++ b/res/field/scripts/scripts_sunyshore_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city_east_house.s
+++ b/res/field/scripts/scripts_sunyshore_city_east_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city_gym_room_1.s
+++ b/res/field/scripts/scripts_sunyshore_city_gym_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city_gym_room_2.s
+++ b/res/field/scripts/scripts_sunyshore_city_gym_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city_gym_room_3.s
+++ b/res/field/scripts/scripts_sunyshore_city_gym_room_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city_mart.s
+++ b/res/field/scripts/scripts_sunyshore_city_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city_northeast_house.s
+++ b/res/field/scripts/scripts_sunyshore_city_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city_northwest_house.s
+++ b/res/field/scripts/scripts_sunyshore_city_northwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_sunyshore_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_sunyshore_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_sunyshore_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city_unknown_house_1.s
+++ b/res/field/scripts/scripts_sunyshore_city_unknown_house_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city_unknown_house_2.s
+++ b/res/field/scripts/scripts_sunyshore_city_unknown_house_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_city_west_house.s
+++ b/res/field/scripts/scripts_sunyshore_city_west_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_sunyshore_market.s
+++ b/res/field/scripts/scripts_sunyshore_market.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_survival_area.s
+++ b/res/field/scripts/scripts_survival_area.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_survival_area_mart.s
+++ b/res/field/scripts/scripts_survival_area_mart.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_survival_area_north_house.s
+++ b/res/field/scripts/scripts_survival_area_north_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_survival_area_pokecenter_1f.s
+++ b/res/field/scripts/scripts_survival_area_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_survival_area_pokecenter_2f.s
+++ b/res/field/scripts/scripts_survival_area_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_survival_area_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_survival_area_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_survival_area_south_house.s
+++ b/res/field/scripts/scripts_survival_area_south_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_team_galactic_eterna_building_1f.s
+++ b/res/field/scripts/scripts_team_galactic_eterna_building_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_team_galactic_eterna_building_2f.s
+++ b/res/field/scripts/scripts_team_galactic_eterna_building_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_team_galactic_eterna_building_3f.s
+++ b/res/field/scripts/scripts_team_galactic_eterna_building_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_team_galactic_eterna_building_4f.s
+++ b/res/field/scripts/scripts_team_galactic_eterna_building_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_trainers_school.s
+++ b/res/field/scripts/scripts_trainers_school.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_entrance.s
+++ b/res/field/scripts/scripts_turnback_cave_entrance.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_giratina_room.s
+++ b/res/field/scripts/scripts_turnback_cave_giratina_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_1_room_1.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_1_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_1_room_2.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_1_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_1_room_3.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_1_room_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_1_room_4.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_1_room_4.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_1_room_5.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_1_room_5.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_1_room_6.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_1_room_6.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_2_room_1.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_2_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_2_room_2.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_2_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_2_room_3.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_2_room_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_2_room_4.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_2_room_4.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_2_room_5.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_2_room_5.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_2_room_6.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_2_room_6.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_3_room_1.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_3_room_1.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_3_room_2.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_3_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_3_room_3.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_3_room_3.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_3_room_4.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_3_room_4.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_3_room_5.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_3_room_5.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_3_room_6.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_3_room_6.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_turnback_cave_pillar_room.s
+++ b/res/field/scripts/scripts_turnback_cave_pillar_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_twinleaf_town.s
+++ b/res/field/scripts/scripts_twinleaf_town.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_twinleaf_town_northeast_house.s
+++ b/res/field/scripts/scripts_twinleaf_town_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_twinleaf_town_player_house_1f.s
+++ b/res/field/scripts/scripts_twinleaf_town_player_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_twinleaf_town_player_house_2f.s
+++ b/res/field/scripts/scripts_twinleaf_town_player_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_twinleaf_town_rival_house_1f.s
+++ b/res/field/scripts/scripts_twinleaf_town_rival_house_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_twinleaf_town_rival_house_2f.s
+++ b/res/field/scripts/scripts_twinleaf_town_rival_house_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_twinleaf_town_southwest_house.s
+++ b/res/field/scripts/scripts_twinleaf_town_southwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_underground.s
+++ b/res/field/scripts/scripts_underground.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_union_room.s
+++ b/res/field/scripts/scripts_union_room.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0000.s
+++ b/res/field/scripts/scripts_unk_0000.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0001.s
+++ b/res/field/scripts/scripts_unk_0001.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0022.s
+++ b/res/field/scripts/scripts_unk_0022.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0173.s
+++ b/res/field/scripts/scripts_unk_0173.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0210.s
+++ b/res/field/scripts/scripts_unk_0210.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0211.s
+++ b/res/field/scripts/scripts_unk_0211.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0212.s
+++ b/res/field/scripts/scripts_unk_0212.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0213.s
+++ b/res/field/scripts/scripts_unk_0213.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0222.s
+++ b/res/field/scripts/scripts_unk_0222.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0225.s
+++ b/res/field/scripts/scripts_unk_0225.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0226.s
+++ b/res/field/scripts/scripts_unk_0226.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0227.s
+++ b/res/field/scripts/scripts_unk_0227.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0228.s
+++ b/res/field/scripts/scripts_unk_0228.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0229.s
+++ b/res/field/scripts/scripts_unk_0229.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0230.s
+++ b/res/field/scripts/scripts_unk_0230.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0235.s
+++ b/res/field/scripts/scripts_unk_0235.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0241.s
+++ b/res/field/scripts/scripts_unk_0241.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0242.s
+++ b/res/field/scripts/scripts_unk_0242.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0251.s
+++ b/res/field/scripts/scripts_unk_0251.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0252.s
+++ b/res/field/scripts/scripts_unk_0252.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0254.s
+++ b/res/field/scripts/scripts_unk_0254.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0255.s
+++ b/res/field/scripts/scripts_unk_0255.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0256.s
+++ b/res/field/scripts/scripts_unk_0256.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0257.s
+++ b/res/field/scripts/scripts_unk_0257.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0258.s
+++ b/res/field/scripts/scripts_unk_0258.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0259.s
+++ b/res/field/scripts/scripts_unk_0259.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0260.s
+++ b/res/field/scripts/scripts_unk_0260.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0261.s
+++ b/res/field/scripts/scripts_unk_0261.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0262.s
+++ b/res/field/scripts/scripts_unk_0262.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0263.s
+++ b/res/field/scripts/scripts_unk_0263.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0265.s
+++ b/res/field/scripts/scripts_unk_0265.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0266.s
+++ b/res/field/scripts/scripts_unk_0266.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0268.s
+++ b/res/field/scripts/scripts_unk_0268.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0269.s
+++ b/res/field/scripts/scripts_unk_0269.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0271.s
+++ b/res/field/scripts/scripts_unk_0271.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0272.s
+++ b/res/field/scripts/scripts_unk_0272.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0276.s
+++ b/res/field/scripts/scripts_unk_0276.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0287.s
+++ b/res/field/scripts/scripts_unk_0287.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0311.s
+++ b/res/field/scripts/scripts_unk_0311.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0313.s
+++ b/res/field/scripts/scripts_unk_0313.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0314.s
+++ b/res/field/scripts/scripts_unk_0314.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0315.s
+++ b/res/field/scripts/scripts_unk_0315.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0316.s
+++ b/res/field/scripts/scripts_unk_0316.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0319.s
+++ b/res/field/scripts/scripts_unk_0319.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0323.s
+++ b/res/field/scripts/scripts_unk_0323.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0326.s
+++ b/res/field/scripts/scripts_unk_0326.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0328.s
+++ b/res/field/scripts/scripts_unk_0328.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0335.s
+++ b/res/field/scripts/scripts_unk_0335.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0336.s
+++ b/res/field/scripts/scripts_unk_0336.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0338.s
+++ b/res/field/scripts/scripts_unk_0338.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0340.s
+++ b/res/field/scripts/scripts_unk_0340.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0350.s
+++ b/res/field/scripts/scripts_unk_0350.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0354.s
+++ b/res/field/scripts/scripts_unk_0354.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0358.s
+++ b/res/field/scripts/scripts_unk_0358.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0366.s
+++ b/res/field/scripts/scripts_unk_0366.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0391.s
+++ b/res/field/scripts/scripts_unk_0391.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0393.s
+++ b/res/field/scripts/scripts_unk_0393.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0395.s
+++ b/res/field/scripts/scripts_unk_0395.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0397.s
+++ b/res/field/scripts/scripts_unk_0397.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0400.s
+++ b/res/field/scripts/scripts_unk_0400.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0402.s
+++ b/res/field/scripts/scripts_unk_0402.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0403.s
+++ b/res/field/scripts/scripts_unk_0403.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0404.s
+++ b/res/field/scripts/scripts_unk_0404.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0405.s
+++ b/res/field/scripts/scripts_unk_0405.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0406.s
+++ b/res/field/scripts/scripts_unk_0406.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0407.s
+++ b/res/field/scripts/scripts_unk_0407.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0408.s
+++ b/res/field/scripts/scripts_unk_0408.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0409.s
+++ b/res/field/scripts/scripts_unk_0409.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0411.s
+++ b/res/field/scripts/scripts_unk_0411.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0412.s
+++ b/res/field/scripts/scripts_unk_0412.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0413.s
+++ b/res/field/scripts/scripts_unk_0413.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0421.s
+++ b/res/field/scripts/scripts_unk_0421.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0422.s
+++ b/res/field/scripts/scripts_unk_0422.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0423.s
+++ b/res/field/scripts/scripts_unk_0423.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0424.s
+++ b/res/field/scripts/scripts_unk_0424.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0425.s
+++ b/res/field/scripts/scripts_unk_0425.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0426.s
+++ b/res/field/scripts/scripts_unk_0426.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0443.s
+++ b/res/field/scripts/scripts_unk_0443.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0444.s
+++ b/res/field/scripts/scripts_unk_0444.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0445.s
+++ b/res/field/scripts/scripts_unk_0445.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0488.s
+++ b/res/field/scripts/scripts_unk_0488.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0496.s
+++ b/res/field/scripts/scripts_unk_0496.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0497.s
+++ b/res/field/scripts/scripts_unk_0497.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0498.s
+++ b/res/field/scripts/scripts_unk_0498.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0499.s
+++ b/res/field/scripts/scripts_unk_0499.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0500.s
+++ b/res/field/scripts/scripts_unk_0500.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0501.s
+++ b/res/field/scripts/scripts_unk_0501.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0522.s
+++ b/res/field/scripts/scripts_unk_0522.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0673.s
+++ b/res/field/scripts/scripts_unk_0673.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0710.s
+++ b/res/field/scripts/scripts_unk_0710.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0719.s
+++ b/res/field/scripts/scripts_unk_0719.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0722.s
+++ b/res/field/scripts/scripts_unk_0722.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0723.s
+++ b/res/field/scripts/scripts_unk_0723.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0724.s
+++ b/res/field/scripts/scripts_unk_0724.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0725.s
+++ b/res/field/scripts/scripts_unk_0725.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0726.s
+++ b/res/field/scripts/scripts_unk_0726.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0727.s
+++ b/res/field/scripts/scripts_unk_0727.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0732.s
+++ b/res/field/scripts/scripts_unk_0732.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0738.s
+++ b/res/field/scripts/scripts_unk_0738.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0739.s
+++ b/res/field/scripts/scripts_unk_0739.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0748.s
+++ b/res/field/scripts/scripts_unk_0748.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0749.s
+++ b/res/field/scripts/scripts_unk_0749.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0751.s
+++ b/res/field/scripts/scripts_unk_0751.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0752.s
+++ b/res/field/scripts/scripts_unk_0752.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0753.s
+++ b/res/field/scripts/scripts_unk_0753.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0754.s
+++ b/res/field/scripts/scripts_unk_0754.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0755.s
+++ b/res/field/scripts/scripts_unk_0755.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0756.s
+++ b/res/field/scripts/scripts_unk_0756.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0757.s
+++ b/res/field/scripts/scripts_unk_0757.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0758.s
+++ b/res/field/scripts/scripts_unk_0758.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0759.s
+++ b/res/field/scripts/scripts_unk_0759.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0760.s
+++ b/res/field/scripts/scripts_unk_0760.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0762.s
+++ b/res/field/scripts/scripts_unk_0762.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0763.s
+++ b/res/field/scripts/scripts_unk_0763.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0765.s
+++ b/res/field/scripts/scripts_unk_0765.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0766.s
+++ b/res/field/scripts/scripts_unk_0766.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0768.s
+++ b/res/field/scripts/scripts_unk_0768.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0769.s
+++ b/res/field/scripts/scripts_unk_0769.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0773.s
+++ b/res/field/scripts/scripts_unk_0773.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0784.s
+++ b/res/field/scripts/scripts_unk_0784.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0808.s
+++ b/res/field/scripts/scripts_unk_0808.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0810.s
+++ b/res/field/scripts/scripts_unk_0810.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0811.s
+++ b/res/field/scripts/scripts_unk_0811.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0812.s
+++ b/res/field/scripts/scripts_unk_0812.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0813.s
+++ b/res/field/scripts/scripts_unk_0813.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0816.s
+++ b/res/field/scripts/scripts_unk_0816.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0820.s
+++ b/res/field/scripts/scripts_unk_0820.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0823.s
+++ b/res/field/scripts/scripts_unk_0823.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0825.s
+++ b/res/field/scripts/scripts_unk_0825.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0832.s
+++ b/res/field/scripts/scripts_unk_0832.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0833.s
+++ b/res/field/scripts/scripts_unk_0833.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0835.s
+++ b/res/field/scripts/scripts_unk_0835.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0837.s
+++ b/res/field/scripts/scripts_unk_0837.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0847.s
+++ b/res/field/scripts/scripts_unk_0847.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0851.s
+++ b/res/field/scripts/scripts_unk_0851.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0855.s
+++ b/res/field/scripts/scripts_unk_0855.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0863.s
+++ b/res/field/scripts/scripts_unk_0863.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0888.s
+++ b/res/field/scripts/scripts_unk_0888.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0890.s
+++ b/res/field/scripts/scripts_unk_0890.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0892.s
+++ b/res/field/scripts/scripts_unk_0892.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0896.s
+++ b/res/field/scripts/scripts_unk_0896.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0898.s
+++ b/res/field/scripts/scripts_unk_0898.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0900.s
+++ b/res/field/scripts/scripts_unk_0900.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0908.s
+++ b/res/field/scripts/scripts_unk_0908.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0925.s
+++ b/res/field/scripts/scripts_unk_0925.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0926.s
+++ b/res/field/scripts/scripts_unk_0926.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0927.s
+++ b/res/field/scripts/scripts_unk_0927.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0970.s
+++ b/res/field/scripts/scripts_unk_0970.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0978.s
+++ b/res/field/scripts/scripts_unk_0978.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0979.s
+++ b/res/field/scripts/scripts_unk_0979.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0980.s
+++ b/res/field/scripts/scripts_unk_0980.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_0981.s
+++ b/res/field/scripts/scripts_unk_0981.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_1017.s
+++ b/res/field/scripts/scripts_unk_1017.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_1046.s
+++ b/res/field/scripts/scripts_unk_1046.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_1047.s
+++ b/res/field/scripts/scripts_unk_1047.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_1051.s
+++ b/res/field/scripts/scripts_unk_1051.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_1087.s
+++ b/res/field/scripts/scripts_unk_1087.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_1114.s
+++ b/res/field/scripts/scripts_unk_1114.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_1115.s
+++ b/res/field/scripts/scripts_unk_1115.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_1116.s
+++ b/res/field/scripts/scripts_unk_1116.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_1119.s
+++ b/res/field/scripts/scripts_unk_1119.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_unk_1120.s
+++ b/res/field/scripts/scripts_unk_1120.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_valley_windworks_building.s
+++ b/res/field/scripts/scripts_valley_windworks_building.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_valley_windworks_outside.s
+++ b/res/field/scripts/scripts_valley_windworks_outside.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_valor_cavern.s
+++ b/res/field/scripts/scripts_valor_cavern.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_valor_lakefront.s
+++ b/res/field/scripts/scripts_valor_lakefront.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_city.s
+++ b/res/field/scripts/scripts_veilstone_city.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_city_galactic_warehouse.s
+++ b/res/field/scripts/scripts_veilstone_city_galactic_warehouse.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_city_gym.s
+++ b/res/field/scripts/scripts_veilstone_city_gym.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_city_northeast_house.s
+++ b/res/field/scripts/scripts_veilstone_city_northeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_city_northwest_house.s
+++ b/res/field/scripts/scripts_veilstone_city_northwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_city_pokecenter_1f.s
+++ b/res/field/scripts/scripts_veilstone_city_pokecenter_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_veilstone_city_pokecenter_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_veilstone_city_pokecenter_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_city_prize_exchange.s
+++ b/res/field/scripts/scripts_veilstone_city_prize_exchange.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_city_southeast_house.s
+++ b/res/field/scripts/scripts_veilstone_city_southeast_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_city_southwest_house.s
+++ b/res/field/scripts/scripts_veilstone_city_southwest_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_store_1f.s
+++ b/res/field/scripts/scripts_veilstone_store_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_store_2f.s
+++ b/res/field/scripts/scripts_veilstone_store_2f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_store_3f.s
+++ b/res/field/scripts/scripts_veilstone_store_3f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_store_4f.s
+++ b/res/field/scripts/scripts_veilstone_store_4f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_store_5f.s
+++ b/res/field/scripts/scripts_veilstone_store_5f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_store_b1f.s
+++ b/res/field/scripts/scripts_veilstone_store_b1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_veilstone_store_elevator.s
+++ b/res/field/scripts/scripts_veilstone_store_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_verity_cavern.s
+++ b/res/field/scripts/scripts_verity_cavern.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_verity_lakefront.s
+++ b/res/field/scripts/scripts_verity_lakefront.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_verity_lakefront_unknown_house.s
+++ b/res/field/scripts/scripts_verity_lakefront_unknown_house.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_victory_road_1f.s
+++ b/res/field/scripts/scripts_victory_road_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_victory_road_1f_room_2.s
+++ b/res/field/scripts/scripts_victory_road_1f_room_2.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_villa.s
+++ b/res/field/scripts/scripts_villa.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_vista_lighthouse.s
+++ b/res/field/scripts/scripts_vista_lighthouse.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_vista_lighthouse_elevator.s
+++ b/res/field/scripts/scripts_vista_lighthouse_elevator.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_wayward_cave_1f.s
+++ b/res/field/scripts/scripts_wayward_cave_1f.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/field/scripts/scripts_wifi_plaza_entrance.s
+++ b/res/field/scripts/scripts_wifi_plaza_entrance.s
@@ -1,4 +1,4 @@
-    .include "macros/scrcmd.inc"
+#include "macros/scrcmd.inc"
 
     .data
 

--- a/res/meson.build
+++ b/res/meson.build
@@ -1,11 +1,34 @@
 nitrofs_files = []
 naix_headers = []
 
-# Prebuilt files
+### PREBUILT FILES ###
 subdir('prebuilt')
 
-# Decompiled data directories
+### DECOMPILED DATA DIRECTORIES ###
 subdir('text') # must be listed first for GMM header targets
+
+# Common generator for "scripting" files, i.e. field and battle scripts
+relative_source_root = fs.relative_to(meson.project_source_root(), meson.project_build_root())
+
+s_to_bin_gen = generator(make_script_bin_sh,
+    arguments: [
+        '-i', relative_source_root / 'include',
+        '-i', relative_source_root / 'asm',
+        '-i', '.' / 'res' / 'text',
+        '-i', '.' / 'res',
+        '-i', '.',
+        '--assembler', arm_none_eabi_gcc_exe.full_path(),
+        '--objcopy', arm_none_eabi_objcopy_exe.full_path(),
+        '@EXTRA_ARGS@',
+        '@INPUT@',
+    ],
+    depends: [
+        message_banks_narc, # for GMM headers
+        asm_consts_generators, # for ASM headers
+        c_consts_generators, # for C headers
+    ],
+    output: '@BASENAME@'
+)
 
 subdir('battle')
 subdir('field')

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -13,6 +13,7 @@ makelcf_exe = find_program('makelcf', native: true)
 makerom_exe = find_program('makerom', native: true)
 
 # ARM binutils
+arm_none_eabi_gcc_exe = find_program('arm-none-eabi-gcc', native: true)
 arm_none_eabi_objcopy_exe = find_program('arm-none-eabi-objcopy', native: true)
 
 # External tools


### PR DESCRIPTION
## Updates to `INSTALL.md` and `Dockerfile`

### `arm-none-eabi-gcc`

* MSYS2 - [`mingw-w64-x86_64-arm-none-eabi-gcc`](https://packages.msys2.org/package/mingw-w64-x86_64-arm-none-eabi-gcc)
* Ubuntu - [`gcc-arm-none-eabi`](https://packages.ubuntu.com/search?keywords=gcc-arm-none-eabi)
* MacOS - [`arm-none-eabi-gcc`](https://formulae.brew.sh/formula/arm-none-eabi-gcc)
* Arch Linux - [`arm-none-eabi-gcc`](https://archlinux.org/packages/extra/x86_64/arm-none-eabi-gcc/)

## Benchmarks

### Linux (Arch x86_64, kernel v6.9.9)

Before:

```
[100% 5284/5284] Generating pokeplatinum.us.nds with a custom command

real    2m9.896s
user    7m41.831s
sys     8m18.068s
```

After:

```
[100% 5284/5284] Generating pokeplatinum.us.nds with a custom command

real    1m37.708s
user    5m36.267s
sys     5m9.644s
```