### PR TITLE
Move Nitro subproject targets to ntrtwl

### DIFF
--- a/subprojects/NitroDWC.wrap
+++ b/subprojects/NitroDWC.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
-url = https://github.com/Nomura-RH/NitroDWC.git
+url = https://github.com/ntrtwl/NitroDWC.git
 revision = 8220c8bdec2e8b5252ee710cf3cc0c148228a03a
 depth = 1
 directory = NitroDWC-2.2.30008

--- a/subprojects/NitroSDK.wrap
+++ b/subprojects/NitroSDK.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
-url = https://github.com/Nomura-RH/NitroSDK.git
+url = https://github.com/ntrtwl/NitroSDK.git
 revision = 0082ec3dd5e951a7ee7c2067595a4fa0e9496d36
 depth = 1
 directory = NitroSDK-4.2.30001

--- a/subprojects/NitroSystem.wrap
+++ b/subprojects/NitroSystem.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
-url = https://github.com/Nomura-RH/NitroSystem.git
+url = https://github.com/ntrtwl/NitroSystem.git
 revision = 507acff1585505bdac3f996551ca5123f8408073
 depth = 1
 directory = NitroSystem-071126.1

--- a/subprojects/NitroWiFi.wrap
+++ b/subprojects/NitroWiFi.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
-url = https://github.com/Nomura-RH/NitroWiFi.git
-revision = 0d74e5de275952680962237da9d592e80815679a
+url = https://github.com/ntrtwl/NitroWiFi.git
+revision = 8f4f0a60d5ecf6f7d90bfd1f85dce252ee12e692
 depth = 1
 directory = NitroWiFi-2.1.30003
 

--- a/subprojects/libvct.wrap
+++ b/subprojects/libvct.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
-url = https://github.com/Nomura-RH/libvct.git
+url = https://github.com/ntrtwl/libvct.git
 revision = dd9f89d7c0a52e74a3c4b25552ea05cdc127a011
 depth = 1
 directory = libvct-1.3.1


### PR DESCRIPTION
Update to `NitroWiFi` target here is bundling some line-ending normalization that had been missed in the project.