### PR TITLE
Mass rename BgConfig and TaskManager in FieldSystem struct

### DIFF
--- a/include/field/field_system.h
+++ b/include/field/field_system.h
@@ -49,7 +49,7 @@
 typedef struct FieldSystem_t {
     FieldSystem_sub1 *unk_00;
     FieldSystem_sub2 *unk_04;
-    BgConfig *unk_08;
+    BgConfig *bgConfig;
     SaveData *saveData;
     TaskManager *unk_10;
     MapHeaderData *mapHeaderData;

--- a/include/field/field_system.h
+++ b/include/field/field_system.h
@@ -51,7 +51,7 @@ typedef struct FieldSystem_t {
     FieldSystem_sub2 *unk_04;
     BgConfig *bgConfig;
     SaveData *saveData;
-    TaskManager *unk_10;
+    TaskManager *taskManager;
     MapHeaderData *mapHeaderData;
     int bottomScreen;
     Location *location;

--- a/src/field_comm_manager.c
+++ b/src/field_comm_manager.c
@@ -417,7 +417,7 @@ static void sub_02059B74(void)
         }
     }
 
-    sub_02038A1C(4, sFieldCommMan->fieldSystem->unk_08);
+    sub_02038A1C(4, sFieldCommMan->fieldSystem->bgConfig);
 }
 
 static void sub_02059BF4(void)

