### PR TITLE
Add trdata.naix as a dependency of compiler for scr_seq binaries

### DIFF
--- a/res/field/scripts/meson.build
+++ b/res/field/scripts/meson.build
@@ -1131,6 +1131,17 @@ scr_seq_files = files(
     'scripts_route_230.s',
 )
 
+# Field scripts have a dependency on `trdata.naix`, and so they require a
+# custom generator.
+field_script_gen = generator(make_script_bin_sh,
+    arguments: make_script_bin_args,
+    depends: [
+        make_script_bin_deps,
+        trdata_naix,
+    ],
+    output: '@BASENAME@',
+)
+
 scr_seq_narc_order = files('scripts.order')
 
 scr_seq_narc = custom_target('scr_seq.narc',
@@ -1138,7 +1149,7 @@ scr_seq_narc = custom_target('scr_seq.narc',
         'scr_seq.narc',
         'scr_seq.naix',
     ],
-    input: s_to_bin_gen.process(
+    input: field_script_gen.process(
         scr_seq_files,
         extra_args: ['--out-dir', scr_seq_private_dir]
     ),
@@ -1148,9 +1159,6 @@ scr_seq_narc = custom_target('scr_seq.narc',
         '--order', scr_seq_narc_order,
         '--output', '@OUTPUT0@',
         '@PRIVATE_DIR@',
-    ],
-    depends: [
-        trdata_narc,
     ],
 )
 

--- a/res/meson.build
+++ b/res/meson.build
@@ -1,13 +1,16 @@
 nitrofs_files = []
 naix_headers = []
 
-subdir('pokemon')
-
 ### PREBUILT FILES ###
 subdir('prebuilt')
 
 ### DECOMPILED DATA DIRECTORIES ###
-subdir('text') # must be listed first for GMM header targets
+# These subpaths are listed because the result of some build-rule inside them
+# is a dependency of some later build-rule. e.g., `trdata.naix` is a dependency
+# of the files compiled into `scr_seq.narc`.
+subdir('pokemon')
+subdir('trainers')
+subdir('text')
 
 # Common generator for "scripting" files, i.e. field and battle scripts
 relative_source_root = fs.relative_to(meson.project_source_root(), meson.project_build_root())
@@ -17,23 +20,27 @@ copy_gen = generator(find_program('cp'),
     output: '@PLAINNAME@'
 )
 
+make_script_bin_args = [
+    '-i', relative_source_root / 'include',
+    '-i', relative_source_root / 'asm',
+    '-i', '.' / 'res' / 'text',
+    '-i', '.' / 'res',
+    '-i', '.',
+    '--assembler', arm_none_eabi_gcc_exe.full_path(),
+    '--objcopy', arm_none_eabi_objcopy_exe.full_path(),
+    '@EXTRA_ARGS@',
+    '@INPUT@',
+]
+
+make_script_bin_deps = [
+    message_banks_narc, # for GMM headers
+    asm_consts_generators, # for ASM headers
+    c_consts_generators, # for C headers
+]
+
 s_to_bin_gen = generator(make_script_bin_sh,
-    arguments: [
-        '-i', relative_source_root / 'include',
-        '-i', relative_source_root / 'asm',
-        '-i', '.' / 'res' / 'text',
-        '-i', '.' / 'res',
-        '-i', '.',
-        '--assembler', arm_none_eabi_gcc_exe.full_path(),
-        '--objcopy', arm_none_eabi_objcopy_exe.full_path(),
-        '@EXTRA_ARGS@',
-        '@INPUT@',
-    ],
-    depends: [
-        message_banks_narc, # for GMM headers
-        asm_consts_generators, # for ASM headers
-        c_consts_generators, # for C headers
-    ],
+    arguments: make_script_bin_args,
+    depends: make_script_bin_deps,
     output: '@BASENAME@'
 )
 
@@ -56,13 +63,6 @@ nanr_gen = generator(nitrogfx_exe,
     arguments: [ '@INPUT@', '@OUTPUT@', '@EXTRA_ARGS@', ],
     output: '@BASENAME@.NANR'
 )
-
-lz_gen = generator(nitrogfx_exe,
-    arguments: [ '@INPUT@', '@OUTPUT@', '@EXTRA_ARGS@', ],
-    output: '@PLAINNAME@.lz',
-)
-
-subdir('trainers')
 
 subdir('battle')
 subdir('field')

--- a/res/trainers/meson.build
+++ b/res/trainers/meson.build
@@ -943,7 +943,7 @@ trainer_party_gen = generator(
 
 trainers_order = files('trainers.order')
 
-trdata_narc = custom_target('trdata.narc',
+trdata_target = custom_target('trdata.narc',
     output: [
         'trdata.narc',
         'trdata.naix',
@@ -959,24 +959,22 @@ trdata_narc = custom_target('trdata.narc',
         '@PRIVATE_DIR@',
     ],
 )
+trdata_narc = trdata_target[0]
+trdata_naix = trdata_target[1]
 
+# Do not generate an NAIX for `trpoke.narc`; it would go wholly unused
 trpoke_narc = custom_target('trpoke.narc',
-    output: [
-        'trpoke.narc',
-        'trpoke.naix',
-    ],
+    output: 'trpoke.narc',
     input: trainer_party_gen.process(trainer_data_files, env: json2bin_env),
     depends: [ py_consts_generators ],
     command: [
         narc_exe, 'create',
-        '--naix',
         '--order', trainers_order,
-        '--output', '@OUTPUT0@',
+        '--output', '@OUTPUT@',
         '@PRIVATE_DIR@',
     ]
 )
 
-nitrofs_files += trdata_narc[0]
-nitrofs_files += trpoke_narc[0]
-naix_headers += trdata_narc[1]
-naix_headers += trpoke_narc[1]
+nitrofs_files += trdata_narc
+nitrofs_files += trpoke_narc
+naix_headers += trdata_naix


### PR DESCRIPTION
This hardens the dependency between the compiling generator for binaries packed into `scr_seq.narc` and `trdata.naix` (which is generated during packing for `trdata.narc`).

The bug is apparent in the following snippet of `build.ninja` from a failure archive:

```ninja
build res/field/scripts/scr_seq.narc.p/scripts_route_230: CUSTOM_COMMAND ../../../home/runner/work/pokeplatinum/pokeplatinum/res/field/scripts/scripts_route_230.s | /home/runner/work/pokeplatinum/pokeplatinum/tools/scripts/make_script_bin.sh consts/abilities.h consts/abilities.inc consts/badges.h consts/badges.inc consts/battle.h consts/battle.inc consts/battle_subscripts.h consts/battle_subscripts.inc consts/btlcmd.h consts/btlcmd.inc consts/catching_show.h consts/catching_show.inc consts/game_records.h consts/game_records.inc consts/gender.h consts/gender.inc consts/items.h consts/items.inc consts/journal.h consts/journal.inc consts/map.h consts/map.inc consts/movement.h consts/movement.inc consts/moves.h consts/moves.inc consts/pokemon.h consts/pokemon.inc consts/poketch.h consts/poketch.inc consts/scrcmd.h consts/scrcmd.inc consts/sdat.h consts/sdat.inc consts/shadows.h consts/shadows.inc consts/species.h consts/species.inc consts/tm_learnset.h consts/tm_learnset.inc consts/trainer.h consts/trainer.inc consts/trainer_ai.h consts/trainer_ai.inc res/text/pl_msg.narc
```

This can be read in human terms as `scripts_route_230` being built by a custom command applied to `scripts_route_230.s` with header dependencies against the files thereafter (which means that any change to those files will flag `scripts_route_230` as dirty and in-need of rebuild. Notably missing is `trdata.naix`, which is used by some script files, such as `scripts_pastoria_gym.s`.

Because `ninja` builds files as immediately as it deems that it is able to, this *sometimes* resulted in the compilation generator for these binaries being kickstarted before `trdata.narc` could be packed, which naturally results in a compilation error. The root of the bug is here:

```meson
scr_seq_narc = custom_target('scr_seq.narc',
    output: [
        'scr_seq.narc',
        'scr_seq.naix',
    ],
    input: field_script_gen.process(
        scr_seq_files,
        extra_args: ['--out-dir', scr_seq_private_dir]
    ),
    command: [
        narc_exe, 'create',
        '--naix',
        '--order', scr_seq_narc_order,
        '--output', '@OUTPUT0@',
        '@PRIVATE_DIR@',
    ],
    depends: [
        trdata_narc,
    ],
)
```

This declares a dependency against `trdata.narc` on the packing procedure for `scr_seq.narc`. Notably, this does *not* propagate the dependency into the generators, which are independent. Instead, that dependency must be declared on the generator itself.