### PR TITLE
Update required Meson version to 1.5.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -211,7 +211,7 @@ GNU `coreutils` installed to run the build scripts:
 > convenience.
 >
 > [!IMPORTANT]
-> This project requires `meson` version `1.3.0` or higher. If the version of
+> This project requires `meson` version `1.5.0` or higher. If the version of
 > `meson` provided by your package manager is out of date, then follow
 > [these instructions](https://mesonbuild.com/Getting-meson.html) to get the
 > most recent version.

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('pokeplatinum', ['c', 'cpp', 'nasm'],
     version: '1.0',
-    meson_version: '>=1.3.0',
+    meson_version: '>=1.5.0',
     default_options : [
         'buildtype=plain',
         'warning_level=0'


### PR DESCRIPTION
Changes to the field scripting compiler to depend on `trdata.naix` use a `CustomTargetIndex` in the `generator`'s `depends` kwarg. This support was added in 1.5.0, as per tags on mesonbuild/meson PR #12956.