--- a/src/field_comm_manager.c
+++ b/src/field_comm_manager.c
@@ -403,7 +403,7 @@ static void sub_02059B74(void)
     for (v0 = 0; v0 < CommSys_ConnectedCount(); v0++) {
         if (v0 != CommSys_CurNetId()) {
             if (sub_02036564(v0) == 94) {
-                if (sFieldCommMan->fieldSystem->unk_10 == NULL) {
+                if (sFieldCommMan->fieldSystem->taskManager == NULL) {
                     for (v1 = 0; v1 < 4; v1++) {
                         if (sFieldCommMan->trainerCard[v1]) {
                             Heap_FreeToHeap(sFieldCommMan->trainerCard[v1]);

--- a/src/field_map_change.c
+++ b/src/field_map_change.c
@@ -1572,5 +1572,5 @@ void sub_02054864(TaskManager *taskMan)
     Location *location = FieldOverworldState_GetSpecialLocation(SaveData_GetFieldOverworldState(fieldSystem->saveData));
 
     fieldSystem->mapLoadType = MAP_LOAD_TYPE_OVERWORLD;
-    FieldSystem_StartChangeMapTask(fieldSystem->unk_10, location);
+    FieldSystem_StartChangeMapTask(fieldSystem->taskManager, location);
 }

--- a/src/field_map_change.c
+++ b/src/field_map_change.c
@@ -1143,7 +1143,7 @@ BOOL FieldTask_MapChangeToUnderground(TaskManager *taskMan)
         mapChangeUndergroundData->unk_34 = MessageLoader_GetNewStrbuf(msgLoader, 124);
         MessageLoader_Free(msgLoader);
 
-        FieldMessage_AddWindow(fieldSystem->unk_08, &mapChangeUndergroundData->unk_24, 3);
+        FieldMessage_AddWindow(fieldSystem->bgConfig, &mapChangeUndergroundData->unk_24, 3);
         FieldMessage_DrawWindow(&mapChangeUndergroundData->unk_24, SaveData_Options(fieldSystem->saveData));
         mapChangeUndergroundData->unk_38 = FieldMessage_Print(&mapChangeUndergroundData->unk_24, mapChangeUndergroundData->unk_34, SaveData_Options(fieldSystem->saveData), 1);
         mapChangeUndergroundData->state = 1;
@@ -1151,8 +1151,8 @@ BOOL FieldTask_MapChangeToUnderground(TaskManager *taskMan)
     case 1:
         if (FieldMessage_FinishedPrinting(mapChangeUndergroundData->unk_38) == 1) {
             Strbuf_Free(mapChangeUndergroundData->unk_34);
-            LoadStandardWindowGraphics(fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 11);
-            mapChangeUndergroundData->unk_3C = Menu_MakeYesNoChoice(fieldSystem->unk_08, &Unk_020EC3A0, 1024 - (18 + 12) - 9, 11, 11);
+            LoadStandardWindowGraphics(fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 11);
+            mapChangeUndergroundData->unk_3C = Menu_MakeYesNoChoice(fieldSystem->bgConfig, &Unk_020EC3A0, 1024 - (18 + 12) - 9, 11, 11);
             mapChangeUndergroundData->state = 2;
         }
         break;

--- a/src/field_menu.c
+++ b/src/field_menu.c
@@ -342,7 +342,7 @@ void sub_0203AB00(FieldSystem *fieldSystem)
         menu->unk_224 = sub_0203ABD0(fieldSystem);
     }
 
-    FieldTask_Change(fieldSystem->unk_10, sub_0203AC44, menu);
+    FieldTask_Change(fieldSystem->taskManager, sub_0203AC44, menu);
 }
 
 static FieldMenu *FieldMenu_Alloc(void)

--- a/src/field_menu.c
+++ b/src/field_menu.c
@@ -496,7 +496,7 @@ static BOOL sub_0203AC44(TaskManager *taskMan)
         Window_EraseStandardFrame(&menu->unk_00, 1);
         Window_Remove(&menu->unk_00);
         sub_0203B200(taskMan);
-        Bg_ScheduleTilemapTransfer(fieldSystem->unk_08, 3);
+        Bg_ScheduleTilemapTransfer(fieldSystem->bgConfig, 3);
         Heap_FreeToHeap(menu);
         MapObjectMan_UnpauseAllMovement(fieldSystem->mapObjMan);
         return TRUE;
@@ -527,8 +527,8 @@ static void sub_0203ADFC(TaskManager *taskMan)
     menu = TaskManager_Environment(taskMan);
     v5 = FieldMenu_MakeList(menu, menu->unk_30);
 
-    Window_Add(fieldSystem->unk_08, &menu->unk_00, 3, 20, 1, 11, v5 * 3, 12, ((((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (11 * 22)));
-    LoadStandardWindowGraphics(fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 1, 11);
+    Window_Add(fieldSystem->bgConfig, &menu->unk_00, 3, 20, 1, 11, v5 * 3, 12, ((((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (11 * 22)));
+    LoadStandardWindowGraphics(fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 1, 11);
     Window_DrawStandardFrame(&menu->unk_00, 1, 1024 - (18 + 12) - 9, 11);
 
     v2 = MessageLoader_Init(0, 26, 367, 11);
@@ -668,8 +668,8 @@ static void sub_0203B094(TaskManager *taskMan)
         return;
     }
 
-    Window_Add(fieldSystem->unk_08, &menu->unk_10, 3, 1, 1, 12, 4, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)));
-    LoadStandardWindowGraphics(fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 1, 11);
+    Window_Add(fieldSystem->bgConfig, &menu->unk_10, 3, 1, 1, 12, 4, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)));
+    LoadStandardWindowGraphics(fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 1, 11);
     Window_DrawStandardFrame(&menu->unk_10, 1, 1024 - (18 + 12) - 9, 11);
     Window_FillTilemap(&menu->unk_10, 15);
 

--- a/src/field_system.c
+++ b/src/field_system.c
@@ -379,7 +379,7 @@ struct PoketchSystem *FieldSystem_GetPoketchSystem(void)
 BgConfig *sub_0203D170(void *param0)
 {
     FieldSystem *fieldSystem = (FieldSystem *)param0;
-    return fieldSystem->unk_08;
+    return fieldSystem->bgConfig;
 }
 
 SaveData *FieldSystem_SaveData(void *param0)

--- a/src/field_system.c
+++ b/src/field_system.c
@@ -174,7 +174,7 @@ static FieldSystem *FieldSystem_Init(OverlayManager *overlayMan)
     v0 = OverlayManager_Args(overlayMan);
 
     fieldSystem->saveData = v0->unk_08;
-    fieldSystem->unk_10 = NULL;
+    fieldSystem->taskManager = NULL;
     fieldSystem->location = sub_0203A720(SaveData_GetFieldOverworldState(fieldSystem->saveData));
     fieldSystem->unk_2C = sub_02039D6C();
 
@@ -240,7 +240,7 @@ BOOL FieldSystem_Run(FieldSystem *fieldSystem)
         sub_0203CECC(&fieldSystem->unk_00->unk_04);
     }
 
-    if (fieldSystem->unk_00->unk_0C && !fieldSystem->unk_10 && !fieldSystem->unk_00->unk_00 && !fieldSystem->unk_00->unk_04) {
+    if (fieldSystem->unk_00->unk_0C && !fieldSystem->taskManager && !fieldSystem->unk_00->unk_00 && !fieldSystem->unk_00->unk_04) {
         return 1;
     }
 

--- a/src/overlay005/encounter_effect.c
+++ b/src/overlay005/encounter_effect.c
@@ -1583,7 +1583,7 @@ static void ov5_021DF30C(FieldSystem *fieldSystem)
     }
 
     {
-        ov5_021D143C(fieldSystem->unk_08);
+        ov5_021D143C(fieldSystem->bgConfig);
 
         {
             G2_SetBG3ControlDCBmp(GX_BG_SCRSIZE_DCBMP_256x256, GX_BG_AREAOVER_XLU, GX_BG_BMPSCRBASE_0x20000);
@@ -1616,9 +1616,9 @@ static void ov5_021DF30C(FieldSystem *fieldSystem)
                 0
             };
 
-            Bg_InitFromTemplate(fieldSystem->unk_08, 2, &v3, 0);
+            Bg_InitFromTemplate(fieldSystem->bgConfig, 2, &v3, 0);
             Bg_ClearTilesRange(2, 32, 0, 4);
-            Bg_ClearTilemap(fieldSystem->unk_08, 2);
+            Bg_ClearTilemap(fieldSystem->bgConfig, 2);
         }
     }
 
@@ -1627,8 +1627,8 @@ static void ov5_021DF30C(FieldSystem *fieldSystem)
 
 static void ov5_021DF3D4(FieldSystem *fieldSystem)
 {
-    Bg_FreeTilemapBuffer(fieldSystem->unk_08, 2);
-    ov5_021D1434(fieldSystem->unk_08);
+    Bg_FreeTilemapBuffer(fieldSystem->bgConfig, 2);
+    ov5_021D1434(fieldSystem->bgConfig);
 }
 
 static u32 ov5_021DF3E8(u32 param0, BOOL param1)

--- a/src/overlay005/encounter_effect_core.c
+++ b/src/overlay005/encounter_effect_core.c
@@ -1175,7 +1175,7 @@ void EncounterEffect_Trainer_Water_HigherLevel(SysTask *param0, void *param1)
         GXLayers_EngineAToggleLayers(GX_PLANEMASK_OBJ, 1);
 
         v1->unk_270 = Window_New(4, 1);
-        Window_Add(v0->fieldSystem->unk_08, v1->unk_270, 3, 0, 0, 32, 32, 0, 0);
+        Window_Add(v0->fieldSystem->bgConfig, v1->unk_270, 3, 0, 0, 32, 32, 0, 0);
 
         {
             GXRgb v6 = 0;
@@ -1311,7 +1311,7 @@ void EncounterEffect_Trainer_Water_HigherLevel(SysTask *param0, void *param1)
         Windows_Delete(v1->unk_270, 1);
 
         Bg_ClearTilesRange(3, 32, 0, 4);
-        Bg_ClearTilemap(v0->fieldSystem->unk_08, 3);
+        Bg_ClearTilemap(v0->fieldSystem->bgConfig, 3);
 
         EncounterEffect_Finish(v0, param0);
         return;
@@ -1507,7 +1507,7 @@ void EncounterEffect_Trainer_Cave_HigherLevel(SysTask *param0, void *param1)
         GXLayers_EngineAToggleLayers(GX_PLANEMASK_OBJ, 1);
 
         v1->unk_264 = Window_New(4, 1);
-        Window_Add(v0->fieldSystem->unk_08, v1->unk_264, 3, 0, 0, 32, 32, 0, 0);
+        Window_Add(v0->fieldSystem->bgConfig, v1->unk_264, 3, 0, 0, 32, 32, 0, 0);
 
         {
             GXRgb v6 = 0;
@@ -1658,7 +1658,7 @@ void EncounterEffect_Trainer_Cave_HigherLevel(SysTask *param0, void *param1)
         Windows_Delete(v1->unk_264, 1);
 
         Bg_ClearTilesRange(3, 32, 0, 4);
-        Bg_ClearTilemap(v0->fieldSystem->unk_08, 3);
+        Bg_ClearTilemap(v0->fieldSystem->bgConfig, 3);
 
         EncounterEffect_Finish(v0, param0);
         break;
@@ -2147,7 +2147,7 @@ void EncounterEffect_GalacticBoss(SysTask *param0, void *param1)
         v1->unk_04 = ov5_021DEBEC(4);
 
         v1->unk_00 = Window_New(4, 1);
-        Window_Add(v0->fieldSystem->unk_08, v1->unk_00, 3, 0, 0, 32, 32, 0, 0);
+        Window_Add(v0->fieldSystem->bgConfig, v1->unk_00, 3, 0, 0, 32, 32, 0, 0);
 
         {
             GXRgb v3 = 0;
@@ -2235,7 +2235,7 @@ void EncounterEffect_GalacticBoss(SysTask *param0, void *param1)
         Windows_Delete(v1->unk_00, 1);
 
         Bg_ClearTilesRange(3, 32, 0, 4);
-        Bg_ClearTilemap(v0->fieldSystem->unk_08, 3);
+        Bg_ClearTilemap(v0->fieldSystem->bgConfig, 3);
 
         G2_SetOBJMosaicSize(0, 0);
 
@@ -2900,7 +2900,7 @@ static BOOL EncounterEffect_GymLeader(EncounterEffect *encEffect, enum HeapId he
         Graphics_LoadPaletteFromOpenNARC(encEffect->narc, 11, 0, 2 * 0x20, 0x20, heapID);
 
         GXLayers_EngineAToggleLayers(GX_PLANEMASK_BG2, 0);
-        Window_Add(encEffect->fieldSystem->unk_08, &v0->unk_2E0, 2, 0, 10, 16, 2, 2, 1);
+        Window_Add(encEffect->fieldSystem->bgConfig, &v0->unk_2E0, 2, 0, 10, 16, 2, 2, 1);
         Window_FillTilemap(&v0->unk_2E0, 0);
         v7 = EncounterEffect_GetGymLeaderName(param->trainerID, heapID);
         Text_AddPrinterWithParamsAndColor(&v0->unk_2E0, FONT_SYSTEM, v7, 0, 0, TEXT_SPEED_INSTANT, TEXT_COLOR(1, 2, 0), NULL);
@@ -2942,7 +2942,7 @@ static BOOL EncounterEffect_GymLeader(EncounterEffect *encEffect, enum HeapId he
     case 3:
 
         ov5_021DE3D0(
-            encEffect->narc, param->unk_12, param->unk_11, param->unk_10, 0, 1, encEffect->fieldSystem->unk_08, 3);
+            encEffect->narc, param->unk_12, param->unk_11, param->unk_10, 0, 1, encEffect->fieldSystem->bgConfig, 3);
         v0->unk_2F0 = 1;
 
         ov5_021DED20(encEffect, v0->unk_40, 6, 8, 16, (GX_WND_PLANEMASK_BG0 | GX_WND_PLANEMASK_BG1 | GX_WND_PLANEMASK_BG2 | GX_WND_PLANEMASK_BG3 | GX_WND_PLANEMASK_OBJ), (GX_WND_PLANEMASK_BG0 | GX_WND_PLANEMASK_BG1 | GX_WND_PLANEMASK_BG2 | GX_WND_PLANEMASK_OBJ));
@@ -3029,7 +3029,7 @@ static BOOL EncounterEffect_GymLeader(EncounterEffect *encEffect, enum HeapId he
 
             sub_0200AB4C(-14, GX_BLEND_PLANEMASK_BG0 | GX_BLEND_PLANEMASK_BD, 1);
 
-            Bg_ScheduleScroll(encEffect->fieldSystem->unk_08, 2, 0, -((v0->unk_00.currentValue >> FX32_SHIFT) + -92));
+            Bg_ScheduleScroll(encEffect->fieldSystem->bgConfig, 2, 0, -((v0->unk_00.currentValue >> FX32_SHIFT) + -92));
             GXLayers_EngineAToggleLayers(GX_PLANEMASK_BG2, 1);
             Bg_SetPriority(2, 0);
             encEffect->state++;
@@ -3095,13 +3095,13 @@ static BOOL EncounterEffect_GymLeader(EncounterEffect *encEffect, enum HeapId he
 
         sub_0200AB4C(0, GX_BLEND_PLANEMASK_NONE, 1);
 
-        Bg_SetOffset(encEffect->fieldSystem->unk_08, 2, 0, 0);
+        Bg_SetOffset(encEffect->fieldSystem->bgConfig, 2, 0, 0);
 
         return 1;
     }
 
     if (v0->unk_2F0 == 1) {
-        Bg_ScheduleScroll(encEffect->fieldSystem->unk_08, 3, 0, v0->unk_2F4);
+        Bg_ScheduleScroll(encEffect->fieldSystem->bgConfig, 3, 0, v0->unk_2F4);
 
         v0->unk_2F4 = (v0->unk_2F4 + 30) % 512;
     }
@@ -3335,7 +3335,7 @@ static BOOL EncounterEffect_EliteFourChampion(EncounterEffect *encEffect, enum H
             Graphics_LoadPaletteFromOpenNARC(encEffect->narc, 11, 0, 2 * 0x20, 0x20, heapID);
 
             GXLayers_EngineAToggleLayers(GX_PLANEMASK_BG2, 0);
-            Window_Add(encEffect->fieldSystem->unk_08, &v0->unk_358, 2, 21, 13, 11, 2, 2, 1);
+            Window_Add(encEffect->fieldSystem->bgConfig, &v0->unk_358, 2, 21, 13, 11, 2, 2, 1);
             Window_FillTilemap(&v0->unk_358, 0);
             v9 = EncounterEffect_GetGymLeaderName(param->trainerID, heapID);
             Text_AddPrinterWithParamsAndColor(&v0->unk_358, FONT_SYSTEM, v9, 0, 0, TEXT_SPEED_INSTANT, TEXT_COLOR(1, 2, 0), NULL);

--- a/src/overlay005/fieldmap.c
+++ b/src/overlay005/fieldmap.c
@@ -138,7 +138,7 @@ static void ov5_021D0D80(void *param0)
 {
     FieldSystem *fieldSystem = param0;
 
-    Bg_RunScheduledUpdates(fieldSystem->unk_08);
+    Bg_RunScheduledUpdates(fieldSystem->bgConfig);
     sub_0201DCAC();
     sub_0200A858();
 
@@ -198,8 +198,8 @@ static BOOL FieldMap_Init(OverlayManager *overlayMan, int *param1)
         ov5_021D154C();
 
         GXLayers_SwapDisplay();
-        fieldSystem->unk_08 = BgConfig_New(4);
-        ov5_021D1444(fieldSystem->unk_08);
+        fieldSystem->bgConfig = BgConfig_New(4);
+        ov5_021D1444(fieldSystem->bgConfig);
         sub_0205D8CC(0, 1);
         sub_0203F5C0(fieldSystem, 4);
         break;
@@ -323,7 +323,7 @@ static BOOL FieldMap_Exit(OverlayManager *overlayMan, int *param1)
             ov5_021D57D8(&fieldSystem->unk_48);
             ov5_021D5894(&fieldSystem->unk_44);
             ov5_021D1570();
-            ov5_021D1524(fieldSystem->unk_08);
+            ov5_021D1524(fieldSystem->bgConfig);
             ov5_021D5C14(fieldSystem);
             (*param1)++;
         }
@@ -336,7 +336,7 @@ static BOOL FieldMap_Exit(OverlayManager *overlayMan, int *param1)
             Easy3D_Shutdown();
             ov5_021D1AE4(fieldSystem->unk_04->unk_04);
             SetMainCallback(NULL, NULL);
-            Heap_FreeToHeap(fieldSystem->unk_08);
+            Heap_FreeToHeap(fieldSystem->bgConfig);
             Heap_FreeToHeap(fieldSystem->unk_04);
 
             fieldSystem->unk_04 = NULL;
@@ -922,7 +922,7 @@ static void ov5_021D1968(FieldSystem *fieldSystem)
         fieldSystem->unk_04->unk_0C = ov5_021D5EB8(fieldSystem);
     }
 
-    fieldSystem->unk_04->unk_08 = ov5_021DD98C(fieldSystem->unk_08);
+    fieldSystem->unk_04->unk_08 = ov5_021DD98C(fieldSystem->bgConfig);
     fieldSystem->unk_64 = ov5_021E1B08(4);
     fieldSystem->unk_04->unk_10 = ov5_021D5CB0();
 

--- a/src/overlay005/ov5_021D431C.c
+++ b/src/overlay005/ov5_021D431C.c
@@ -296,7 +296,7 @@ BOOL ov5_021D453C(FieldSystem *fieldSystem, UnkStruct_ov5_021D432C *param1)
         (param1->unk_00)++;
     } break;
     case 1:
-        sub_02056B30(fieldSystem->unk_10, 0, 9, 1, 0x0, 6, 1, 11);
+        sub_02056B30(fieldSystem->taskManager, 0, 9, 1, 0x0, 6, 1, 11);
         {
             int v9;
             int v10;
@@ -814,7 +814,7 @@ void ov5_021D4D48(FieldSystem *fieldSystem, const u8 param1)
     u8 *v0 = Heap_AllocFromHeapAtEnd(4, sizeof(u8));
 
     *v0 = param1;
-    FieldTask_Start(fieldSystem->unk_10, ov5_021D4BC8, v0);
+    FieldTask_Start(fieldSystem->taskManager, ov5_021D4BC8, v0);
 }
 
 void ov5_021D4D68(FieldSystem *fieldSystem, const u8 param1)

--- a/src/overlay005/ov5_021D5EB8.c
+++ b/src/overlay005/ov5_021D5EB8.c
@@ -1510,7 +1510,7 @@ static void ov5_021D6DCC(UnkStruct_ov5_021D6594 *param0, int param1)
 
         NNS_G2dGetUnpackedCharacterData(v0.unk_04, &v0.unk_10);
 
-        Bg_LoadTiles(param0->fieldSystem->unk_08, 2, v0.unk_10->pRawData, v0.unk_10->szByte, 0);
+        Bg_LoadTiles(param0->fieldSystem->bgConfig, 2, v0.unk_10->pRawData, v0.unk_10->szByte, 0);
         Heap_FreeToHeap(v0.unk_04);
 
         v0.unk_04 = NULL;
@@ -1529,10 +1529,10 @@ static void ov5_021D6E20(UnkStruct_ov5_021D6594 *param0, int param1)
 
         NNS_G2dGetUnpackedScreenData(v0.unk_08, &v0.unk_0C);
 
-        Bg_CopyTilemapBufferRangeToVRAM(param0->fieldSystem->unk_08, 2, (void *)v0.unk_0C->rawData, v0.unk_0C->szByte, 0);
-        Bg_LoadTilemapBuffer(param0->fieldSystem->unk_08, 2, (void *)v0.unk_0C->rawData, v0.unk_0C->szByte);
-        Bg_ChangeTilemapRectPalette(param0->fieldSystem->unk_08, 2, 0, 0, 32, 32, 6);
-        Bg_CopyTilemapBufferToVRAM(param0->fieldSystem->unk_08, 2);
+        Bg_CopyTilemapBufferRangeToVRAM(param0->fieldSystem->bgConfig, 2, (void *)v0.unk_0C->rawData, v0.unk_0C->szByte, 0);
+        Bg_LoadTilemapBuffer(param0->fieldSystem->bgConfig, 2, (void *)v0.unk_0C->rawData, v0.unk_0C->szByte);
+        Bg_ChangeTilemapRectPalette(param0->fieldSystem->bgConfig, 2, 0, 0, 32, 32, 6);
+        Bg_CopyTilemapBufferToVRAM(param0->fieldSystem->bgConfig, 2);
         Heap_FreeToHeap(v0.unk_08);
 
         v0.unk_08 = NULL;
@@ -5243,8 +5243,8 @@ static void ov5_021DB144(SysTask *param0, void *param1)
 
         v5 = Unk_ov5_02201D38[v1->unk_B4 / 8];
 
-        Bg_ScheduleScroll(v0->unk_00->fieldSystem->unk_08, 2, 0, (v1->unk_AC >> FX32_SHIFT) + v5);
-        Bg_ScheduleScroll(v0->unk_00->fieldSystem->unk_08, 2, 3, (v1->unk_B0 >> FX32_SHIFT));
+        Bg_ScheduleScroll(v0->unk_00->fieldSystem->bgConfig, 2, 0, (v1->unk_AC >> FX32_SHIFT) + v5);
+        Bg_ScheduleScroll(v0->unk_00->fieldSystem->bgConfig, 2, 3, (v1->unk_B0 >> FX32_SHIFT));
     }
 }
 

--- a/src/overlay005/ov5_021DC018.c
+++ b/src/overlay005/ov5_021DC018.c
@@ -188,8 +188,8 @@ void ov5_021DC1AC(UnkStruct_ov5_021DC1A4 *param0)
         param0->unk_99 -= param0->unk_9B * 2;
     }
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_08, 3, param0->unk_98, param0->unk_99, v0, param0->unk_9B * 2, 13, ((1 + (10 * 4)) + (10 * 2)));
-    LoadStandardWindowGraphics(param0->fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_08, 3, param0->unk_98, param0->unk_99, v0, param0->unk_9B * 2, 13, ((1 + (10 * 4)) + (10 * 2)));
+    LoadStandardWindowGraphics(param0->fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
     Window_DrawStandardFrame(&param0->unk_08, 1, 1024 - (18 + 12) - 9, 11);
 
     ov5_021DC33C(param0);
@@ -373,12 +373,12 @@ void ov5_021DC528(UnkStruct_ov5_021DC1A4 *param0, u16 param1)
 static void ov5_021DC530(UnkStruct_ov5_021DC1A4 *param0, u32 param1)
 {
     if (param0->unk_9B > 8) {
-        Window_Add(param0->fieldSystem->unk_08, &param0->unk_08, 3, param0->unk_98, param0->unk_99, param1, 8 * 2, 13, ((1 + (10 * 4)) + (10 * 2)));
+        Window_Add(param0->fieldSystem->bgConfig, &param0->unk_08, 3, param0->unk_98, param0->unk_99, param1, 8 * 2, 13, ((1 + (10 * 4)) + (10 * 2)));
     } else {
-        Window_Add(param0->fieldSystem->unk_08, &param0->unk_08, 3, param0->unk_98, param0->unk_99, param1, param0->unk_9B * 2, 13, ((1 + (10 * 4)) + (10 * 2)));
+        Window_Add(param0->fieldSystem->bgConfig, &param0->unk_08, 3, param0->unk_98, param0->unk_99, param1, param0->unk_9B * 2, 13, ((1 + (10 * 4)) + (10 * 2)));
     }
 
-    LoadStandardWindowGraphics(param0->fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    LoadStandardWindowGraphics(param0->fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
     Window_DrawStandardFrame(&param0->unk_08, 1, 1024 - (18 + 12) - 9, 11);
 
     ov5_021DC7E4(param0);
@@ -403,12 +403,12 @@ void ov5_021DC600(UnkStruct_ov5_021DC1A4 *param0, u16 *param1, u16 *param2)
     }
 
     if (param0->unk_9B > 8) {
-        Window_Add(param0->fieldSystem->unk_08, &param0->unk_08, 3, param0->unk_98, param0->unk_99, v0, 8 * 2, 13, ((1 + (10 * 4)) + (10 * 2)));
+        Window_Add(param0->fieldSystem->bgConfig, &param0->unk_08, 3, param0->unk_98, param0->unk_99, v0, 8 * 2, 13, ((1 + (10 * 4)) + (10 * 2)));
     } else {
-        Window_Add(param0->fieldSystem->unk_08, &param0->unk_08, 3, param0->unk_98, param0->unk_99, v0, param0->unk_9B * 2, 13, ((1 + (10 * 4)) + (10 * 2)));
+        Window_Add(param0->fieldSystem->bgConfig, &param0->unk_08, 3, param0->unk_98, param0->unk_99, v0, param0->unk_9B * 2, 13, ((1 + (10 * 4)) + (10 * 2)));
     }
 
-    LoadStandardWindowGraphics(param0->fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    LoadStandardWindowGraphics(param0->fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
     Window_DrawStandardFrame(&param0->unk_08, 1, 1024 - (18 + 12) - 9, 11);
 
     ov5_021DC7E4(param0);
@@ -638,8 +638,8 @@ void ov5_021DCB24(FieldSystem *fieldSystem, u8 param1, u8 param2, u16 *param3, S
         v1 = (v1 / 8) + 1;
     }
 
-    Window_Add(v3->fieldSystem->unk_08, &v3->unk_08, 3, v3->unk_98, v3->unk_99, v1, 4, 13, ((1 + (10 * 4)) + (10 * 2)) + (16 * 10));
-    LoadStandardWindowGraphics(v3->fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    Window_Add(v3->fieldSystem->bgConfig, &v3->unk_08, 3, v3->unk_98, v3->unk_99, v1, 4, 13, ((1 + (10 * 4)) + (10 * 2)) + (16 * 10));
+    LoadStandardWindowGraphics(v3->fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
     Window_DrawStandardFrame(&v3->unk_08, 1, 1024 - (18 + 12) - 9, 11);
     Window_FillRectWithColor(&v3->unk_08, 15, 0, 0, (v1 * 8), (4 * 8));
 
@@ -778,8 +778,8 @@ void ov5_021DCD94(UnkStruct_ov5_021DC1A4 *param0, u8 param1)
         v1++;
     }
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_08, 3, param0->unk_98, param0->unk_99, (v0 * param1), v1 * 2, 13, ((1 + (10 * 4)) + (10 * 2)));
-    LoadStandardWindowGraphics(param0->fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_08, 3, param0->unk_98, param0->unk_99, (v0 * param1), v1 * 2, 13, ((1 + (10 * 4)) + (10 * 2)));
+    LoadStandardWindowGraphics(param0->fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
     Window_DrawStandardFrame(&param0->unk_08, 1, 1024 - (18 + 12) - 9, 11);
 
     ov5_021DCE64(param0, param1, v1);
@@ -807,8 +807,8 @@ Window *ov5_021DCEB0(FieldSystem *fieldSystem, u8 param1, u8 param2)
 {
     Window *v0 = Window_New(4, 1);
 
-    Window_Add(fieldSystem->unk_08, v0, 3, param1, param2, 10, 4, 13, 1);
-    LoadStandardWindowGraphics(fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    Window_Add(fieldSystem->bgConfig, v0, 3, param1, param2, 10, 4, 13, 1);
+    LoadStandardWindowGraphics(fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
     Window_DrawStandardFrame(v0, 1, 1024 - (18 + 12) - 9, 11);
     Window_FillTilemap(v0, 15);
 
@@ -869,8 +869,8 @@ Window *ov5_021DD020(FieldSystem *fieldSystem, u8 param1, u8 param2)
 {
     Window *v0 = Window_New(4, 1);
 
-    Window_Add(fieldSystem->unk_08, v0, 3, param1, param2, 10, 2, 13, (1 + (10 * 4)));
-    LoadStandardWindowGraphics(fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    Window_Add(fieldSystem->bgConfig, v0, 3, param1, param2, 10, 2, 13, (1 + (10 * 4)));
+    LoadStandardWindowGraphics(fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
     Window_DrawStandardFrame(v0, 1, 1024 - (18 + 12) - 9, 11);
 
     ov5_021DD098(fieldSystem, v0);
@@ -918,8 +918,8 @@ Window *ov5_021DD140(FieldSystem *fieldSystem, u8 param1, u8 param2)
 {
     Window *v0 = Window_New(4, 1);
 
-    Window_Add(fieldSystem->unk_08, v0, 3, param1, param2, 10, 2, 13, (1 + (10 * 4)));
-    LoadStandardWindowGraphics(fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    Window_Add(fieldSystem->bgConfig, v0, 3, param1, param2, 10, 2, 13, (1 + (10 * 4)));
+    LoadStandardWindowGraphics(fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
     Window_DrawStandardFrame(v0, 1, 1024 - (18 + 12) - 9, 11);
 
     ov5_021DD1A4(fieldSystem, v0);
@@ -963,8 +963,8 @@ UnkStruct_ov5_021DC1A4 *ov5_021DD250(FieldSystem *fieldSystem, u8 param1, u8 par
 
     v0 = ov5_021DC150(fieldSystem, param1, param2, 0, 0, param3, param4, NULL, NULL);
 
-    Window_Add(v0->fieldSystem->unk_08, &v0->unk_08, 3, v0->unk_98, v0->unk_99, 10, 16, 13, ((1 + (10 * 4)) + (10 * 2)));
-    LoadStandardWindowGraphics(v0->fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    Window_Add(v0->fieldSystem->bgConfig, &v0->unk_08, 3, v0->unk_98, v0->unk_99, 10, 16, 13, ((1 + (10 * 4)) + (10 * 2)));
+    LoadStandardWindowGraphics(v0->fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
     Window_DrawStandardFrame(&v0->unk_08, 1, 1024 - (18 + 12) - 9, 11);
     Window_FillRectWithColor(&v0->unk_08, 15, 0, 0, (10 * 8), (16 * 8));
 

--- a/src/overlay005/ov5_021DD42C.c
+++ b/src/overlay005/ov5_021DD42C.c
@@ -133,7 +133,7 @@ static void ov5_021DD5D0(FieldSystem *fieldSystem, StringTemplate *param1, UnkSt
 static void ov5_021DD610(FieldSystem *fieldSystem, UnkStruct_ov5_021DD648 *param1)
 {
     if (*(param1->unk_10) == 0) {
-        FieldMessage_AddWindow(fieldSystem->unk_08, param1->unk_0C, 3);
+        FieldMessage_AddWindow(fieldSystem->bgConfig, param1->unk_0C, 3);
         FieldMessage_DrawWindow(param1->unk_0C, SaveData_Options(fieldSystem->saveData));
         *(param1->unk_10) = 1;
     }

--- a/src/overlay005/ov5_021DDAE4.c
+++ b/src/overlay005/ov5_021DDAE4.c
@@ -36,18 +36,18 @@ static BOOL ov5_021DDAE4(TaskManager *param0)
         break;
     case 1:
         if (sub_0200AC1C(2)) {
-            ov24_02253DA4(fieldSystem->unk_08);
+            ov24_02253DA4(fieldSystem->bgConfig);
             v1->unk_00++;
         }
         break;
     case 2:
-        if (ov24_02253DB4(fieldSystem->unk_08)) {
+        if (ov24_02253DB4(fieldSystem->bgConfig)) {
             PoketchData *poketchData = SaveData_PoketchData(fieldSystem->saveData);
 
             Overlay_UnloadByID(FS_OVERLAY_ID(overlay24));
             Overlay_LoadByID(FS_OVERLAY_ID(overlay25), 2);
             PoketchData_Enable(poketchData);
-            PoketchSystem_Create(fieldSystem, &fieldSystem->unk_04->poketchSys, fieldSystem->saveData, fieldSystem->unk_08, sub_0200A914(1));
+            PoketchSystem_Create(fieldSystem, &fieldSystem->unk_04->poketchSys, fieldSystem->saveData, fieldSystem->bgConfig, sub_0200A914(1));
             v1->unk_00++;
         }
         break;

--- a/src/overlay005/ov5_021DFB54.c
+++ b/src/overlay005/ov5_021DFB54.c
@@ -588,7 +588,7 @@ static void ov5_021E00B0(FieldSystem *fieldSystem, int param1, const UnkStruct_o
     v0->unk_24 = Player_MapObject(v0->playerAvatar);
     v0->unk_0C = *param2;
 
-    FieldTask_Start(fieldSystem->unk_10, ov5_021E0160, v0);
+    FieldTask_Start(fieldSystem->taskManager, ov5_021E0160, v0);
 }
 
 void ov5_021E00EC(TaskManager *taskMan, int param1, int param2)
@@ -969,7 +969,7 @@ static void ov5_021E06F8(FieldSystem *fieldSystem, int param1, const UnkStruct_o
     v0->unk_14 = Player_MapObject(v0->playerAvatar);
     v0->unk_1C = *param2;
 
-    FieldTask_Start(fieldSystem->unk_10, ov5_021E07A0, v0);
+    FieldTask_Start(fieldSystem->taskManager, ov5_021E07A0, v0);
 }
 
 void ov5_021E0734(TaskManager *param0, int param1, int param2)
@@ -1521,7 +1521,7 @@ static void ov5_021E0DE0(FieldSystem *fieldSystem)
     v0->unk_08 = Player_MapObject(v0->playerAvatar);
     v0->unk_10 = PlayerAvatar_Gender(v0->playerAvatar);
 
-    FieldTask_Start(fieldSystem->unk_10, ov5_021E0E10, v0);
+    FieldTask_Start(fieldSystem->taskManager, ov5_021E0E10, v0);
 }
 
 static BOOL ov5_021E0E10(TaskManager *param0)

--- a/src/overlay005/ov5_021E1B08.c
+++ b/src/overlay005/ov5_021E1B08.c
@@ -106,10 +106,10 @@ void ov5_021E1BCC(FieldSystem *fieldSystem, u8 param1)
 
 static void ov5_021E1BE0(FieldSystem *fieldSystem)
 {
-    Bg_SetOffset(fieldSystem->unk_08, 3, 3, -48);
+    Bg_SetOffset(fieldSystem->bgConfig, 3, 3, -48);
 
     if (fieldSystem->unk_64->unk_13_7 == 0) {
-        sub_0205DA1C(fieldSystem->unk_08, &fieldSystem->unk_64->unk_00, fieldSystem->unk_64->unk_12, 3);
+        sub_0205DA1C(fieldSystem->bgConfig, &fieldSystem->unk_64->unk_00, fieldSystem->unk_64->unk_12, 3);
         fieldSystem->unk_64->unk_13_7 = 1;
     }
 
@@ -123,46 +123,46 @@ static void ov5_021E1C1C(FieldSystem *fieldSystem)
     }
 
     Window_Remove(&fieldSystem->unk_64->unk_00);
-    Bg_FillTilemapRect(fieldSystem->unk_08, 3, 0, 0, 18, 32, 6, 16);
-    Bg_CopyTilemapBufferToVRAM(fieldSystem->unk_08, 3);
-    Bg_SetOffset(fieldSystem->unk_08, 3, 3, 0);
+    Bg_FillTilemapRect(fieldSystem->bgConfig, 3, 0, 0, 18, 32, 6, 16);
+    Bg_CopyTilemapBufferToVRAM(fieldSystem->bgConfig, 3);
+    Bg_SetOffset(fieldSystem->bgConfig, 3, 3, 0);
 
     fieldSystem->unk_64->unk_13_7 = 0;
 }
 
 static BOOL ov5_021E1C70(FieldSystem *fieldSystem)
 {
-    int v0 = Bg_GetYOffset(fieldSystem->unk_08, 3);
+    int v0 = Bg_GetYOffset(fieldSystem->bgConfig, 3);
 
     if (v0 == 0) {
         return 1;
     }
 
     if (!((v0 > -48) && (v0 < 0))) {
-        Bg_SetOffset(fieldSystem->unk_08, 3, 3, -48);
+        Bg_SetOffset(fieldSystem->bgConfig, 3, 3, -48);
     }
 
-    Bg_SetOffset(fieldSystem->unk_08, 3, 4, 16);
+    Bg_SetOffset(fieldSystem->bgConfig, 3, 4, 16);
 
     return 0;
 }
 
 static BOOL ov5_021E1CB0(FieldSystem *fieldSystem)
 {
-    int v0 = Bg_GetYOffset(fieldSystem->unk_08, 3);
+    int v0 = Bg_GetYOffset(fieldSystem->bgConfig, 3);
 
     if (v0 == -48) {
-        Bg_FillTilemapRect(fieldSystem->unk_08, 3, 0, 0, 18, 32, 6, 16);
-        Bg_CopyTilemapBufferToVRAM(fieldSystem->unk_08, 3);
-        Bg_SetOffset(fieldSystem->unk_08, 3, 3, 0);
+        Bg_FillTilemapRect(fieldSystem->bgConfig, 3, 0, 0, 18, 32, 6, 16);
+        Bg_CopyTilemapBufferToVRAM(fieldSystem->bgConfig, 3);
+        Bg_SetOffset(fieldSystem->bgConfig, 3, 3, 0);
         return 1;
     }
 
     if (!((v0 > -48) && (v0 < 0))) {
-        Bg_SetOffset(fieldSystem->unk_08, 3, 3, 0);
+        Bg_SetOffset(fieldSystem->bgConfig, 3, 3, 0);
     }
 
-    Bg_SetOffset(fieldSystem->unk_08, 3, 5, 16);
+    Bg_SetOffset(fieldSystem->bgConfig, 3, 5, 16);
 
     return 0;
 }

--- a/src/overlay005/ov5_021EA714.c
+++ b/src/overlay005/ov5_021EA714.c
@@ -31,10 +31,10 @@ void ov5_021EA728(FieldSystem *fieldSystem)
     if (PoketchData_IsEnabled(poketchData)
         && (sub_0206AE2C(v1) == 0)) {
         Overlay_LoadByID(FS_OVERLAY_ID(overlay25), 2);
-        PoketchSystem_Create(fieldSystem, &fieldSystem->unk_04->poketchSys, fieldSystem->saveData, fieldSystem->unk_08, sub_0200A914(1));
+        PoketchSystem_Create(fieldSystem, &fieldSystem->unk_04->poketchSys, fieldSystem->saveData, fieldSystem->bgConfig, sub_0200A914(1));
     } else {
         Overlay_LoadByID(FS_OVERLAY_ID(overlay24), 2);
-        ov24_02253CE0(fieldSystem->unk_08);
+        ov24_02253CE0(fieldSystem->bgConfig);
     }
 }
 
@@ -47,7 +47,7 @@ void ov5_021EA790(FieldSystem *fieldSystem)
         && (sub_0206AE2C(v1) == 0)) {
         PoketchSystem_StartShutdown(fieldSystem->unk_04->poketchSys);
     } else {
-        ov24_02253DA4(fieldSystem->unk_08);
+        ov24_02253DA4(fieldSystem->bgConfig);
     }
 }
 
@@ -64,7 +64,7 @@ u8 ov5_021EA7CC(FieldSystem *fieldSystem)
             return 1;
         }
     } else {
-        if (ov24_02253DB4(fieldSystem->unk_08)) {
+        if (ov24_02253DB4(fieldSystem->bgConfig)) {
             Overlay_UnloadByID(FS_OVERLAY_ID(overlay24));
             return 1;
         }
@@ -76,17 +76,17 @@ u8 ov5_021EA7CC(FieldSystem *fieldSystem)
 void ov5_021EA830(FieldSystem *fieldSystem)
 {
     Overlay_LoadByID(FS_OVERLAY_ID(overlay24), 2);
-    ov24_02253CE0(fieldSystem->unk_08);
+    ov24_02253CE0(fieldSystem->bgConfig);
 }
 
 void ov5_021EA848(FieldSystem *fieldSystem)
 {
-    ov24_02253DA4(fieldSystem->unk_08);
+    ov24_02253DA4(fieldSystem->bgConfig);
 }
 
 BOOL ov5_021EA854(FieldSystem *fieldSystem)
 {
-    if (ov24_02253DB4(fieldSystem->unk_08)) {
+    if (ov24_02253DB4(fieldSystem->bgConfig)) {
         Overlay_UnloadByID(FS_OVERLAY_ID(overlay24));
         return 1;
     }

--- a/src/overlay005/ov5_021EA874.c
+++ b/src/overlay005/ov5_021EA874.c
@@ -466,7 +466,7 @@ static void ov5_021EAF1C(UnkStruct_ov5_021EAE78 *param0)
 void ov5_021EAF50(FieldSystem *fieldSystem)
 {
     UnkStruct_ov5_021EAE78 *v0;
-    TaskManager *v1 = fieldSystem->unk_10;
+    TaskManager *v1 = fieldSystem->taskManager;
 
     v0 = Heap_AllocFromHeapAtEnd(11, sizeof(UnkStruct_ov5_021EAE78));
     ov5_021EAEE0(v0);

--- a/src/overlay005/ov5_021EA874.c
+++ b/src/overlay005/ov5_021EA874.c
@@ -69,8 +69,8 @@ static BOOL ov5_021EA874(UnkStruct_ov5_021EAE78 *param0)
 
     param0->unk_8C = 0;
 
-    LoadMessageBoxGraphics(param0->fieldSystem->unk_08, 3, (512 - (18 + 12)), 10, Options_Frame(SaveData_Options(param0->unk_34)), 4);
-    LoadStandardWindowGraphics(param0->fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    LoadMessageBoxGraphics(param0->fieldSystem->bgConfig, 3, (512 - (18 + 12)), 10, Options_Frame(SaveData_Options(param0->unk_34)), 4);
+    LoadStandardWindowGraphics(param0->fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
 
     param0->unk_48 = 1;
     return 0;
@@ -130,7 +130,7 @@ static const WindowTemplate Unk_ov5_021FAF00 = {
 static BOOL ov5_021EA9BC(UnkStruct_ov5_021EAE78 *param0)
 {
     if (Text_IsPrinterActive(param0->unk_40) == 0) {
-        param0->unk_44 = Menu_MakeYesNoChoice(param0->fieldSystem->unk_08, &Unk_ov5_021FAF00, 1024 - (18 + 12) - 9, 11, 4);
+        param0->unk_44 = Menu_MakeYesNoChoice(param0->fieldSystem->bgConfig, &Unk_ov5_021FAF00, 1024 - (18 + 12) - 9, 11, 4);
         param0->unk_48 = 3;
     }
 
@@ -170,7 +170,7 @@ static BOOL ov5_021EA9F8(UnkStruct_ov5_021EAE78 *param0)
 static BOOL ov5_021EAA6C(UnkStruct_ov5_021EAE78 *param0)
 {
     if (Text_IsPrinterActive(param0->unk_40) == 0) {
-        param0->unk_44 = Menu_MakeYesNoChoice(param0->fieldSystem->unk_08, &Unk_ov5_021FAF00, 1024 - (18 + 12) - 9, 11, 4);
+        param0->unk_44 = Menu_MakeYesNoChoice(param0->fieldSystem->bgConfig, &Unk_ov5_021FAF00, 1024 - (18 + 12) - 9, 11, 4);
         param0->unk_48 = 5;
     }
 
@@ -202,7 +202,7 @@ static BOOL ov5_021EAAA8(UnkStruct_ov5_021EAE78 *param0)
 static BOOL ov5_021EAAEC(UnkStruct_ov5_021EAE78 *param0)
 {
     if (Text_IsPrinterActive(param0->unk_40) == 0) {
-        param0->unk_44 = Menu_MakeYesNoChoice(param0->fieldSystem->unk_08, &Unk_ov5_021FAF00, 1024 - (18 + 12) - 9, 11, 4);
+        param0->unk_44 = Menu_MakeYesNoChoice(param0->fieldSystem->bgConfig, &Unk_ov5_021FAF00, 1024 - (18 + 12) - 9, 11, 4);
         param0->unk_48 = 7;
     }
 
@@ -260,7 +260,7 @@ static BOOL ov5_021EAB58(UnkStruct_ov5_021EAE78 *param0)
 
     param0->unk_00 = StringList_New(v2 + 1, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_20, 3, 19, 1, 12, v3 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (10 * (v3 + 2) * 2));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_20, 3, 19, 1, 12, v3 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (10 * (v3 + 2) * 2));
     Window_DrawStandardFrame(&param0->unk_20, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -339,7 +339,7 @@ static BOOL ov5_021EAC44(UnkStruct_ov5_021EAE78 *param0)
 static BOOL ov5_021EACFC(UnkStruct_ov5_021EAE78 *param0)
 {
     if (Text_IsPrinterActive(param0->unk_40) == 0) {
-        param0->unk_44 = Menu_MakeYesNoChoice(param0->fieldSystem->unk_08, &Unk_ov5_021FAF00, 1024 - (18 + 12) - 9, 11, 4);
+        param0->unk_44 = Menu_MakeYesNoChoice(param0->fieldSystem->bgConfig, &Unk_ov5_021FAF00, 1024 - (18 + 12) - 9, 11, 4);
         param0->unk_48 = 11;
     }
 
@@ -435,7 +435,7 @@ static void ov5_021EAE78(UnkStruct_ov5_021EAE78 *param0, int param1)
 
     MessageLoader_GetStrbuf(param0->unk_3C, param1, param0->unk_08);
     StringTemplate_Format(param0->unk_38, param0->unk_0C, param0->unk_08);
-    FieldMessage_AddWindow(param0->fieldSystem->unk_08, &param0->unk_10, 3);
+    FieldMessage_AddWindow(param0->fieldSystem->bgConfig, &param0->unk_10, 3);
     FieldMessage_DrawWindow(&param0->unk_10, SaveData_Options(param0->fieldSystem->saveData));
 
     param0->unk_40 = FieldMessage_Print(&param0->unk_10, param0->unk_0C, SaveData_Options(param0->fieldSystem->saveData), 1);

--- a/src/overlay005/ov5_021F007C.c
+++ b/src/overlay005/ov5_021F007C.c
@@ -113,7 +113,7 @@ static void ov5_021F013C(UnkStruct_ov5_021D1BEC *param0, FieldSystem *fieldSyste
 {
     UnkStruct_ov5_021F013C *v0 = param2;
 
-    ov5_021F0260(fieldSystem->unk_08);
+    ov5_021F0260(fieldSystem->bgConfig);
     ov5_021F02B8(&v0->unk_00, 0, 10, 19);
 
     v0->unk_14 = 0;
@@ -129,7 +129,7 @@ static void ov5_021F0188(UnkStruct_ov5_021D1BEC *param0, FieldSystem *fieldSyste
 {
     UnkStruct_ov5_021F013C *v0 = param2;
 
-    ov5_021F0260(fieldSystem->unk_08);
+    ov5_021F0260(fieldSystem->bgConfig);
     ov5_021F02B8(&v0->unk_00, 10, 0, 15);
 
     v0->unk_14 = 0;
@@ -307,8 +307,8 @@ static void ov5_021F0310(FieldSystem *fieldSystem)
     G2_SetBG2Priority(3);
 
     Bg_LoadPalette(2, &v0, 2, ((6 * 32) + 4));
-    Bg_FillTilesRange(fieldSystem->unk_08, 2, 2, 1, 2);
-    Bg_FillTilemap(fieldSystem->unk_08, 2, ((6 << 12) | 2));
+    Bg_FillTilesRange(fieldSystem->bgConfig, 2, 2, 1, 2);
+    Bg_FillTilemap(fieldSystem->bgConfig, 2, ((6 << 12) | 2));
     GXLayers_EngineAToggleLayers(GX_PLANEMASK_BG2, 1);
 
     ov5_021F02F4(fieldSystem);
@@ -323,8 +323,8 @@ static void ov5_021F0374(FieldSystem *fieldSystem)
     G2_SetBG3Priority(3);
 
     Bg_LoadPalette(3, &v0, 2, ((6 * 32) + 4));
-    Bg_FillTilesRange(fieldSystem->unk_08, 3, 2, 1, 2);
-    Bg_FillTilemap(fieldSystem->unk_08, 3, ((6 << 12) | 2));
+    Bg_FillTilesRange(fieldSystem->bgConfig, 3, 2, 1, 2);
+    Bg_FillTilemap(fieldSystem->bgConfig, 3, ((6 << 12) | 2));
     GXLayers_EngineAToggleLayers(GX_PLANEMASK_BG3, 1);
 
     ov5_021F02F4(fieldSystem);
@@ -524,7 +524,7 @@ BOOL ov5_021F0488(TaskManager *param0)
                 G2_BlendNone();
                 Bg_SetPriority(2, 3);
 
-                Bg_ClearTilemap(fieldSystem->unk_08, 2);
+                Bg_ClearTilemap(fieldSystem->bgConfig, 2);
             } else {
                 Bg_SetPriority(2, 1);
             }

--- a/src/overlay005/ov5_021F08CC.c
+++ b/src/overlay005/ov5_021F08CC.c
@@ -521,7 +521,7 @@ static void ov5_021F0DC4(UnkStruct_ov5_021F0D6C *param0)
 {
     FieldSystem *fieldSystem = param0->fieldSystem;
 
-    FieldMessage_AddWindow(fieldSystem->unk_08, &param0->window, 3);
+    FieldMessage_AddWindow(fieldSystem->bgConfig, &param0->window, 3);
     FieldMessage_DrawWindow(&param0->window, SaveData_Options(fieldSystem->saveData));
 }
 

--- a/src/overlay005/ov5_021F6454.c
+++ b/src/overlay005/ov5_021F6454.c
@@ -273,12 +273,12 @@ void ov5_021F6760(UnkStruct_ov5_021F6704 *param0, u32 param1, u32 param2, u32 pa
 static void ov5_021F6768(UnkStruct_ov5_021F6704 *param0)
 {
     if (param0->unk_20B > 8) {
-        Window_Add(param0->fieldSystem->unk_08, &param0->unk_08, 3, param0->unk_208, param0->unk_209, 11, 8 * 2, 13, 1);
+        Window_Add(param0->fieldSystem->bgConfig, &param0->unk_08, 3, param0->unk_208, param0->unk_209, 11, 8 * 2, 13, 1);
     } else {
-        Window_Add(param0->fieldSystem->unk_08, &param0->unk_08, 3, param0->unk_208, param0->unk_209, 11, param0->unk_20B * 2, 13, 1);
+        Window_Add(param0->fieldSystem->bgConfig, &param0->unk_08, 3, param0->unk_208, param0->unk_209, 11, param0->unk_20B * 2, 13, 1);
     }
 
-    LoadStandardWindowGraphics(param0->fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    LoadStandardWindowGraphics(param0->fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
     Window_DrawStandardFrame(&param0->unk_08, 1, 1024 - (18 + 12) - 9, 11);
     ov5_021F68BC(param0);
 

--- a/src/overlay005/ov5_021F77A8.c
+++ b/src/overlay005/ov5_021F77A8.c
@@ -471,12 +471,12 @@ void ov5_021F7F2C(UnkStruct_ov5_021F7ED8 *param0, u32 param1, u32 param2, u32 pa
 static void ov5_021F7F34(UnkStruct_ov5_021F7ED8 *param0)
 {
     if (param0->unk_C7 > 8) {
-        Window_Add(param0->fieldSystem->unk_08, &param0->unk_08, 3, param0->unk_C4, param0->unk_C5, 11, 8 * 2, 13, 1);
+        Window_Add(param0->fieldSystem->bgConfig, &param0->unk_08, 3, param0->unk_C4, param0->unk_C5, 11, 8 * 2, 13, 1);
     } else {
-        Window_Add(param0->fieldSystem->unk_08, &param0->unk_08, 3, param0->unk_C4, param0->unk_C5, 11, param0->unk_C7 * 2, 13, 1);
+        Window_Add(param0->fieldSystem->bgConfig, &param0->unk_08, 3, param0->unk_C4, param0->unk_C5, 11, param0->unk_C7 * 2, 13, 1);
     }
 
-    LoadStandardWindowGraphics(param0->fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    LoadStandardWindowGraphics(param0->fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
     Window_DrawStandardFrame(&param0->unk_08, 1, 1024 - (18 + 12) - 9, 11);
     ov5_021F8090(param0);
 

--- a/src/overlay005/save_info_window.c
+++ b/src/overlay005/save_info_window.c
@@ -168,7 +168,7 @@ SaveInfoWindow *SaveInfoWindow_New(FieldSystem *fieldSystem, enum HeapId heapID,
     saveInfoWin->fieldSystem = fieldSystem;
     saveInfoWin->heapID = heapID;
     saveInfoWin->bgLayer = bgLayer;
-    saveInfoWin->bgConfig = fieldSystem->unk_08;
+    saveInfoWin->bgConfig = fieldSystem->bgConfig;
     saveInfoWin->strTemplate = StringTemplate_Default(heapID);
     saveInfoWin->msgLoader = MessageLoader_Init(MESSAGE_LOADER_NARC_HANDLE, NARC_INDEX_MSGDATA__PL_MSG, message_bank_save_info_window, heapID);
 

--- a/src/overlay006/ov6_0223E140.c
+++ b/src/overlay006/ov6_0223E140.c
@@ -418,8 +418,8 @@ static void ov6_0223E25C(SysTask *param0, void *param1)
     UnkStruct_ov6_0223E140 *v0 = param1;
 
     ov6_0223E1B0();
-    ov6_0223E2A4(v0->fieldSystem->unk_08);
-    ov6_0223E1D0(v0->fieldSystem->unk_08);
+    ov6_0223E2A4(v0->fieldSystem->bgConfig);
+    ov6_0223E1D0(v0->fieldSystem->bgConfig);
 
     SysTask_Done(param0);
 }
@@ -429,8 +429,8 @@ static void ov6_0223E280(SysTask *param0, void *param1)
     UnkStruct_ov6_0223E140 *v0 = param1;
 
     GXLayers_SetBanks(&v0->unk_04);
-    ov6_0223E2A4(v0->fieldSystem->unk_08);
-    ov6_0223E2AC(v0->fieldSystem->unk_08);
+    ov6_0223E2A4(v0->fieldSystem->bgConfig);
+    ov6_0223E2AC(v0->fieldSystem->bgConfig);
     SysTask_Done(param0);
 }
 

--- a/src/overlay006/ov6_02242AF0.c
+++ b/src/overlay006/ov6_02242AF0.c
@@ -176,7 +176,7 @@ void ov6_02242B58(FieldSystem *fieldSystem, const u16 param1, const u16 param2)
         v2->unk_00 = ov6_02242E60;
     }
 
-    FieldTask_Start(fieldSystem->unk_10, ov6_02242C5C, v2);
+    FieldTask_Start(fieldSystem->taskManager, ov6_02242C5C, v2);
 }
 
 u32 ov6_02242C3C(FieldSystem *fieldSystem, const u16 param1)

--- a/src/overlay006/ov6_02243258.c
+++ b/src/overlay006/ov6_02243258.c
@@ -1496,7 +1496,7 @@ static int ov6_02244548(UnkStruct_ov6_02243FFC *param0)
     }
 
     if ((param0->unk_4C == (FX32_ONE * (96 - 1))) && (param0->unk_50 == (FX32_ONE * (96 + 1)))) {
-        ov6_02244F20(param0->fieldSystem->unk_08);
+        ov6_02244F20(param0->fieldSystem->bgConfig);
         param0->unk_14 = 1;
         ov6_02244F58(param0);
         param0->unk_00++;
@@ -1687,8 +1687,8 @@ static void ov6_0224481C(UnkStruct_ov6_02243FFC *param0)
     ov6_02244F80(param0, (FX32_ONE * 0), (FX32_ONE * 192), (FX32_ONE * 1), (FX32_ONE * 192));
     ov6_02244F2C(param0);
 
-    param0->unk_24 = Bg_GetPriority(param0->fieldSystem->unk_08, 0);
-    param0->unk_26 = Bg_GetPriority(param0->fieldSystem->unk_08, 3);
+    param0->unk_24 = Bg_GetPriority(param0->fieldSystem->bgConfig, 0);
+    param0->unk_26 = Bg_GetPriority(param0->fieldSystem->bgConfig, 3);
 
     G2_SetBG1Priority(1);
     G2_SetBG3Priority(0);
@@ -1696,8 +1696,8 @@ static void ov6_0224481C(UnkStruct_ov6_02243FFC *param0)
     GXLayers_EngineAToggleLayers(GX_PLANEMASK_BG3, 0);
 
     ov6_02244E54(v0, 2, &param0->unk_6C);
-    ov6_02244E7C(param0->fieldSystem->unk_08, v0, 0, &param0->unk_68);
-    ov6_02244EB4(param0->fieldSystem->unk_08, v0, 1, &param0->unk_64);
+    ov6_02244E7C(param0->fieldSystem->bgConfig, v0, 0, &param0->unk_68);
+    ov6_02244EB4(param0->fieldSystem->bgConfig, v0, 1, &param0->unk_64);
     ov6_02244928(param0, v0);
 
     NARC_dtor(v0);
@@ -1710,7 +1710,7 @@ static void ov6_022448C8(UnkStruct_ov6_02243FFC *param0)
     GXLayers_EngineAToggleLayers(GX_PLANEMASK_BG3, 0);
     sub_0207121C(param0->unk_244);
 
-    ov6_02244F20(param0->fieldSystem->unk_08);
+    ov6_02244F20(param0->fieldSystem->bgConfig);
     ov6_02244B6C(param0);
 
     G2_SetBG0Priority(param0->unk_24);

--- a/src/overlay006/ov6_02246C24.c
+++ b/src/overlay006/ov6_02246C24.c
@@ -64,7 +64,7 @@ void ov6_02246C24(FieldSystem *fieldSystem, const u8 param1)
             v4->unk_00.z += v5.z;
         }
 
-        FieldTask_Start(fieldSystem->unk_10, ov6_02246C9C, v4);
+        FieldTask_Start(fieldSystem->taskManager, ov6_02246C9C, v4);
     } else {
         GF_ASSERT(FALSE);
     }

--- a/src/overlay006/ov6_02246F00.c
+++ b/src/overlay006/ov6_02246F00.c
@@ -38,7 +38,7 @@ void ov6_02246F00(FieldSystem *fieldSystem, const u8 param1, const u8 param2)
         v1->unk_01 = param1;
         v1->unk_02 = 0;
 
-        FieldTask_Start(fieldSystem->unk_10, ov6_02246F40, v1);
+        FieldTask_Start(fieldSystem->taskManager, ov6_02246F40, v1);
     } else {
         GF_ASSERT(FALSE);
     }

--- a/src/overlay006/ov6_02247D30.c
+++ b/src/overlay006/ov6_02247D30.c
@@ -62,7 +62,7 @@ void ov6_02247D30(FieldSystem *fieldSystem, const u8 param1)
             v4->unk_00.z += v5.z;
         }
 
-        FieldTask_Start(fieldSystem->unk_10, ov6_02247DAC, v4);
+        FieldTask_Start(fieldSystem->taskManager, ov6_02247DAC, v4);
     } else {
         GF_ASSERT(FALSE);
     }

--- a/src/overlay006/ov6_02247F5C.c
+++ b/src/overlay006/ov6_02247F5C.c
@@ -35,7 +35,7 @@ void ov6_02247F5C(FieldSystem *fieldSystem)
 
 void ov6_02247FBC(FieldSystem *fieldSystem)
 {
-    FieldTask_Start(fieldSystem->unk_10, ov6_02247FD0, NULL);
+    FieldTask_Start(fieldSystem->taskManager, ov6_02247FD0, NULL);
 }
 
 static BOOL ov6_02247FD0(TaskManager *param0)

--- a/src/overlay007/communication_club.c
+++ b/src/overlay007/communication_club.c
@@ -160,7 +160,7 @@ static void CommClubMan_PrintMessage(int msgId, BOOL format)
     }
 
     if (!Window_IsInUse(&sCommClubMan->msgWindow)) {
-        FieldMessage_AddWindow(sCommClubMan->fieldSystem->unk_08, &sCommClubMan->msgWindow, 3);
+        FieldMessage_AddWindow(sCommClubMan->fieldSystem->bgConfig, &sCommClubMan->msgWindow, 3);
     }
 
     FieldMessage_DrawWindow(&sCommClubMan->msgWindow, SaveData_Options(sCommClubMan->fieldSystem->saveData));
@@ -181,7 +181,7 @@ static inline void CommClubMan_PrintMessageFastSpeed(int msgId, BOOL format)
     }
 
     if (!Window_IsInUse(&sCommClubMan->msgWindow)) {
-        FieldMessage_AddWindow(sCommClubMan->fieldSystem->unk_08, &sCommClubMan->msgWindow, 3);
+        FieldMessage_AddWindow(sCommClubMan->fieldSystem->bgConfig, &sCommClubMan->msgWindow, 3);
     }
 
     FieldMessage_DrawWindow(&sCommClubMan->msgWindow, SaveData_Options(sCommClubMan->fieldSystem->saveData));
@@ -194,7 +194,7 @@ static inline void CommClubMan_PrintMessageFastSpeed(int msgId, BOOL format)
 static void CommClubMan_CreateList(ListMenuTemplate param0, u8 param1, u8 param2, u8 param3, u8 param4, u16 param5)
 {
     if (!Window_IsInUse(&sCommClubMan->unk_20)) {
-        Window_Add(sCommClubMan->fieldSystem->unk_08, &sCommClubMan->unk_20, 3, param1, param2, param3, param4, 13, param5);
+        Window_Add(sCommClubMan->fieldSystem->bgConfig, &sCommClubMan->unk_20, 3, param1, param2, param3, param4, 13, param5);
     }
 
     Window_DrawStandardFrame(&sCommClubMan->unk_20, 1, 1024 - (18 + 12) - 9, 11);
@@ -358,7 +358,7 @@ static void ov7_02249C94(ListMenu *param0, u32 param1, u8 param2)
 static void CommClubMan_PrintChooseJoinMsg(CommClubManager *param0)
 {
     if (!Window_IsInUse(&sCommClubMan->unk_30)) {
-        Window_Add(sCommClubMan->fieldSystem->unk_08, &sCommClubMan->unk_30, 3, 23, 2, 8, 4, 13, (1 + 20 * 5 * 2));
+        Window_Add(sCommClubMan->fieldSystem->bgConfig, &sCommClubMan->unk_30, 3, 23, 2, 8, 4, 13, (1 + 20 * 5 * 2));
     }
 
     Window_DrawStandardFrame(&sCommClubMan->unk_30, 1, 1024 - (18 + 12) - 9, 11);
@@ -592,7 +592,7 @@ static void CommClubTask_WaitConfirmLeaveGroup(SysTask *task, void *data)
     }
 
     if (FieldMessage_FinishedPrinting(sCommClubMan->printMsgIndex)) {
-        commClubMan->unk_60 = Menu_MakeYesNoChoice(sCommClubMan->fieldSystem->unk_08, &Unk_ov7_0224ED0C, 1024 - (18 + 12) - 9, 11, 4);
+        commClubMan->unk_60 = Menu_MakeYesNoChoice(sCommClubMan->fieldSystem->bgConfig, &Unk_ov7_0224ED0C, 1024 - (18 + 12) - 9, 11, 4);
         CommClubMan_SetTask(CommClubTask_LeaveGroup);
     }
 }
@@ -689,7 +689,7 @@ static void ov7_0224A53C(CommClubManager *man)
     ov7_0224A5D0();
 
     if (!Window_IsInUse(&sCommClubMan->unk_30)) {
-        Window_Add(sCommClubMan->fieldSystem->unk_08, &sCommClubMan->unk_30, 3, 22, 2, 9, 4, 13, (1 + 17 * 6 * 2));
+        Window_Add(sCommClubMan->fieldSystem->bgConfig, &sCommClubMan->unk_30, 3, 22, 2, 9, 4, 13, (1 + 17 * 6 * 2));
     }
 
     Window_DrawStandardFrame(&sCommClubMan->unk_30, 1, 1024 - (18 + 12) - 9, 11);
@@ -1140,7 +1140,7 @@ static void ov7_0224AC48(SysTask *task, void *param1)
     ListMenu_ProcessInput(commClubMan->unk_5C);
 
     if (FieldMessage_FinishedPrinting(sCommClubMan->printMsgIndex)) {
-        commClubMan->unk_60 = Menu_MakeYesNoChoice(sCommClubMan->fieldSystem->unk_08, &Unk_ov7_0224ED0C, 1024 - (18 + 12) - 9, 11, 4);
+        commClubMan->unk_60 = Menu_MakeYesNoChoice(sCommClubMan->fieldSystem->bgConfig, &Unk_ov7_0224ED0C, 1024 - (18 + 12) - 9, 11, 4);
         CommClubMan_SetTask(ov7_0224ACA4);
     }
 }
@@ -1305,7 +1305,7 @@ static void ov7_0224AE78(SysTask *task, void *param1)
     ListMenu_ProcessInput(commClubMan->unk_5C);
 
     if (FieldMessage_FinishedPrinting(sCommClubMan->printMsgIndex)) {
-        commClubMan->unk_60 = Menu_MakeYesNoChoice(sCommClubMan->fieldSystem->unk_08, &Unk_ov7_0224ED0C, 1024 - (18 + 12) - 9, 11, 4);
+        commClubMan->unk_60 = Menu_MakeYesNoChoice(sCommClubMan->fieldSystem->bgConfig, &Unk_ov7_0224ED0C, 1024 - (18 + 12) - 9, 11, 4);
         CommClubMan_SetTask(ov7_0224AECC);
     }
 }
@@ -1361,7 +1361,7 @@ static void ov7_0224AF84(SysTask *task, void *param1)
     ListMenu_ProcessInput(commClubMan->unk_5C);
 
     if (FieldMessage_FinishedPrinting(sCommClubMan->printMsgIndex)) {
-        commClubMan->unk_60 = Menu_MakeYesNoChoice(sCommClubMan->fieldSystem->unk_08, &Unk_ov7_0224ED0C, 1024 - (18 + 12) - 9, 11, 4);
+        commClubMan->unk_60 = Menu_MakeYesNoChoice(sCommClubMan->fieldSystem->bgConfig, &Unk_ov7_0224ED0C, 1024 - (18 + 12) - 9, 11, 4);
         CommClubMan_SetTask(ov7_0224A97C);
     }
 }

--- a/src/overlay007/ov7_0224B4E8.c
+++ b/src/overlay007/ov7_0224B4E8.c
@@ -87,7 +87,7 @@ static void ov7_0224B4E8(UnkStruct_ov7_0224B4E8 *param0, int param1)
 {
     if (Window_IsInUse(&param0->unk_54) == 0) {
         Window_Init(&param0->unk_54);
-        FieldMessage_AddWindow(param0->fieldSystem->unk_08, &param0->unk_54, 3);
+        FieldMessage_AddWindow(param0->fieldSystem->bgConfig, &param0->unk_54, 3);
         FieldMessage_DrawWindow(&param0->unk_54, SaveData_Options(param0->fieldSystem->saveData));
     } else {
         sub_0205D988(&param0->unk_54);
@@ -131,7 +131,7 @@ static void ov7_0224B5A8(UnkStruct_ov7_0224B4E8 *param0)
 
         param0->unk_08 = StringList_New(v3 + 2, 4);
 
-        Window_Add(param0->fieldSystem->unk_08, v1, 3, 1, 1, 16, (v3 + 2) * 2, 13, 1);
+        Window_Add(param0->fieldSystem->bgConfig, v1, 3, 1, 1, 16, (v3 + 2) * 2, 13, 1);
         Window_DrawStandardFrame(&param0->unk_34, 1, 1024 - (18 + 12) - 9, 11);
         StringList_AddFromMessageBank(param0->unk_08, param0->unk_68, 123, 12);
 
@@ -224,7 +224,7 @@ static void ov7_0224B788(UnkStruct_ov7_0224B4E8 *param0)
 
     param0->unk_0C = StringList_New(v1, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_44, 3, v5, v3, v4, v1 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - v4 * v1 * 2);
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_44, 3, v5, v3, v4, v1 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - v4 * v1 * 2);
     Window_DrawStandardFrame(&param0->unk_44, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -331,7 +331,7 @@ static void ov7_0224B8DC(UnkStruct_ov7_0224B4E8 *param0)
     v3 = Strbuf_Init((90 * 2), 4);
     v4 = &param0->unk_24;
 
-    Window_Add(param0->fieldSystem->unk_08, v4, 3, 4, 2, 24, 19, 13, 1);
+    Window_Add(param0->fieldSystem->bgConfig, v4, 3, 4, 2, 24, 19, 13, 1);
     Window_DrawStandardFrame(v4, 1, 1024 - (18 + 12) - 9, 11);
     Window_FillTilemap(v4, 15);
 

--- a/src/overlay007/ov7_0224CD28.c
+++ b/src/overlay007/ov7_0224CD28.c
@@ -185,7 +185,7 @@ void ov7_0224CDA4(TaskManager *param0, FieldSystem *fieldSystem, u16 *param2, u8
 {
     UnkStruct_ov7_0224D008 *v0 = ov7_0224CD88();
 
-    v0->unk_00 = fieldSystem->unk_08;
+    v0->unk_00 = fieldSystem->bgConfig;
 
     v0->unk_298 = Strbuf_Init((24 * 2 * 2), 11);
     v0->unk_270 = SaveData_GetTrainerInfo(fieldSystem->saveData);
@@ -1395,7 +1395,7 @@ static u8 ov7_0224E950(FieldSystem *fieldSystem, UnkStruct_ov7_0224D008 *param1)
         return 19;
     }
 
-    FieldMessage_AddWindow(fieldSystem->unk_08, &param1->unk_08[1], 3);
+    FieldMessage_AddWindow(fieldSystem->bgConfig, &param1->unk_08[1], 3);
     FieldMessage_DrawWindow(&param1->unk_08[1], param1->unk_278);
 
     {
@@ -1434,7 +1434,7 @@ static void ov7_0224EA54(FieldSystem *fieldSystem, UnkStruct_ov7_0224D008 *param
 
     StringTemplate_Format(param1->unk_8C, param1->unk_298, v0);
     Strbuf_Free(v0);
-    FieldMessage_AddWindow(fieldSystem->unk_08, &param1->unk_08[1], 3);
+    FieldMessage_AddWindow(fieldSystem->bgConfig, &param1->unk_08[1], 3);
     FieldMessage_DrawWindow(&param1->unk_08[1], param1->unk_278);
 
     param1->unk_2A4 = FieldMessage_Print(&param1->unk_08[1], param1->unk_298, param1->unk_278, 1);
@@ -1558,7 +1558,7 @@ static u8 ov7_0224EC9C(FieldSystem *fieldSystem, UnkStruct_ov7_0224D008 *param1)
         return 18;
     }
 
-    FieldMessage_AddWindow(fieldSystem->unk_08, &param1->unk_08[1], 3);
+    FieldMessage_AddWindow(fieldSystem->bgConfig, &param1->unk_08[1], 3);
     FieldMessage_DrawWindow(&param1->unk_08[1], param1->unk_278);
 
     {

--- a/src/overlay008/ov8_02249960.c
+++ b/src/overlay008/ov8_02249960.c
@@ -367,13 +367,13 @@ void ov8_0224997C(FieldSystem *fieldSystem)
         v6->unk_00 = 0;
 
         if (v4 == 239) {
-            FieldTask_Start(fieldSystem->unk_10, ov8_02249CD8, v6);
+            FieldTask_Start(fieldSystem->taskManager, ov8_02249CD8, v6);
             v8->unk_00 = 2;
         } else if (v4 == 240) {
-            FieldTask_Start(fieldSystem->unk_10, ov8_02249B74, v6);
+            FieldTask_Start(fieldSystem->taskManager, ov8_02249B74, v6);
             v8->unk_00 = 1;
         } else if (v4 == 241) {
-            FieldTask_Start(fieldSystem->unk_10, ov8_02249A94, v6);
+            FieldTask_Start(fieldSystem->taskManager, ov8_02249A94, v6);
             v8->unk_00 = 0;
         } else {
             GF_ASSERT(FALSE);
@@ -762,10 +762,10 @@ void ov8_02249FB8(FieldSystem *fieldSystem)
         PlayerAvatar_PosVectorOut(fieldSystem->playerAvatar, &v1);
 
         if (v1.y == (FX32_ONE * 16 * 0)) {
-            FieldTask_Start(fieldSystem->unk_10, ov8_0224A018, v0);
+            FieldTask_Start(fieldSystem->taskManager, ov8_0224A018, v0);
             v3->unk_00 = 1;
         } else {
-            FieldTask_Start(fieldSystem->unk_10, ov8_0224A0E8, v0);
+            FieldTask_Start(fieldSystem->taskManager, ov8_0224A0E8, v0);
             v3->unk_00 = 0;
         }
     }
@@ -2207,7 +2207,7 @@ void ov8_0224AD34(FieldSystem *fieldSystem, const u8 param1)
         v1->unk_13 = v4;
 
         Sound_PlayEffect(1599);
-        FieldTask_Start(fieldSystem->unk_10, ov8_0224ADE8, v0);
+        FieldTask_Start(fieldSystem->taskManager, ov8_0224ADE8, v0);
     }
 }
 
@@ -2906,7 +2906,7 @@ BOOL ov8_0224B67C(FieldSystem *fieldSystem, Window *param1, MessageLoader *param
         v2->unk_14 = v1;
         v2->unk_18 = v3;
 
-        FieldTask_Start(fieldSystem->unk_10, ov8_0224B3D4, v2);
+        FieldTask_Start(fieldSystem->taskManager, ov8_0224B3D4, v2);
     }
 
     return 1;

--- a/src/overlay008/ov8_02249960.c
+++ b/src/overlay008/ov8_02249960.c
@@ -2844,7 +2844,7 @@ static BOOL ov8_0224B3D4(TaskManager *param0)
 
             sub_020057A4(1593, 0);
             MessageLoader_GetStrbuf(v2->unk_48, 12, v2->unk_4C);
-            FieldMessage_AddWindow(fieldSystem->unk_08, v2->unk_44, 3);
+            FieldMessage_AddWindow(fieldSystem->bgConfig, v2->unk_44, 3);
             Window_EraseMessageBox(v2->unk_44, 0);
             FieldMessage_DrawWindow(v2->unk_44, SaveData_Options(fieldSystem->saveData));
 

--- a/src/overlay009/ov9_02249960.c
+++ b/src/overlay009/ov9_02249960.c
@@ -2601,7 +2601,7 @@ static void ov9_0224ADC0(UnkStruct_ov9_02249B04 *param0)
         v6 = NARC_AllocAndReadWholeMember(param0->unk_10, 0, 4);
         NNS_G2dGetUnpackedCharacterData(v6, &v7);
 
-        Bg_LoadTiles(param0->fieldSystem->unk_08, 2, v7->pRawData, v7->szByte, 0);
+        Bg_LoadTiles(param0->fieldSystem->bgConfig, 2, v7->pRawData, v7->szByte, 0);
         Heap_FreeToHeap(v6);
     }
 
@@ -2612,9 +2612,9 @@ static void ov9_0224ADC0(UnkStruct_ov9_02249B04 *param0)
         v8 = NARC_AllocAndReadWholeMember(param0->unk_10, 2, 4);
         NNS_G2dGetUnpackedScreenData(v8, &v9);
 
-        Bg_CopyTilemapBufferRangeToVRAM(param0->fieldSystem->unk_08, 2, (void *)v9->rawData, v9->szByte, 0);
-        Bg_LoadTilemapBuffer(param0->fieldSystem->unk_08, 2, (void *)v9->rawData, v9->szByte);
-        Bg_CopyTilemapBufferToVRAM(param0->fieldSystem->unk_08, 2);
+        Bg_CopyTilemapBufferRangeToVRAM(param0->fieldSystem->bgConfig, 2, (void *)v9->rawData, v9->szByte, 0);
+        Bg_LoadTilemapBuffer(param0->fieldSystem->bgConfig, 2, (void *)v9->rawData, v9->szByte);
+        Bg_CopyTilemapBufferToVRAM(param0->fieldSystem->bgConfig, 2);
         Heap_FreeToHeap(v8);
     }
 

--- a/src/overlay023/ov23_0223E140.c
+++ b/src/overlay023/ov23_0223E140.c
@@ -1021,7 +1021,7 @@ static void ov23_0223EA38(SysTask *param0, void *param1)
 
     if (Unk_ov23_02257740->unk_A24 != -1) {
         if (Text_IsPrinterActive(Unk_ov23_02257740->unk_A24) == 0) {
-            Unk_ov23_02257740->unk_848 = Menu_MakeYesNoChoice(Unk_ov23_02257740->fieldSystem->unk_08, &Unk_ov23_0225630E, 1024 - (18 + 12) - 9, 11, 4);
+            Unk_ov23_02257740->unk_848 = Menu_MakeYesNoChoice(Unk_ov23_02257740->fieldSystem->bgConfig, &Unk_ov23_0225630E, 1024 - (18 + 12) - 9, 11, 4);
             Unk_ov23_02257740->unk_A24 = -1;
         }
     } else {
@@ -1398,7 +1398,7 @@ static void ov23_0223F020(UnkStruct_ov23_0223EE80 *param0)
     Unk_ov23_02257740->unk_04 = NULL;
 
     Heap_Destroy(29);
-    ov23_02253E2C(ov23_0224219C(), Unk_ov23_02257740->fieldSystem->unk_08, (1024 - (18 + 12)), (((1024 - (18 + 12)) - 73) - (27 * 4)));
+    ov23_02253E2C(ov23_0224219C(), Unk_ov23_02257740->fieldSystem->bgConfig, (1024 - (18 + 12)), (((1024 - (18 + 12)) - 73) - (27 * 4)));
 }
 
 static void ov23_0223F118(SysTask *param0, void *param1)
@@ -1590,7 +1590,7 @@ static void ov23_0223F118(SysTask *param0, void *param1)
             HBlankSystem_Start(v0->fieldSystem->unk_04->hBlankSystem);
 
             Graphics_LoadPalette(50, 52, 0, 10 * 0x20, 4 * 0x20, 4);
-            LoadStandardWindowGraphics(v0->fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 2, 4);
+            LoadStandardWindowGraphics(v0->fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 2, 4);
             CommPlayerMan_Restart();
 
             ov23_0224B460();

--- a/src/overlay023/ov23_02241F74.c
+++ b/src/overlay023/ov23_02241F74.c
@@ -137,15 +137,15 @@ static void CommManUnderground_Init(CommManUnderground *param0, FieldSystem *fie
     sCommManUnderground->unk_1C.unk_02 = 0;
     sCommManUnderground->unk_14B = 0;
     sCommManUnderground->unk_147 = 1;
-    sCommManUnderground->unk_118 = ov23_02253D48(634, 33, fieldSystem->unk_08, v0, 500);
-    sCommManUnderground->unk_11C = ov23_02253D48(638, 33, fieldSystem->unk_08, v0, 0);
-    sCommManUnderground->unk_120 = ov23_02253D48(636, 33, fieldSystem->unk_08, v0, 1000);
-    sCommManUnderground->unk_124 = ov23_02253D48(637, 33, fieldSystem->unk_08, v0, 0);
-    sCommManUnderground->unk_128 = ov23_02253D48(630, 33, fieldSystem->unk_08, v0, 0);
+    sCommManUnderground->unk_118 = ov23_02253D48(634, 33, fieldSystem->bgConfig, v0, 500);
+    sCommManUnderground->unk_11C = ov23_02253D48(638, 33, fieldSystem->bgConfig, v0, 0);
+    sCommManUnderground->unk_120 = ov23_02253D48(636, 33, fieldSystem->bgConfig, v0, 1000);
+    sCommManUnderground->unk_124 = ov23_02253D48(637, 33, fieldSystem->bgConfig, v0, 0);
+    sCommManUnderground->unk_128 = ov23_02253D48(630, 33, fieldSystem->bgConfig, v0, 0);
 
-    LoadMessageBoxGraphics(sCommManUnderground->fieldSystem->unk_08, 3, (1024 - (18 + 12)), 10, 0, 4);
+    LoadMessageBoxGraphics(sCommManUnderground->fieldSystem->bgConfig, 3, (1024 - (18 + 12)), 10, 0, 4);
     Graphics_LoadPalette(50, 52, 0, 10 * 0x20, 4 * 0x20, 4);
-    LoadStandardWindowGraphics(sCommManUnderground->fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 2, 4);
+    LoadStandardWindowGraphics(sCommManUnderground->fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 2, 4);
 
     for (v1 = 0; v1 < (7 + 1); v1++) {
         sCommManUnderground->unk_C2[v1] = 0xff;
@@ -761,7 +761,7 @@ void ov23_02242B14(void)
     ov23_0223E878();
 
     if (!sCommManUnderground->unk_14B) {
-        ov23_022468A8(sCommManUnderground->fieldSystem->unk_08);
+        ov23_022468A8(sCommManUnderground->fieldSystem->bgConfig);
     }
 }
 
@@ -819,7 +819,7 @@ void ov23_02242CB4(void)
         ov23_022435A8();
         ov23_0223E2F4();
         sCommManUnderground->unk_14B = 0;
-        LoadMessageBoxGraphics(sCommManUnderground->fieldSystem->unk_08, 3, (1024 - (18 + 12)), 10, 0, 4);
+        LoadMessageBoxGraphics(sCommManUnderground->fieldSystem->bgConfig, 3, (1024 - (18 + 12)), 10, 0, 4);
     }
 }
 

--- a/src/overlay023/ov23_02241F74.c
+++ b/src/overlay023/ov23_02241F74.c
@@ -1192,7 +1192,7 @@ BOOL ov23_02243298(int param0)
         return 0;
     }
 
-    if (sCommManUnderground->fieldSystem->unk_10) {
+    if (sCommManUnderground->fieldSystem->taskManager) {
         sCommManUnderground->unk_130++;
 
         if (sCommManUnderground->unk_130 > 100) {

--- a/src/overlay023/ov23_0224340C.c
+++ b/src/overlay023/ov23_0224340C.c
@@ -2159,7 +2159,7 @@ static void ov23_02244EA4(FieldSystem *fieldSystem, BOOL param1, int param2)
     Unk_ov23_02257764->unk_300 = v0;
     ov23_022451BC(v0);
 
-    v0->unk_10 = fieldSystem->unk_08;
+    v0->unk_10 = fieldSystem->bgConfig;
     v0->fieldSystem = fieldSystem;
     v0->unk_19 = param1;
     v0->unk_18 = param2;
@@ -2224,7 +2224,7 @@ static void ov23_02244FD0(int param0, BOOL param1)
 
         {
             int v1;
-            u8 *v2 = Bg_GetTilemapBuffer(Unk_ov23_02257764->fieldSystem->unk_08, 2);
+            u8 *v2 = Bg_GetTilemapBuffer(Unk_ov23_02257764->fieldSystem->bgConfig, 2);
 
             for (v1 = 0; v1 < 0x800; v1 += 2) {
                 v2[v1] = 0;
@@ -3159,7 +3159,7 @@ static void ov23_02245F94(SysTask *param0, void *param1)
         }
         break;
     case 7:
-        if (ov23_02246640(Unk_ov23_02257764->fieldSystem->unk_08, v0)) {
+        if (ov23_02246640(Unk_ov23_02257764->fieldSystem->bgConfig, v0)) {
             if (v0->unk_113) {
                 v0->unk_00 = 11;
             } else {
@@ -3587,7 +3587,7 @@ static void ov23_02246A80(SysTask *param0, void *param1)
     case 7:
         G2_SetBlendAlpha(GX_BLEND_PLANEMASK_OBJ, GX_BLEND_PLANEMASK_BG0, 14, 7);
 
-        if (ov23_02246F20(Unk_ov23_02257764->fieldSystem->unk_08, v0)) {
+        if (ov23_02246F20(Unk_ov23_02257764->fieldSystem->bgConfig, v0)) {
             sub_020057A4(1632, 0);
 
             if (v0->unk_15E) {
@@ -3792,7 +3792,7 @@ static void ov23_0224710C(int param0, BOOL param1, int param2)
     ov23_0224AD7C(param0, 2);
 
     if (CommSys_CurNetId() == param0) {
-        ov23_02246CF0(Unk_ov23_02257764->fieldSystem->unk_08, param1, param2);
+        ov23_02246CF0(Unk_ov23_02257764->fieldSystem->bgConfig, param1, param2);
     }
 }
 
@@ -4204,7 +4204,7 @@ static void ov23_02247A8C(SysTask *param0, void *param1)
         }
         break;
     case 7:
-        if (ov23_02247568(Unk_ov23_02257764->fieldSystem->unk_08, v0)) {
+        if (ov23_02247568(Unk_ov23_02257764->fieldSystem->bgConfig, v0)) {
             if (v0->unk_127) {
                 v0->unk_00 = 11;
             } else {
@@ -4265,7 +4265,7 @@ static void ov23_02247D78(int param0, BOOL param1, int param2)
     ov23_0224AD7C(param0, 2);
 
     if (CommSys_CurNetId() == param0) {
-        ov23_02247D28(Unk_ov23_02257764->fieldSystem->unk_08, param1, param2);
+        ov23_02247D28(Unk_ov23_02257764->fieldSystem->bgConfig, param1, param2);
     }
 }
 
@@ -4500,7 +4500,7 @@ static void ov23_022480C4(SysTask *param0, void *param1)
     case 7:
         G2_SetBlendAlpha(GX_BLEND_PLANEMASK_OBJ, GX_BLEND_PLANEMASK_BG0, 14, 7);
 
-        if (ov23_02247F4C(Unk_ov23_02257764->fieldSystem->unk_08, v0)) {
+        if (ov23_02247F4C(Unk_ov23_02257764->fieldSystem->bgConfig, v0)) {
             if (v0->unk_2A) {
                 v0->unk_00 = 11;
             } else {
@@ -4561,7 +4561,7 @@ static void ov23_02248364(int param0, BOOL param1, int param2)
     ov23_0224AD7C(param0, 2);
 
     if (CommSys_CurNetId() == param0) {
-        ov23_02248318(Unk_ov23_02257764->fieldSystem->unk_08, param1, param2);
+        ov23_02248318(Unk_ov23_02257764->fieldSystem->bgConfig, param1, param2);
     }
 }
 
@@ -4683,7 +4683,7 @@ static void ov23_02248570(int param0, BOOL param1, int param2)
     ov23_0224AD7C(param0, 2);
 
     if (CommSys_CurNetId() == param0) {
-        ov23_0224852C(Unk_ov23_02257764->fieldSystem->unk_08, param1, param2);
+        ov23_0224852C(Unk_ov23_02257764->fieldSystem->bgConfig, param1, param2);
     }
 }
 
@@ -4833,7 +4833,7 @@ static void ov23_02248884(SysTask *param0, void *param1)
         v0->unk_00 = 7;
         break;
     case 7:
-        if (ov23_02248614(Unk_ov23_02257764->fieldSystem->unk_08, v0)) {
+        if (ov23_02248614(Unk_ov23_02257764->fieldSystem->bgConfig, v0)) {
             v0->unk_00 = 9;
         }
         break;

--- a/src/overlay023/ov23_02248F1C.c
+++ b/src/overlay023/ov23_02248F1C.c
@@ -323,7 +323,7 @@ UnkStruct_ov23_0224942C *ov23_02249404(FieldSystem *fieldSystem)
     v0 = SysTask_GetParam(v1);
 
     v0->fieldSystem = fieldSystem;
-    v0->unk_1B8 = fieldSystem->unk_08;
+    v0->unk_1B8 = fieldSystem->bgConfig;
 
     return v0;
 }

--- a/src/overlay023/ov23_022499E4.c
+++ b/src/overlay023/ov23_022499E4.c
@@ -391,7 +391,7 @@ static void ov23_02249E18(void)
 
     ov23_02242B14();
 
-    if (v0->fieldSystem->unk_10 != NULL) {
+    if (v0->fieldSystem->taskManager != NULL) {
         return;
     }
 
@@ -579,7 +579,7 @@ static void ov23_0224A09C(void)
     ov23_02242B14();
     sub_02059524();
 
-    if (v0->fieldSystem->unk_10 != NULL) {
+    if (v0->fieldSystem->taskManager != NULL) {
         return;
     }
 

--- a/src/overlay023/ov23_0224B05C.c
+++ b/src/overlay023/ov23_0224B05C.c
@@ -858,7 +858,7 @@ static void ov23_0224BAAC(SysTask *param0, void *param1)
         break;
     case 1:
         if (ov23_02254238(ov23_0224219C()) == 0) {
-            v0->unk_04 = Menu_MakeYesNoChoice(fieldSystem->unk_08, &Unk_ov23_02256864, 1024 - (18 + 12) - 9, 11, 4);
+            v0->unk_04 = Menu_MakeYesNoChoice(fieldSystem->bgConfig, &Unk_ov23_02256864, 1024 - (18 + 12) - 9, 11, 4);
             v0->unk_0C = 2;
         }
         break;
@@ -875,7 +875,7 @@ static void ov23_0224BAAC(SysTask *param0, void *param1)
         break;
     case 3:
         if (ov23_02254238(ov23_0224219C()) == 0) {
-            v0->unk_04 = Menu_MakeYesNoChoice(fieldSystem->unk_08, &Unk_ov23_02256864, 1024 - (18 + 12) - 9, 11, 4);
+            v0->unk_04 = Menu_MakeYesNoChoice(fieldSystem->bgConfig, &Unk_ov23_02256864, 1024 - (18 + 12) - 9, 11, 4);
             v0->unk_0C = 4;
         }
         break;
@@ -893,7 +893,7 @@ static void ov23_0224BAAC(SysTask *param0, void *param1)
         break;
     case 5:
         if (ov23_02254238(ov23_0224219C()) == 0) {
-            v0->unk_04 = Menu_MakeYesNoChoice(fieldSystem->unk_08, &Unk_ov23_02256864, 1024 - (18 + 12) - 9, 11, 4);
+            v0->unk_04 = Menu_MakeYesNoChoice(fieldSystem->bgConfig, &Unk_ov23_02256864, 1024 - (18 + 12) - 9, 11, 4);
             v0->unk_0C = 6;
         }
         break;
@@ -1058,7 +1058,7 @@ static void ov23_0224BE28(SysTask *param0, void *param1)
         break;
     case 1:
         if (ov23_02254238(ov23_0224219C()) == 0) {
-            v0->unk_04 = Menu_MakeYesNoChoice(fieldSystem->unk_08, &Unk_ov23_02256864, 1024 - (18 + 12) - 9, 11, 4);
+            v0->unk_04 = Menu_MakeYesNoChoice(fieldSystem->bgConfig, &Unk_ov23_02256864, 1024 - (18 + 12) - 9, 11, 4);
             v0->unk_0C = 2;
         }
         break;
@@ -1080,7 +1080,7 @@ static void ov23_0224BE28(SysTask *param0, void *param1)
         break;
     case 4:
         if (ov23_02254238(ov23_0224219C()) == 0) {
-            v0->unk_04 = Menu_MakeYesNoChoice(fieldSystem->unk_08, &Unk_ov23_02256864, 1024 - (18 + 12) - 9, 11, 4);
+            v0->unk_04 = Menu_MakeYesNoChoice(fieldSystem->bgConfig, &Unk_ov23_02256864, 1024 - (18 + 12) - 9, 11, 4);
             v0->unk_0C = 5;
         }
         break;
@@ -1104,7 +1104,7 @@ static void ov23_0224BE28(SysTask *param0, void *param1)
         break;
     case 6:
         if (ov23_02254238(ov23_0224219C()) == 0) {
-            v0->unk_04 = ov23_0224BD90(fieldSystem->unk_08, &Unk_ov23_0225686C, 1024 - (18 + 12) - 9, 11, 4);
+            v0->unk_04 = ov23_0224BD90(fieldSystem->bgConfig, &Unk_ov23_0225686C, 1024 - (18 + 12) - 9, 11, 4);
             v0->unk_0C = 7;
         }
         break;
@@ -1639,7 +1639,7 @@ static BOOL ov23_0224C790(TaskManager *param0)
         sub_020594FC();
 
         Graphics_LoadPalette(50, 52, 0, 10 * 0x20, 4 * 0x20, 4);
-        LoadStandardWindowGraphics(fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 2, 4);
+        LoadStandardWindowGraphics(fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 2, 4);
 
         if (v1->unk_2D) {
             sub_020594EC();
@@ -1811,7 +1811,7 @@ static void ov23_0224CB1C(SysTask *param0, void *param1)
         break;
     case 5:
         if (ov23_02254238(ov23_0224219C()) == 0) {
-            v0->unk_08 = Menu_MakeYesNoChoice(fieldSystem->unk_08, &Unk_ov23_02256864, 1024 - (18 + 12) - 9, 11, 4);
+            v0->unk_08 = Menu_MakeYesNoChoice(fieldSystem->bgConfig, &Unk_ov23_02256864, 1024 - (18 + 12) - 9, 11, 4);
             v0->unk_0C = 6;
         }
         break;

--- a/src/overlay023/ov23_0224B05C.c
+++ b/src/overlay023/ov23_0224B05C.c
@@ -960,7 +960,7 @@ static UnkStruct_ov23_0224BA48 *ov23_0224BCC4(FieldSystem *fieldSystem, int para
 {
     UnkStruct_ov23_0224BA48 *v0 = NULL;
 
-    if (fieldSystem->unk_10 == NULL) {
+    if (fieldSystem->taskManager == NULL) {
         v0 = Heap_AllocFromHeapAtEnd(11, sizeof(UnkStruct_ov23_0224BA48));
         MI_CpuClear8(v0, sizeof(UnkStruct_ov23_0224BA48));
 

--- a/src/overlay023/ov23_0224DC40.c
+++ b/src/overlay023/ov23_0224DC40.c
@@ -233,7 +233,7 @@ static void ov23_0224DD2C(UnkStruct_ov23_0224E280 *param0)
 
     param0->unk_1C = StringList_New(NELEMS(Unk_ov23_022568B4), 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_0C, 3, 1, 1, 10, NELEMS(Unk_ov23_022568B4) * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (10 * NELEMS(Unk_ov23_022568B4) * 2));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_0C, 3, 1, 1, 10, NELEMS(Unk_ov23_022568B4) * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (10 * NELEMS(Unk_ov23_022568B4) * 2));
     Window_DrawStandardFrame(&param0->unk_0C, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -294,7 +294,7 @@ static void ov23_0224DE3C(UnkStruct_ov23_0224E280 *param0)
 
     param0->unk_1C = StringList_New(4, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_0C, 3, 1, 1, 16, 4 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (16 * 4 * 2));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_0C, 3, 1, 1, 16, 4 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (16 * 4 * 2));
     Window_DrawStandardFrame(&param0->unk_0C, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -382,7 +382,7 @@ static void ov23_0224DFA0(UnkStruct_ov23_0224E280 *param0)
 
     param0->unk_1C = StringList_New(4, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_0C, 3, 1, 1, 16, 4 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (16 * 4 * 2));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_0C, 3, 1, 1, 16, 4 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (16 * 4 * 2));
     Window_DrawStandardFrame(&param0->unk_0C, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -628,7 +628,7 @@ static void ov23_0224E2D8(SysTask *param0, void *param1)
     case 9:
         if (ov23_022539D8()) {
             ov23_02254044(ov23_0224219C());
-            ov23_02253834(v0->fieldSystem->unk_08, CommInfo_TrainerInfo(v0->unk_30), ov23_0224E2D0, v0, 0);
+            ov23_02253834(v0->fieldSystem->bgConfig, CommInfo_TrainerInfo(v0->unk_30), ov23_0224E2D0, v0, 0);
             v0->unk_37 = 10;
         }
         break;
@@ -690,7 +690,7 @@ static void ov23_0224E2D8(SysTask *param0, void *param1)
         break;
     case 19:
         if (ov23_02254238(ov23_0224219C()) == 0) {
-            v0->unk_24 = Menu_MakeYesNoChoice(v0->fieldSystem->unk_08, &Unk_ov23_0225688C, 1024 - (18 + 12) - 9, 11, 4);
+            v0->unk_24 = Menu_MakeYesNoChoice(v0->fieldSystem->bgConfig, &Unk_ov23_0225688C, 1024 - (18 + 12) - 9, 11, 4);
             v0->unk_37 = 20;
 
             if (v0->unk_38 != 8) {
@@ -976,7 +976,7 @@ static void ov23_0224EAA4(UnkStruct_ov23_022577B0 *param0)
 
     param0->unk_18 = StringList_New(v1, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_08, 3, 1, 1, 16, v1 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (16 * v1 * 2));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_08, 3, 1, 1, 16, v1 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (16 * v1 * 2));
     Window_DrawStandardFrame(&param0->unk_08, 1, 1024 - (18 + 12) - 9, 11);
     {
         MessageLoader *v2;
@@ -1100,7 +1100,7 @@ static void ov23_0224EC50(SysTask *param0, void *param1)
     case 6:
         if (ov23_02254238(ov23_0224219C()) == 0) {
             v0->unk_34 = 7;
-            v0->unk_20 = Menu_MakeYesNoChoice(v0->fieldSystem->unk_08, &Unk_ov23_0225688C, 1024 - (18 + 12) - 9, 11, 4);
+            v0->unk_20 = Menu_MakeYesNoChoice(v0->fieldSystem->bgConfig, &Unk_ov23_0225688C, 1024 - (18 + 12) - 9, 11, 4);
         }
         break;
     case 7:
@@ -1120,7 +1120,7 @@ static void ov23_0224EC50(SysTask *param0, void *param1)
     case 10:
         if (ov23_022539D8()) {
             ov23_02254044(ov23_0224219C());
-            ov23_02253834(v0->fieldSystem->unk_08, CommInfo_TrainerInfo(v0->unk_2C), ov23_0224EC48, v0, 0);
+            ov23_02253834(v0->fieldSystem->bgConfig, CommInfo_TrainerInfo(v0->unk_2C), ov23_0224EC48, v0, 0);
             v0->unk_34 = 11;
         }
         break;
@@ -1155,7 +1155,7 @@ static void ov23_0224EC50(SysTask *param0, void *param1)
     case 17:
         if (ov23_02254238(ov23_0224219C()) == 0) {
             v0->unk_34 = 18;
-            v0->unk_20 = Menu_MakeYesNoChoice(v0->fieldSystem->unk_08, &Unk_ov23_0225688C, 1024 - (18 + 12) - 9, 11, 4);
+            v0->unk_20 = Menu_MakeYesNoChoice(v0->fieldSystem->bgConfig, &Unk_ov23_0225688C, 1024 - (18 + 12) - 9, 11, 4);
         }
         break;
     case 18:

--- a/src/overlay023/ov23_0224F294.c
+++ b/src/overlay023/ov23_0224F294.c
@@ -478,7 +478,7 @@ static void ov23_0224F7F4(UnkStruct_ov23_02250CD4 *param0)
     v3 = ov23_0224F7D4(v2);
     param0->unk_40 = StringList_New(NELEMS(Unk_ov23_02256924), 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_10, 3, 20, 1, 11, NELEMS(Unk_ov23_02256924) * 3, 13, (1024 - (18 + 12) - 9 - 11 * 22));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_10, 3, 20, 1, 11, NELEMS(Unk_ov23_02256924) * 3, 13, (1024 - (18 + 12) - 9 - 11 * 22));
     Window_DrawStandardFrame(&param0->unk_10, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -735,7 +735,7 @@ static void ov23_0224FBFC(UnkStruct_ov23_02250CD4 *param0, int param1)
 
     param0->unk_44 = StringList_New(v1, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_20, 3, v5, v3, v4, v1 * 2, 13, (1024 - (18 + 12) - 9 - 11 * 22));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_20, 3, v5, v3, v4, v1 * 2, 13, (1024 - (18 + 12) - 9 - 11 * 22));
     Window_DrawStandardFrame(&param0->unk_20, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -847,7 +847,7 @@ static void ov23_0224FE38(UnkStruct_ov23_02250CD4 *param0, UnkFuncPtr_ov23_02248
 
     param0->unk_40 = StringList_New(v3 + 1, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_10, 3, 19, 3, 12, (6 * 2), 13, ((1024 - (18 + 12) - 9 - 11 * 22) - 12 * (6 * 2)));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_10, 3, 19, 3, 12, (6 * 2), 13, ((1024 - (18 + 12) - 9 - 11 * 22) - 12 * (6 * 2)));
     Window_DrawStandardFrame(&param0->unk_10, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -1038,7 +1038,7 @@ static void ov23_0225021C(UnkStruct_ov23_02250CD4 *param0, UnkFuncPtr_ov23_02248
 
     param0->unk_40 = StringList_New(v4 + 1, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_10, 3, 19, 3, 12, (6 * 2), 13, ((1024 - (18 + 12) - 9 - 11 * 22) - 12 * (6 * 2)));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_10, 3, 19, 3, 12, (6 * 2), 13, ((1024 - (18 + 12) - 9 - 11 * 22) - 12 * (6 * 2)));
     Window_DrawStandardFrame(&param0->unk_10, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -1214,7 +1214,7 @@ static void ov23_022505EC(UnkStruct_ov23_02250CD4 *param0, UnkFuncPtr_ov23_02248
 
     param0->unk_40 = StringList_New(v3 + 1, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_10, 3, 19, 3, 12, (6 * 2), 13, ((1024 - (18 + 12) - 9 - 11 * 22) - 12 * (6 * 2)));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_10, 3, 19, 3, 12, (6 * 2), 13, ((1024 - (18 + 12) - 9 - 11 * 22) - 12 * (6 * 2)));
     Window_DrawStandardFrame(&param0->unk_10, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -1377,7 +1377,7 @@ static void ov23_02250998(SysTask *param0, void *param1)
     UnkStruct_ov23_02250CD4 *v0 = param1;
 
     if (ov23_02254238(ov23_0224219C()) == 0) {
-        v0->unk_5C = Menu_MakeYesNoChoice(v0->fieldSystem->unk_08, &Unk_ov23_022568D8, 1024 - (18 + 12) - 9, 11, 4);
+        v0->unk_5C = Menu_MakeYesNoChoice(v0->fieldSystem->bgConfig, &Unk_ov23_022568D8, 1024 - (18 + 12) - 9, 11, 4);
         v0->unk_2AA = 12;
     }
 }
@@ -1409,7 +1409,7 @@ static void ov23_02250A14(UnkStruct_ov23_02250CD4 *param0)
 {
     ov23_0224FB7C(param0);
     ov23_02253968();
-    ov23_02253834(param0->fieldSystem->unk_08, SaveData_GetTrainerInfo(FieldSystem_SaveData(param0->fieldSystem)), ov23_02250A0C, param0, 1);
+    ov23_02253834(param0->fieldSystem->bgConfig, SaveData_GetTrainerInfo(FieldSystem_SaveData(param0->fieldSystem)), ov23_02250A0C, param0, 1);
     param0->unk_2AA = 10;
 }
 
@@ -1439,7 +1439,7 @@ void ov23_02250A50(UnkFuncPtr_ov23_0224F758 param0, FieldSystem *fieldSystem)
 static void ov23_02250ACC(UnkStruct_ov23_02250CD4 *param0)
 {
     if (ov23_02254238(ov23_022421AC()) == 0) {
-        param0->unk_5C = Menu_MakeYesNoChoice(param0->fieldSystem->unk_08, &Unk_ov23_022568D8, 1024 - (18 + 12) - 9, 11, 4);
+        param0->unk_5C = Menu_MakeYesNoChoice(param0->fieldSystem->bgConfig, &Unk_ov23_022568D8, 1024 - (18 + 12) - 9, 11, 4);
         param0->unk_2AA = 1;
     }
 }
@@ -1615,7 +1615,7 @@ static void ov23_02250D90(UnkStruct_ov23_02250CD4 *param0, UnkFuncPtr_ov23_02248
 
     param0->unk_40 = StringList_New(v3 + 1, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_10, 3, 19, 3, 12, (6 * 2), 13, ((1024 - (18 + 12) - 9 - 11 * 22) - 12 * (6 * 2)));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_10, 3, 19, 3, 12, (6 * 2), 13, ((1024 - (18 + 12) - 9 - 11 * 22) - 12 * (6 * 2)));
     Window_DrawStandardFrame(&param0->unk_10, 1, 1024 - (18 + 12) - 9, 11);
 
     {

--- a/src/overlay023/ov23_0225128C.c
+++ b/src/overlay023/ov23_0225128C.c
@@ -355,7 +355,7 @@ static void ov23_022515D8(UnkStruct_ov23_02250CD4 *param0, int param1, int param
 
     param0->unk_40 = StringList_New(v1, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_10, 3, 17, 3, 14, v1 * 2, 13, 2);
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_10, 3, 17, 3, 14, v1 * 2, 13, 2);
     Window_DrawStandardFrame(&param0->unk_10, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -401,7 +401,7 @@ static void ov23_022516E8(UnkStruct_ov23_02250CD4 *param0, int param1, int param
 
     param0->unk_40 = StringList_New(v1, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_10, 3, 17, 3, 14, v1 * 2, 13, (2 + 14 * 16));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_10, 3, 17, 3, 14, v1 * 2, 13, (2 + 14 * 16));
     Window_DrawStandardFrame(&param0->unk_10, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -702,7 +702,7 @@ static void ov23_02251C04(SysTask *param0, void *param1)
     case 6:
         ov23_0224FB7C(param1);
         ov23_02254044(ov23_022421BC());
-        v0->unk_270 = ov23_02253C64(v0->fieldSystem->unk_08, SaveData_GetTrainerInfo(FieldSystem_SaveData(v0->fieldSystem)), sub_020298B0(FieldSystem_SaveData(v0->fieldSystem)), NULL, NULL);
+        v0->unk_270 = ov23_02253C64(v0->fieldSystem->bgConfig, SaveData_GetTrainerInfo(FieldSystem_SaveData(v0->fieldSystem)), sub_020298B0(FieldSystem_SaveData(v0->fieldSystem)), NULL, NULL);
         v0->unk_2AA = 7;
         break;
     case 7:
@@ -868,7 +868,7 @@ static void ov23_02252038(SysTask *param0, void *param1)
     switch (v0->unk_00) {
     case 0:
         if (ov23_02254238(ov23_0224219C()) == 0) {
-            v0->unk_08 = Menu_MakeYesNoChoice(v0->fieldSystem->unk_08, &Unk_ov23_022569C8, 1024 - (18 + 12) - 9, 11, 4);
+            v0->unk_08 = Menu_MakeYesNoChoice(v0->fieldSystem->bgConfig, &Unk_ov23_022569C8, 1024 - (18 + 12) - 9, 11, 4);
             v0->unk_00 = 1;
         }
         break;

--- a/src/overlay023/ov23_0225128C.c
+++ b/src/overlay023/ov23_0225128C.c
@@ -783,7 +783,7 @@ static void ov23_02251C04(SysTask *param0, void *param1)
         }
         break;
     case 3:
-        if (v0->fieldSystem->unk_10 == NULL) {
+        if (v0->fieldSystem->taskManager == NULL) {
             v2 = Heap_AllocFromHeapAtEnd(11, sizeof(UnkStruct_ov23_02251ACC));
             MI_CpuClear8(v2, sizeof(UnkStruct_ov23_02251ACC));
             v2->unk_00 = 0;

--- a/src/overlay023/ov23_022521F0.c
+++ b/src/overlay023/ov23_022521F0.c
@@ -216,7 +216,7 @@ static void *ov23_022524B8(UnkStruct_ov23_02250CD4 *param0)
 
     param0->unk_40 = StringList_New(v1, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_10, 3, 19, 3, 12, v1 * 2, 13, ((((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - 12 * 6));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_10, 3, 19, 3, 12, v1 * 2, 13, ((((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - 12 * 6));
     Window_DrawStandardFrame(&param0->unk_10, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -398,7 +398,7 @@ static void ov23_02252A18(UnkStruct_ov23_02250CD4 *param0)
     ov23_0224FB7C(param0);
     param0->unk_40 = StringList_New(v1, 4);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_10, 3, 19, 3, 12, v1 * 2, 13, (((((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - 12 * 6) - 12 * 12));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_10, 3, 19, 3, 12, v1 * 2, 13, (((((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - 12 * 6) - 12 * 12));
     Window_DrawStandardFrame(&param0->unk_10, 1, 1024 - (18 + 12) - 9, 11);
 
     {
@@ -546,7 +546,7 @@ void ov23_02252D08(int param0, int param1)
 static void ov23_02252D1C(UnkStruct_ov23_02250CD4 *param0)
 {
     if (!Window_IsInUse(&param0->unk_20)) {
-        Window_Add(param0->fieldSystem->unk_08, &param0->unk_20, 3, 1, 12, 12, 4, 13, 1);
+        Window_Add(param0->fieldSystem->bgConfig, &param0->unk_20, 3, 1, 12, 12, 4, 13, 1);
         Window_DrawStandardFrame(&param0->unk_20, 1, 1024 - (18 + 12) - 9, 11);
     }
 
@@ -556,7 +556,7 @@ static void ov23_02252D1C(UnkStruct_ov23_02250CD4 *param0)
 
 void ov23_02252D74(UnkStruct_ov23_02250CD4 *param0, int param1)
 {
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_30, 3, 1, 1, 7, 4, 13, 51);
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_30, 3, 1, 1, 7, 4, 13, 51);
     Window_DrawStandardFrame(&param0->unk_30, 1, 1024 - (18 + 12) - 9, 11);
 
     Window_FillTilemap(&param0->unk_30, 15);
@@ -850,7 +850,7 @@ static void ov23_02252E70(SysTask *param0, void *param1)
         break;
     case 14:
         if (ov23_02254238(ov23_022421BC()) == 0) {
-            v0->unk_5C = Menu_MakeYesNoChoice(v0->fieldSystem->unk_08, &Unk_ov23_022569D8, 1024 - (18 + 12) - 9, 11, 4);
+            v0->unk_5C = Menu_MakeYesNoChoice(v0->fieldSystem->bgConfig, &Unk_ov23_022569D8, 1024 - (18 + 12) - 9, 11, 4);
             v0->unk_2AA = 15;
         }
         break;

--- a/src/overlay023/ov23_022542CC.c
+++ b/src/overlay023/ov23_022542CC.c
@@ -107,7 +107,7 @@ void ov23_022542D8(UnkStruct_ov23_022542D8 *param0, FieldSystem *fieldSystem, u1
     param0->unk_34 = param3;
     param0->unk_40 = 0;
 
-    LoadStandardWindowGraphics(fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 2, 4);
+    LoadStandardWindowGraphics(fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 2, 4);
 }
 
 void ov23_0225430C(UnkStruct_ov23_022542D8 *param0)
@@ -162,8 +162,8 @@ static void ov23_0225437C(UnkStruct_ov23_022542D8 *param0)
     v1 = 12 * v4 * 2;
     v2 = 7 * (1 * 2);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_04, 3, 19, 3, 12, v4 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (v1));
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_14, 3, 1, 1, 7, (1 * 2), 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (v1 + v2));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_04, 3, 19, 3, 12, v4 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (v1));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_14, 3, 1, 1, 7, (1 * 2), 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (v1 + v2));
 
     Window_DrawStandardFrame(&param0->unk_04, 1, 1024 - (18 + 12) - 9, 11);
     Window_DrawStandardFrame(&param0->unk_14, 1, 1024 - (18 + 12) - 9, 11);
@@ -283,7 +283,7 @@ void ov23_02254594(UnkStruct_ov23_02254594 *param0, FieldSystem *fieldSystem, u1
     param0->unk_38 = param2;
     param0->unk_3C = param3;
 
-    LoadStandardWindowGraphics(fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 2, 4);
+    LoadStandardWindowGraphics(fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 2, 4);
 }
 
 void ov23_022545C4(UnkStruct_ov23_02254594 *param0, const u8 param1, const u8 param2)
@@ -403,8 +403,8 @@ static void ov23_022546E0(UnkStruct_ov23_02254594 *param0)
     v2 = 12 * 7 * 2;
     v3 = 8 * (2 * 2);
 
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_08, 3, 19, 3, 12, v5 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (v2));
-    Window_Add(param0->fieldSystem->unk_08, &param0->unk_18, 3, 1, 1, 8, (2 * 2), 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (v2 + v3));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_08, 3, 19, 3, 12, v5 * 2, 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (v2));
+    Window_Add(param0->fieldSystem->bgConfig, &param0->unk_18, 3, 1, 1, 8, (2 * 2), 13, (((1024 - (18 + 12) - 9 - (32 * 8)) - (18 + 12 + 24)) - (27 * 4)) - (v2 + v3));
     Window_DrawStandardFrame(&param0->unk_08, 1, 1024 - (18 + 12) - 9, 11);
     Window_DrawStandardFrame(&param0->unk_18, 1, 1024 - (18 + 12) - 9, 11);
 

--- a/src/overlay056/ov56_022561C0.c
+++ b/src/overlay056/ov56_022561C0.c
@@ -228,7 +228,7 @@ UnkStruct_ov56_02256468 *ov56_02256410(FieldSystem *fieldSystem)
     v0 = SysTask_GetParam(v1);
 
     v0->fieldSystem = fieldSystem;
-    v0->unk_14 = fieldSystem->unk_08;
+    v0->unk_14 = fieldSystem->bgConfig;
     v0->unk_04 = fieldSystem->unk_80;
     v0->unk_08 = fieldSystem->unk_7C;
     v0->unk_10 = SaveData_GetTrainerInfo(fieldSystem->saveData);

--- a/src/pokeradar.c
+++ b/src/pokeradar.c
@@ -271,7 +271,7 @@ void sub_0206979C(FieldSystem *fieldSystem)
     GrassPatch *patch;
     int patchRing;
 
-    if (!fieldSystem->chain->active || fieldSystem->unk_10 != NULL) {
+    if (!fieldSystem->chain->active || fieldSystem->taskManager != NULL) {
         return;
     }
 

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -2355,7 +2355,7 @@ static BOOL ScrCmd_OpenMessage(ScriptContext *ctx)
     FieldSystem *fieldSystem = ctx->fieldSystem;
     u8 *isMsgBoxOpen = FieldSystem_GetScriptMemberPtr(fieldSystem, SCRIPT_MANAGER_IS_MSG_BOX_OPEN);
 
-    FieldMessage_AddWindow(fieldSystem->unk_08, FieldSystem_GetScriptMemberPtr(fieldSystem, SCRIPT_MANAGER_WINDOW), 3);
+    FieldMessage_AddWindow(fieldSystem->bgConfig, FieldSystem_GetScriptMemberPtr(fieldSystem, SCRIPT_MANAGER_WINDOW), 3);
     FieldMessage_DrawWindow(FieldSystem_GetScriptMemberPtr(fieldSystem, SCRIPT_MANAGER_WINDOW), SaveData_Options(ctx->fieldSystem->saveData));
 
     *isMsgBoxOpen = TRUE;
@@ -2426,17 +2426,17 @@ static BOOL ScriptContext_ScrollBG3(ScriptContext *ctx)
 
     if (*distanceX != 0) {
         if (*directionX == 0) {
-            Bg_SetOffset(fieldSystem->unk_08, 3, 1, *distanceX);
+            Bg_SetOffset(fieldSystem->bgConfig, 3, 1, *distanceX);
         } else {
-            Bg_SetOffset(fieldSystem->unk_08, 3, 2, *distanceX);
+            Bg_SetOffset(fieldSystem->bgConfig, 3, 2, *distanceX);
         }
     }
 
     if (*distanceY != 0) {
         if (*directionY == 0) {
-            Bg_SetOffset(fieldSystem->unk_08, 3, 4, *distanceY);
+            Bg_SetOffset(fieldSystem->bgConfig, 3, 4, *distanceY);
         } else {
-            Bg_SetOffset(fieldSystem->unk_08, 3, 5, *distanceY);
+            Bg_SetOffset(fieldSystem->bgConfig, 3, 5, *distanceY);
         }
     }
 
@@ -2659,9 +2659,9 @@ static BOOL ScrCmd_03E(ScriptContext *ctx)
     Menu **v1 = FieldSystem_GetScriptMemberPtr(fieldSystem, SCRIPT_MANAGER_UI_CONTROL);
     u16 v2 = ScriptContext_ReadHalfWord(ctx);
 
-    LoadStandardWindowGraphics(fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    LoadStandardWindowGraphics(fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
 
-    *v1 = Menu_MakeYesNoChoice(fieldSystem->unk_08, &Unk_020EAB84, 1024 - (18 + 12) - 9, 11, 4);
+    *v1 = Menu_MakeYesNoChoice(fieldSystem->bgConfig, &Unk_020EAB84, 1024 - (18 + 12) - 9, 11, 4);
     ctx->data[0] = v2;
 
     ScriptContext_Pause(ctx, sub_02040824);
@@ -4013,8 +4013,8 @@ static BOOL ScrCmd_208(ScriptContext *ctx)
     u16 v1 = ScriptContext_GetVar(ctx);
     u16 v2 = ScriptContext_GetVar(ctx);
 
-    LoadStandardWindowGraphics(ctx->fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
-    *v0 = DrawPokemonPreview(ctx->fieldSystem->unk_08, 3, 10, 5, 11, 1024 - (18 + 12) - 9, v1, v2, 4);
+    LoadStandardWindowGraphics(ctx->fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    *v0 = DrawPokemonPreview(ctx->fieldSystem->bgConfig, 3, 10, 5, 11, 1024 - (18 + 12) - 9, v1, v2, 4);
     sub_020451B4(ctx->fieldSystem, v1);
 
     return 0;
@@ -4027,9 +4027,9 @@ static BOOL ScrCmd_28C(ScriptContext *ctx)
     u16 v2 = ScriptContext_GetVar(ctx);
 
     v0 = Party_GetPokemonBySlotIndex(Party_GetFromSavedata(ctx->fieldSystem->saveData), v2);
-    LoadStandardWindowGraphics(ctx->fieldSystem->unk_08, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
+    LoadStandardWindowGraphics(ctx->fieldSystem->bgConfig, 3, 1024 - (18 + 12) - 9, 11, 0, 4);
 
-    *v1 = DrawPokemonPreviewFromStruct(ctx->fieldSystem->unk_08, 3, 10, 5, 11, 1024 - (18 + 12) - 9, v0, 4);
+    *v1 = DrawPokemonPreviewFromStruct(ctx->fieldSystem->bgConfig, 3, 10, 5, 11, 1024 - (18 + 12) - 9, v0, 4);
     sub_020451B4(ctx->fieldSystem, Pokemon_GetValue(v0, MON_DATA_SPECIES, NULL));
 
     return 0;

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -3559,7 +3559,7 @@ static BOOL ScrCmd_192(ScriptContext *ctx)
     void **v0;
 
     v0 = FieldSystem_GetScriptMemberPtr(ctx->fieldSystem, 19);
-    *v0 = sub_0203D50C(ctx->fieldSystem->unk_10, 32);
+    *v0 = sub_0203D50C(ctx->fieldSystem->taskManager, 32);
 
     return 1;
 }
@@ -3926,13 +3926,13 @@ BOOL sub_02041D60(ScriptContext *ctx)
 
 static BOOL ScrCmd_0A1(ScriptContext *ctx)
 {
-    FieldTask_StartFieldMap(ctx->fieldSystem->unk_10);
+    FieldTask_StartFieldMap(ctx->fieldSystem->taskManager);
     return 1;
 }
 
 static BOOL ScrCmd_1F8(ScriptContext *ctx)
 {
-    FieldTask_FinishFieldMap(ctx->fieldSystem->unk_10);
+    FieldTask_FinishFieldMap(ctx->fieldSystem->taskManager);
     return 1;
 }
 
@@ -4125,7 +4125,7 @@ static BOOL ScrCmd_0A6(ScriptContext *ctx)
     u16 *v1 = ScriptContext_GetVarPointer(ctx);
     u16 v2 = ScriptContext_GetVar(ctx);
 
-    sub_0203DAC0(ctx->fieldSystem->unk_10, v1, ctx->fieldSystem->saveData, v0, v2);
+    sub_0203DAC0(ctx->fieldSystem->taskManager, v1, ctx->fieldSystem->saveData, v0, v2);
     return 1;
 }
 
@@ -4340,7 +4340,7 @@ static BOOL ScrCmd_0AD(ScriptContext *ctx)
 
 static BOOL ScrCmd_0AE(ScriptContext *ctx)
 {
-    sub_0203DDDC(ctx->fieldSystem->unk_10);
+    sub_0203DDDC(ctx->fieldSystem->taskManager);
     return 1;
 }
 
@@ -4356,7 +4356,7 @@ static BOOL ScrCmd_0AF(ScriptContext *ctx)
 
 static BOOL ScrCmd_0B0(ScriptContext *ctx)
 {
-    sub_02052E58(ctx->fieldSystem->unk_10);
+    sub_02052E58(ctx->fieldSystem->taskManager);
     return 1;
 }
 
@@ -4541,7 +4541,7 @@ static BOOL ScrCmd_243(ScriptContext *ctx)
     u16 *v2 = ScriptContext_GetVarPointer(ctx);
 
     *v2 = 0xffff;
-    sub_0203D80C(ctx->fieldSystem->unk_10, v1, v2, NULL);
+    sub_0203D80C(ctx->fieldSystem->taskManager, v1, v2, NULL);
 
     return 1;
 }
@@ -4556,7 +4556,7 @@ static BOOL ScrCmd_244(ScriptContext *ctx)
     *v2 = 0xffff;
     *v3 = 0xffff;
 
-    sub_0203D80C(ctx->fieldSystem->unk_10, v1, v2, v3);
+    sub_0203D80C(ctx->fieldSystem->taskManager, v1, v2, v3);
     return 1;
 }
 
@@ -4621,14 +4621,14 @@ static BOOL ScrCmd_203(ScriptContext *ctx)
     v3 = ScriptContext_ReadHalfWord(ctx);
     v4 = -1;
 
-    sub_02054800(ctx->fieldSystem->unk_10, v0, v4, v1, v2, v3);
+    sub_02054800(ctx->fieldSystem->taskManager, v0, v4, v1, v2, v3);
 
     return 1;
 }
 
 static BOOL ScrCmd_204(ScriptContext *ctx)
 {
-    sub_02054864(ctx->fieldSystem->unk_10);
+    sub_02054864(ctx->fieldSystem->taskManager);
     return 1;
 }
 
@@ -4927,7 +4927,7 @@ static BOOL ScrCmd_0F6(ScriptContext *ctx)
     v1 = FieldSystem_GetScriptMemberPtr(ctx->fieldSystem, 19);
     v0 = *v1;
 
-    sub_0205167C(ctx->fieldSystem->unk_10, v0->unk_2C, (0x4 | 0x1));
+    sub_0205167C(ctx->fieldSystem->taskManager, v0->unk_2C, (0x4 | 0x1));
     Heap_FreeToHeap(v0);
 
     *v1 = NULL;
@@ -5491,7 +5491,7 @@ static BOOL sub_02043A4C(ScriptContext *ctx)
 
 static BOOL ScrCmd_153(ScriptContext *ctx)
 {
-    sub_02054708(ctx->fieldSystem->unk_10);
+    sub_02054708(ctx->fieldSystem->taskManager);
     return 1;
 }
 
@@ -6972,7 +6972,7 @@ static BOOL ScrCmd_267(ScriptContext *ctx)
 {
     u16 v0 = ScriptContext_GetVar(ctx);
 
-    sub_0203E414(ctx->fieldSystem->unk_10, v0);
+    sub_0203E414(ctx->fieldSystem->taskManager, v0);
     return 1;
 }
 
@@ -7580,9 +7580,9 @@ static BOOL ScrCmd_29F(ScriptContext *ctx)
     u16 v0 = ScriptContext_GetVar(ctx);
 
     if (v0 == 0) {
-        ov6_0223E384(ctx->fieldSystem->unk_10);
+        ov6_0223E384(ctx->fieldSystem->taskManager);
     } else {
-        ov6_0223E4EC(ctx->fieldSystem->unk_10);
+        ov6_0223E4EC(ctx->fieldSystem->taskManager);
     }
 
     return 1;

--- a/src/script_manager.c
+++ b/src/script_manager.c
@@ -52,7 +52,7 @@ void ScriptManager_Set(FieldSystem *fieldSystem, u16 scriptID, MapObject *object
 
 void ScriptManager_SetApproachingTrainer(FieldSystem *fieldSystem, MapObject *object, int sightRange, int direction, int scriptID, int trainerID, int trainerType, int approachNum)
 {
-    ScriptManager *scriptManager = TaskManager_Environment(fieldSystem->unk_10);
+    ScriptManager *scriptManager = TaskManager_Environment(fieldSystem->taskManager);
     ApproachingTrainer *trainer = &scriptManager->trainers[approachNum];
 
     trainer->sightRange = sightRange;
@@ -187,7 +187,7 @@ static void sub_0203EAF4(FieldSystem *fieldSystem, ScriptContext *ctx, u16 scrip
 
     ScriptContext_Start(ctx, ctx->scripts);
     sub_0203F0E4(ctx, offsetID);
-    ScriptContext_SetTaskManager(ctx, fieldSystem->unk_10);
+    ScriptContext_SetTaskManager(ctx, fieldSystem->taskManager);
 }
 
 static u16 ScriptContext_LoadAndOffsetID(FieldSystem *fieldSystem, ScriptContext *ctx, u16 scriptID)
@@ -434,7 +434,7 @@ void *ScriptManager_GetMemberPtr(ScriptManager *scriptManager, u32 member)
 
 void *FieldSystem_GetScriptMemberPtr(FieldSystem *fieldSystem, u32 member)
 {
-    ScriptManager *script = TaskManager_Environment(fieldSystem->unk_10);
+    ScriptManager *script = TaskManager_Environment(fieldSystem->taskManager);
 
     GF_ASSERT(script->magic == SCRIPT_MANAGER_MAGIC_NUMBER);
 
@@ -443,7 +443,7 @@ void *FieldSystem_GetScriptMemberPtr(FieldSystem *fieldSystem, u32 member)
 
 void sub_0203F0C0(FieldSystem *fieldSystem)
 {
-    ScriptManager *scriptManager = TaskManager_Environment(fieldSystem->unk_10);
+    ScriptManager *scriptManager = TaskManager_Environment(fieldSystem->taskManager);
 
     if (sub_0203A9C8(fieldSystem) == 1) {
         scriptManager->function = sub_0203AB00;

--- a/src/unk_0203D1B8.c
+++ b/src/unk_0203D1B8.c
@@ -1663,7 +1663,7 @@ static BOOL sub_0203E4F8(TaskManager *param0)
 void sub_0203E518(TaskManager *param0)
 {
     FieldSystem *fieldSystem = TaskManager_FieldSystem(param0);
-    UnkStruct_ov7_0224BEFC *v1 = ov7_0224BE9C(4, fieldSystem->saveData, fieldSystem->unk_08);
+    UnkStruct_ov7_0224BEFC *v1 = ov7_0224BE9C(4, fieldSystem->saveData, fieldSystem->bgConfig);
 
     FieldTask_Start(param0, sub_0203E4F8, v1);
 }

--- a/src/unk_0203D1B8.c
+++ b/src/unk_0203D1B8.c
@@ -1537,7 +1537,7 @@ void sub_0203E2FC(FieldSystem *fieldSystem)
     v0.unk_08 = SaveData_GetTrainerInfo(fieldSystem->saveData);
     v0.unk_0C = sub_02055428(fieldSystem, fieldSystem->location->mapId);
 
-    sub_020985AC(fieldSystem->unk_10, &v0);
+    sub_020985AC(fieldSystem->taskManager, &v0);
 }
 
 BOOL sub_0203E348(FieldSystem *fieldSystem, UnkStruct_0203E348 *param1)

--- a/src/unk_02046AD4.c
+++ b/src/unk_02046AD4.c
@@ -108,6 +108,6 @@ BOOL ScrCmd_14A(ScriptContext *param0)
 
 BOOL ScrCmd_257(ScriptContext *param0)
 {
-    sub_0203E518(param0->fieldSystem->unk_10);
+    sub_0203E518(param0->fieldSystem->taskManager);
     return 1;
 }

--- a/src/unk_020494DC.c
+++ b/src/unk_020494DC.c
@@ -299,7 +299,7 @@ BOOL ScrCmd_1E2(ScriptContext *param0)
     v0 = ScriptContext_ReadHalfWord(param0);
 
     if (sub_0205E6D8(param0->fieldSystem->saveData) == 1) {
-        sub_0206BD88(param0->fieldSystem->unk_10, v1, v0);
+        sub_0206BD88(param0->fieldSystem->taskManager, v1, v0);
     } else {
         v2->unk_8DA = v0;
         v2->unk_8D5 = v1;

--- a/src/unk_0204F13C.c
+++ b/src/unk_0204F13C.c
@@ -296,7 +296,7 @@ void sub_0204F470(TaskManager *param0, void **param1, u8 param2)
     v1->unk_04 = param2;
     v1->unk_08 = param1;
 
-    FieldTask_Start(fieldSystem->unk_10, sub_0204F4A4, v1);
+    FieldTask_Start(fieldSystem->taskManager, sub_0204F4A4, v1);
     return;
 }
 

--- a/src/unk_0204FAB4.c
+++ b/src/unk_0204FAB4.c
@@ -221,7 +221,7 @@ static void sub_0204FDB4(TaskManager *param0, void **param1, u8 param2)
     v1->unk_04 = param2;
     v1->unk_0C = param1;
 
-    FieldTask_Start(fieldSystem->unk_10, sub_0204FDE8, v1);
+    FieldTask_Start(fieldSystem->taskManager, sub_0204FDE8, v1);
     return;
 }
 

--- a/src/unk_0205003C.c
+++ b/src/unk_0205003C.c
@@ -211,7 +211,7 @@ void sub_020502E0(TaskManager *param0, void **param1, u8 param2)
     v1->unk_04 = param2;
     v1->unk_0C = param1;
 
-    FieldTask_Start(fieldSystem->unk_10, sub_02050314, v1);
+    FieldTask_Start(fieldSystem->taskManager, sub_02050314, v1);
     return;
 }
 

--- a/src/unk_02050568.c
+++ b/src/unk_02050568.c
@@ -45,7 +45,7 @@ void sub_02050568(FieldSystem *fieldSystem)
     UnkStruct_02050568 *v0 = Heap_AllocFromHeapAtEnd(11, sizeof(UnkStruct_02050568));
 
     memset(v0, 0, sizeof(UnkStruct_02050568));
-    FieldTask_Start(fieldSystem->unk_10, sub_020505A0, v0);
+    FieldTask_Start(fieldSystem->taskManager, sub_020505A0, v0);
 }
 
 static BOOL sub_020505A0(TaskManager *taskMan)

--- a/src/unk_020508D4.c
+++ b/src/unk_020508D4.c
@@ -48,10 +48,10 @@ TaskManager *FieldTask_Set(FieldSystem *fieldSystem, FieldTask param1, void *par
 {
     TaskManager *v0;
 
-    GF_ASSERT(fieldSystem->unk_10 == NULL);
+    GF_ASSERT(fieldSystem->taskManager == NULL);
 
     v0 = sub_020508D4(fieldSystem, param1, param2);
-    fieldSystem->unk_10 = v0;
+    fieldSystem->taskManager = v0;
 
     return v0;
 }
@@ -76,30 +76,30 @@ TaskManager *FieldTask_Start(TaskManager *param0, FieldTask param1, void *param2
     v0 = sub_020508D4(param0->fieldSystem, param1, param2);
     v0->unk_00 = param0;
 
-    param0->fieldSystem->unk_10 = v0;
+    param0->fieldSystem->taskManager = v0;
 
     return v0;
 }
 
 BOOL sub_02050958(FieldSystem *fieldSystem)
 {
-    if (fieldSystem->unk_10 == NULL) {
+    if (fieldSystem->taskManager == NULL) {
         return 0;
     }
 
-    while (fieldSystem->unk_10->unk_04(fieldSystem->unk_10) == 1) {
+    while (fieldSystem->taskManager->unk_04(fieldSystem->taskManager) == 1) {
         TaskManager *v0;
 
-        v0 = fieldSystem->unk_10->unk_00;
+        v0 = fieldSystem->taskManager->unk_00;
 
-        if (fieldSystem->unk_10->unk_14) {
-            Heap_FreeToHeap(fieldSystem->unk_10->unk_14);
+        if (fieldSystem->taskManager->unk_14) {
+            Heap_FreeToHeap(fieldSystem->taskManager->unk_14);
         }
 
-        Heap_FreeToHeap(fieldSystem->unk_10->unk_1C);
-        Heap_FreeToHeap(fieldSystem->unk_10);
+        Heap_FreeToHeap(fieldSystem->taskManager->unk_1C);
+        Heap_FreeToHeap(fieldSystem->taskManager);
 
-        fieldSystem->unk_10 = v0;
+        fieldSystem->taskManager = v0;
 
         if (v0 == NULL) {
             return 1;
@@ -111,7 +111,7 @@ BOOL sub_02050958(FieldSystem *fieldSystem)
 
 BOOL sub_020509A4(FieldSystem *fieldSystem)
 {
-    return fieldSystem->unk_10 != NULL;
+    return fieldSystem->taskManager != NULL;
 }
 
 BOOL sub_020509B4(FieldSystem *fieldSystem)

--- a/src/unk_02052C6C.c
+++ b/src/unk_02052C6C.c
@@ -261,10 +261,10 @@ static void sub_02052F28(FieldSystem *fieldSystem, UnkStruct_0205300C *param1)
 
     SetAllGraphicsModes(&v1);
     Bg_MaskPalette(3, 0x0);
-    Bg_InitFromTemplate(fieldSystem->unk_08, 3, &v2, 0);
+    Bg_InitFromTemplate(fieldSystem->bgConfig, 3, &v2, 0);
     Bg_ClearTilesRange(3, 0x20, 0, 32);
-    Bg_FillTilemapRect(fieldSystem->unk_08, 3, 0x0, 0, 0, 32, 32, 17);
-    Bg_CopyTilemapBufferToVRAM(fieldSystem->unk_08, 3);
+    Bg_FillTilemapRect(fieldSystem->bgConfig, 3, 0x0, 0, 0, 32, 32, 17);
+    Bg_CopyTilemapBufferToVRAM(fieldSystem->bgConfig, 3);
 }
 
 static void sub_02052FA8(FieldSystem *fieldSystem, UnkStruct_0205300C *param1)
@@ -273,7 +273,7 @@ static void sub_02052FA8(FieldSystem *fieldSystem, UnkStruct_0205300C *param1)
 
     param1->unk_2C = MessageBank_GetNewStrbufFromNARC(26, 213, 15, 32);
 
-    FieldMessage_AddWindow(fieldSystem->unk_08, &param1->unk_1C, 3);
+    FieldMessage_AddWindow(fieldSystem->bgConfig, &param1->unk_1C, 3);
     FieldMessage_DrawWindow(&param1->unk_1C, v0);
 
     param1->unk_34 = FieldMessage_Print(&param1->unk_1C, param1->unk_2C, v0, 1);
@@ -321,5 +321,5 @@ static void sub_02053098(FieldSystem *fieldSystem, UnkStruct_0205300C *param1)
         Window_Remove(&param1->unk_1C);
     }
 
-    Bg_FreeTilemapBuffer(fieldSystem->unk_08, 3);
+    Bg_FreeTilemapBuffer(fieldSystem->bgConfig, 3);
 }

--- a/src/unk_02055C50.c
+++ b/src/unk_02055C50.c
@@ -474,7 +474,7 @@ void sub_020562AC(FieldSystem *fieldSystem)
     v0->unk_0C = NULL;
     v0->unk_04 = PlayerAvatar_GetDir(fieldSystem->playerAvatar);
 
-    FieldTask_Start(fieldSystem->unk_10, sub_02056124, v0);
+    FieldTask_Start(fieldSystem->taskManager, sub_02056124, v0);
 }
 
 void sub_020562D8(FieldSystem *fieldSystem)

--- a/src/unk_0205A0D8.c
+++ b/src/unk_0205A0D8.c
@@ -655,7 +655,7 @@ static void sub_0205AAA0(UnkStruct_0205A0D8 *param0, BOOL param1)
 void sub_0205AB10(FieldSystem *fieldSystem, UnkFuncPtr_0205AB10 *param1)
 {
     UnkStruct_0205A0D8 *v0;
-    TaskManager *v1 = fieldSystem->unk_10;
+    TaskManager *v1 = fieldSystem->taskManager;
 
     if (v1) {
         return;
@@ -738,7 +738,7 @@ static void sub_0205AC28(UnkStruct_0205A0D8 *param0)
 
 static UnkStruct_0205A0D8 *sub_0205AC74(FieldSystem *fieldSystem)
 {
-    return TaskManager_Environment(fieldSystem->unk_10);
+    return TaskManager_Environment(fieldSystem->taskManager);
 }
 
 static void sub_0205AC80(UnkStruct_0205A0D8 *param0, BOOL param1)

--- a/src/unk_0205A0D8.c
+++ b/src/unk_0205A0D8.c
@@ -620,7 +620,7 @@ static int sub_0205AA50(UnkStruct_0205A0D8 *param0, const Strbuf *param1)
     Window *v0 = &(param0->unk_14);
 
     if (Window_IsInUse(v0) == 0) {
-        FieldMessage_AddWindow(param0->fieldSystem->unk_08, v0, 3);
+        FieldMessage_AddWindow(param0->fieldSystem->bgConfig, v0, 3);
         FieldMessage_DrawWindow(v0, SaveData_Options(param0->fieldSystem->saveData));
     } else {
         sub_0205D988(v0);
@@ -874,8 +874,8 @@ static void sub_0205ADF8(UnkStruct_0205A0D8 *param0, int param1)
         v4 = MessageLoader_Init(1, 26, 412, 4);
         v3 = Pokemon_GetStructSize();
 
-        Window_Add(param0->fieldSystem->unk_08, v0, 3, 21, 9, 10, 8, 13, 10);
-        LoadStandardWindowGraphics(param0->fieldSystem->unk_08, 3, 1, 11, 0, 4);
+        Window_Add(param0->fieldSystem->bgConfig, v0, 3, 21, 9, 10, 8, 13, 10);
+        LoadStandardWindowGraphics(param0->fieldSystem->bgConfig, 3, 1, 11, 0, 4);
         Window_FillTilemap(v0, 15);
 
         for (v1 = 0; v1 < 3; v1++) {
@@ -906,8 +906,8 @@ static void sub_0205AF18(UnkStruct_0205A0D8 *param0, int param1)
     if (Window_IsInUse(v0) == 0) {
         int v1;
 
-        Window_Add(param0->fieldSystem->unk_08, v0, 3, 20, 11, 11, 6, 13, 90);
-        LoadStandardWindowGraphics(param0->fieldSystem->unk_08, 3, 1, 11, 0, 4);
+        Window_Add(param0->fieldSystem->bgConfig, v0, 3, 20, 11, 11, 6, 13, 90);
+        LoadStandardWindowGraphics(param0->fieldSystem->bgConfig, 3, 1, 11, 0, 4);
         Window_FillTilemap(v0, 15);
 
         for (v1 = 0; v1 < 3; v1++) {
@@ -1020,7 +1020,7 @@ static BOOL sub_0205B140(TaskManager *param0)
         MessageLoader_GetStrbuf(v1->unk_1C, 2 + v2->unk_03, v1->unk_00);
         StringTemplate_SetPlayerName(v1->unk_18, 0, CommInfo_TrainerInfo(v1->unk_24));
         StringTemplate_Format(v1->unk_18, v1->unk_04, v1->unk_00);
-        FieldMessage_AddWindow(fieldSystem->unk_08, &v1->unk_08, 3);
+        FieldMessage_AddWindow(fieldSystem->bgConfig, &v1->unk_08, 3);
         FieldMessage_DrawWindow(&v1->unk_08, SaveData_Options(fieldSystem->saveData));
 
         v1->unk_20 = FieldMessage_Print(&v1->unk_08, v1->unk_04, SaveData_Options(fieldSystem->saveData), 1);

--- a/src/unk_0205DFC4.c
+++ b/src/unk_0205DFC4.c
@@ -332,7 +332,7 @@ void sub_0205E318(TaskManager *param0, MapObject *param1, u16 param2, u16 param3
     v1->unk_10 = param3;
     v1->unk_00 = param1;
 
-    FieldTask_Start(fieldSystem->unk_10, sub_0205E268, v1);
+    FieldTask_Start(fieldSystem->taskManager, sub_0205E268, v1);
 }
 
 static BOOL sub_0205E3AC(TaskManager *param0)
@@ -367,7 +367,7 @@ void sub_0205E3F4(TaskManager *param0, MapObject *param1, u16 param2, u16 param3
     v1->unk_00 = param1;
     v1->unk_09 = 0;
 
-    FieldTask_Start(fieldSystem->unk_10, sub_0205E3AC, v1);
+    FieldTask_Start(fieldSystem->taskManager, sub_0205E3AC, v1);
 }
 
 int sub_0205E430(u8 param0, u8 param1)

--- a/src/unk_020683F4.c
+++ b/src/unk_020683F4.c
@@ -950,7 +950,7 @@ static BOOL sub_02068F48(TaskManager *param0)
     switch (v1->unk_16) {
     case 0:
         MapObjectMan_PauseAllMovement(fieldSystem->mapObjMan);
-        FieldMessage_AddWindow(fieldSystem->unk_08, &v1->unk_00, 3);
+        FieldMessage_AddWindow(fieldSystem->bgConfig, &v1->unk_00, 3);
 
         {
             const Options *v2 = SaveData_Options(fieldSystem->saveData);

--- a/src/unk_0206B9D8.c
+++ b/src/unk_0206B9D8.c
@@ -215,7 +215,7 @@ void sub_0206BBFC(TaskManager *param0, void **param1, u8 param2, u8 param3, u8 p
     v1->unk_0D = param7;
     v1->unk_14 = param1;
 
-    FieldTask_Start(fieldSystem->unk_10, sub_0206BB94, v1);
+    FieldTask_Start(fieldSystem->taskManager, sub_0206BB94, v1);
 }
 
 static int sub_0206BC48(UnkStruct_0206BC48 *param0, FieldSystem *fieldSystem)
@@ -280,7 +280,7 @@ void sub_0206BCE4(TaskManager *param0, u16 param1, u16 param2, u16 param3)
     v1->unk_14 = param3;
     v1->unk_10 = param2;
 
-    FieldTask_Start(fieldSystem->unk_10, sub_0206BC94, v1);
+    FieldTask_Start(fieldSystem->taskManager, sub_0206BC94, v1);
 }
 
 static BOOL sub_0206BD1C(TaskManager *param0)
@@ -323,7 +323,7 @@ void sub_0206BD88(TaskManager *param0, u16 param1, u16 param2)
     v1->unk_00 = param1;
     v1->unk_02 = param2;
 
-    FieldTask_Start(fieldSystem->unk_10, sub_0206BD1C, v1);
+    FieldTask_Start(fieldSystem->taskManager, sub_0206BD1C, v1);
 }
 
 u16 sub_0206BDBC(SaveData *param0)

--- a/src/unk_0206C0E8.c
+++ b/src/unk_0206C0E8.c
@@ -47,7 +47,7 @@ void sub_0206C0E8(FieldSystem *fieldSystem)
     v0->unk_0C = 0;
     v0->unk_0D = 0;
 
-    FieldTask_Start(fieldSystem->unk_10, sub_0206C120, v0);
+    FieldTask_Start(fieldSystem->taskManager, sub_0206C120, v0);
 }
 
 static BOOL sub_0206C120(TaskManager *taskMan)

--- a/src/unk_0206C784.c
+++ b/src/unk_0206C784.c
@@ -127,7 +127,7 @@ void sub_0206C784(FieldSystem *fieldSystem, const u8 param1, const u8 param2, co
         v0->unk_00 = 2;
     }
 
-    FieldTask_Start(fieldSystem->unk_10, sub_0206C964, v0);
+    FieldTask_Start(fieldSystem->taskManager, sub_0206C964, v0);
 }
 
 static void sub_0206C8D4(FieldSystem *fieldSystem, const u8 param1, UnkStruct_ov5_021D5894 *param2)
@@ -139,7 +139,7 @@ static void sub_0206C8D4(FieldSystem *fieldSystem, const u8 param1, UnkStruct_ov
     v0->unk_04 = param2;
     v0->unk_00 = param1;
 
-    FieldTask_Start(fieldSystem->unk_10, sub_0206C8F8, v0);
+    FieldTask_Start(fieldSystem->taskManager, sub_0206C8F8, v0);
 }
 
 static BOOL sub_0206C8F8(TaskManager *taskMan)

--- a/src/unk_0206F314.c
+++ b/src/unk_0206F314.c
@@ -200,7 +200,7 @@ static int sub_0206F314(UnkStruct_0206F314 *param0, FieldSystem *fieldSystem, u1
     v0->unk_18 = sub_0202E840(v0->unk_16);
     v0->unk_19 = sub_0202E84C(v0->unk_16);
     v0->fieldSystem = fieldSystem;
-    v0->unk_D0 = fieldSystem->unk_08;
+    v0->unk_D0 = fieldSystem->bgConfig;
     v0->unk_304 = sub_0202E8C0(v1);
     v0->unk_1A = Options_TextFrameDelay(SaveData_Options(v1));
     v0->unk_1C = Options_Frame(SaveData_Options(v1));

--- a/src/unk_0206F314.c
+++ b/src/unk_0206F314.c
@@ -912,5 +912,5 @@ void sub_020703FC(TaskManager *param0, u16 param1)
     v1->unk_04 = param1;
     v1->unk_08 = NULL;
 
-    FieldTask_Start(fieldSystem->unk_10, sub_020702D0, v1);
+    FieldTask_Start(fieldSystem->taskManager, sub_020702D0, v1);
 }

--- a/src/unk_0207160C.c
+++ b/src/unk_0207160C.c
@@ -306,11 +306,11 @@ void sub_0207183C(FieldSystem *fieldSystem)
 
         if (v1->unk_00 == 0) {
             v2->unk_04 = Unk_020F03F4[v1->unk_02].unk_00[1];
-            FieldTask_Start(fieldSystem->unk_10, sub_020718D8, v2);
+            FieldTask_Start(fieldSystem->taskManager, sub_020718D8, v2);
             v1->unk_00 = 1;
         } else {
             v2->unk_04 = Unk_020F03F4[v1->unk_02].unk_00[0];
-            FieldTask_Start(fieldSystem->unk_10, sub_020719D8, v2);
+            FieldTask_Start(fieldSystem->taskManager, sub_020719D8, v2);
             v1->unk_00 = 0;
         }
     }

--- a/src/unk_02071D40.c
+++ b/src/unk_02071D40.c
@@ -282,7 +282,7 @@ void sub_02072204(FieldSystem *fieldSystem)
     v0->unk_00 = 0;
     v0->unk_04 = (TrainerCard *)sub_0205C17C(fieldSystem->unk_7C);
 
-    FieldTask_Start(fieldSystem->unk_10, sub_02072230, v0);
+    FieldTask_Start(fieldSystem->taskManager, sub_02072230, v0);
 }
 
 static BOOL sub_02072230(TaskManager *param0)

--- a/src/unk_020722AC.c
+++ b/src/unk_020722AC.c
@@ -1304,5 +1304,5 @@ void sub_020736D8(TaskManager *param0)
     v1->unk_00 = 0;
     v1->unk_04 = 0;
 
-    FieldTask_Start(fieldSystem->unk_10, sub_02073694, v1);
+    FieldTask_Start(fieldSystem->taskManager, sub_02073694, v1);
 }

--- a/src/unk_0209ACF4.c
+++ b/src/unk_0209ACF4.c
@@ -266,7 +266,7 @@ static void sub_0209B084(UnkStruct_0209AD84 *param0, int param1, BOOL param2)
     }
 
     if (Window_IsInUse(v0) == 0) {
-        FieldMessage_AddWindow(param0->fieldSystem->unk_08, v0, 3);
+        FieldMessage_AddWindow(param0->fieldSystem->bgConfig, v0, 3);
         FieldMessage_DrawWindow(v0, SaveData_Options(param0->fieldSystem->saveData));
     } else {
         sub_0205D988(v0);
@@ -297,8 +297,8 @@ static void sub_0209B12C(UnkStruct_0209AD84 *param0)
     if (Window_IsInUse(v0) == 0) {
         int v1;
 
-        LoadStandardWindowGraphics(param0->fieldSystem->unk_08, 3, 155, 11, 0, 32);
-        Window_Add(param0->fieldSystem->unk_08, v0, 3, 1, 1, 13, 10, 13, 1);
+        LoadStandardWindowGraphics(param0->fieldSystem->bgConfig, 3, 155, 11, 0, 32);
+        Window_Add(param0->fieldSystem->bgConfig, v0, 3, 1, 1, 13, 10, 13, 1);
         Window_FillTilemap(v0, 15);
 
         for (v1 = 0; v1 < 5; v1++) {
@@ -329,8 +329,8 @@ static void sub_0209B1D8(UnkStruct_0209AD84 *param0)
     if (Window_IsInUse(v0) == 0) {
         int v1;
 
-        LoadStandardWindowGraphics(param0->fieldSystem->unk_08, 3, 155, 11, 0, 32);
-        Window_Add(param0->fieldSystem->unk_08, v0, 3, 25, 13, 6, 4, 13, 131);
+        LoadStandardWindowGraphics(param0->fieldSystem->bgConfig, 3, 155, 11, 0, 32);
+        Window_Add(param0->fieldSystem->bgConfig, v0, 3, 25, 13, 6, 4, 13, 131);
         Window_FillTilemap(v0, 15);
 
         for (v1 = 0; v1 < 2; v1++) {


### PR DESCRIPTION
Just renames:
- `FieldSystem` `unk_08` ->`bgConfig`
- `FieldSystem` `unk_10` ->`taskManager`

Giving these struct members actual names since we've identified them now (and mostly it's just bugging me :) ).