### PR TITLE
Add FreeBSD compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,13 @@ ifneq (,$(findstring Darwin,$(UNAME_S)))
 NATIVE := native_macos.ini
 CROSS := cross_unix.ini
 else
+ifneq (,$(findstring BSD, $(UNAME_S)))
+NATIVE := native_unix.ini 
+CROSS := cross_unix.ini
+else
 NATIVE := native.ini
 CROSS := cross.ini
+endif
 endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -224,9 +224,6 @@ pokeplatinum_nds = custom_target('pokeplatinum.us.nds',
         nitrofs_files # Make sure this is always listed last
     ],
     command : [
-        'sh', '-c',
-        '"$@" && @INPUT6@ @OUTPUT0@ --secure-crc 0xF8B8 --game-code CPUE',
-        '--',
         makerom_exe,
         '-DTITLE_NAME=POKEMON PL',
         '-DBNR=@INPUT1@',
@@ -235,7 +232,9 @@ pokeplatinum_nds = custom_target('pokeplatinum.us.nds',
         '-DARM7_DEFS=@INPUT5@',
         '@INPUT3@',
         '@OUTPUT0@',
-        '@OUTPUT1@'
+        '@OUTPUT1@',
+        '&&','sh', '-c',
+        '@INPUT6@ @OUTPUT0@ --secure-crc 0xF8B8 --game-code CPUE'
     ],
     build_by_default: true
 )

--- a/res/text/meson.build
+++ b/res/text/meson.build
@@ -723,9 +723,7 @@ gmm_header_dir = custom_target('gmm_header_dir',
     capture: true,
     output: 'gmm_header_dir',
     command: [
-        'sh', '-c', '"$@"',
-        '--',
-        'mkdir', '-p', gmm_header_target
+        'sh', '-c', 'mkdir -p ' + gmm_header_target
     ]
 )
 


### PR DESCRIPTION
Changed 3 files to make the project build on FreeBSD (and possibly the other BSDs, requires gmake).

The meson.build in the project root has the most questionable change that should be improved, since the new second custom_target call outputs the file "junk.txt" that serves no purpose other than the fact that meson does not allow an empty output for the custom_target method. For whatever reason FreeBSD does not like some of the shell commands that are in the meson.build files custom_target methods, requiring some of them to be tweaked a little to build successfully.

The issue is that the wine call with makerom_exe did not work when sandwiched in there so there had to be some separate execution step with the added custom_target running after pokeplatinum_nds for it work. 

The repo with this patch builds fine on my Debian and FreeBSD machines.

I would love any suggestions as to how to improve this very bad solution, I'll test them!  