### PR TITLE
Switch metang to python implementation as temp-fix for native Windows builds

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,64 +1,32 @@
 # Installation Instructions
 
-<!--toc:start-->
-- [Installation Instructions](#installation-instructions)
-  - [0. Preliminaries](#0-preliminaries)
-  - [1. Setting Up Your Development Environment](#1-setting-up-your-development-environment)
-    - [Windows with MSYS2](#windows-with-msys2)
-    - [Windows Subsystem for Linux](#windows-subsystem-for-linux)
-      - [New Installs](#new-installs)
-      - [Existing Installs](#existing-installs)
-      - [Install Build Dependencies](#install-build-dependencies)
-    - [MacOS](#macos)
-    - [Linux](#linux)
-      - [Ubuntu (and other Debian derivatives)](#ubuntu-and-other-debian-derivatives)
-      - [Arch Linux (and derivatives)](#arch-linux-and-derivatives)
-      - [Fedora (and derivatives)](#fedora-and-derivatives)
-    - [Docker](#docker)
-  - [2. Downloading the Repository](#2-downloading-the-repository)
-  - [3. Specifying a Compiler License](#3-specifying-a-compiler-license)
-    - [Windows (including WSL 1)](#windows-including-wsl-1)
-    - [Unix Systems](#unix-systems)
-  - [4. Building the Repository](#4-building-the-repository)
-  - [5. Debugger Support](#5-debugger-support)
-  - [Troubleshooting FAQ](#troubleshooting-faq)
-    - [My Build is Failing After Merging from Main](#my-build-is-failing-after-merging-from-main)
-<!--toc:end-->
-
 This document details the steps necessary to build a copy of Pokémon Platinum
 (EN-US) using this repository.
 
-## 0. Preliminaries
+## Table of Contents
+
+- [1. Setting Up Your Development Environment](#1-setting-up-your-development-environment)
+  - [Windows Subsystem for Linux](#windows-subsystem-for-linux)
+    - [New Installs](#new-installs)
+    - [Existing Installs](#existing-installs)
+    - [Install Build Dependencies](#install-build-dependencies)
+  - [Windows with MSYS2](#windows-with-msys2)
+  - [MacOS](#macos)
+  - [Linux](#linux)
+    - [Ubuntu (and other Debian derivatives)](#ubuntu-and-other-debian-derivatives)
+    - [Arch Linux (and derivatives)](#arch-linux-and-derivatives)
+    - [Fedora (and derivatives)](#fedora-and-derivatives)
+  - [Docker](#docker)
+- [2. Downloading the Repository](#2-downloading-the-repository)
+- [3. Specifying a Compiler License](#3-specifying-a-compiler-license)
+  - [Windows (including WSL 1)](#windows-including-wsl-1)
+  - [Unix Systems](#unix-systems)
+- [4. Building the Repository](#4-building-the-repository)
+- [5. Debugger Support](#5-debugger-support)
+- [Troubleshooting FAQ](#troubleshooting-faq)
+  - [My Build is Failing After Merging from Main](#my-build-is-failing-after-merging-from-main)
 
 ## 1. Setting Up Your Development Environment
-
-### Windows with MSYS2
-
-1. Download the MSYS2 installer from [the official website](https://www.msys2.org/)
-and install it on your system.
-
-2. Once the installation is complete, a terminal should automatically pop up.
-To update your package registry, enter the following command:
-
-    ```bash
-    pacman -Syu
-    ```
-
-    Press 'Y' when prompted to confirm the update. This process may take a few
-minutes. Once completed, the terminal will automatically close.
-
-3. Re-open an MSYS terminal (the pink icon) from your Start Menu, then enter
-the following commands to install necessary build dependencies:
-
-    ```bash
-    echo 'export PATH=${PATH}:/mingw64/bin' >> ~/.bashrc
-    source ~/.bashrc
-    pacman -S git meson gcc flex bison base-devel mingw-w64-x86_64-arm-none-eabi-{binutils,gcc}
-    ```
-
-    Press 'Y' when prompted to confirm the installation.
-
-4. [Download the repository](#2-downloading-the-repository).
 
 ### Windows Subsystem for Linux
 
@@ -175,6 +143,42 @@ with the path reported by `pip` above:
 
 3. [Download the repository](#2-downloading-the-repository).
 
+### Windows with MSYS2
+
+> [!CAUTION]
+> `MSYS2 is known to currently produce a non-matching ROM; proceed at your own
+> risk, and heavily prefer to build using Windows Subsystem for Linux, if at all
+> possible.
+
+If you are unable to run Windows Subsystem for Linux due to performance reasons
+or lacking virtualization requirements, then MSYS2 may be an option for you.
+
+1. Download the MSYS2 installer from [the official website](https://www.msys2.org/)
+and install it on your system.
+
+2. Once the installation is complete, a terminal should automatically pop up.
+To update your package registry, enter the following command:
+
+    ```bash
+    pacman -Syu
+    ```
+
+    Press 'Y' when prompted to confirm the update. This process may take a few
+minutes. Once completed, the terminal will automatically close.
+
+3. Re-open an MSYS terminal (the pink icon) from your Start Menu, then enter
+the following commands to install necessary build dependencies:
+
+    ```bash
+    echo 'export PATH=${PATH}:/mingw64/bin' >> ~/.bashrc
+    source ~/.bashrc
+    pacman -S git meson gcc flex bison base-devel mingw-w64-x86_64-arm-none-eabi-{binutils,gcc}
+    ```
+
+    Press 'Y' when prompted to confirm the installation.
+
+4. [Download the repository](#2-downloading-the-repository).
+
 ### MacOS
 
 1. Apple bundles a number of the requisite utilities into Xcode Command Line Tools;
@@ -209,7 +213,7 @@ GNU `coreutils` installed to run the build scripts:
 > Precise packages to be installed will vary by Linux distribution and
 > package registry. A handful of common distributions are listed below for
 > convenience.
->
+
 > [!IMPORTANT]
 > This project requires `meson` version `1.5.0` or higher. If the version of
 > `meson` provided by your package manager is out of date, then follow
@@ -260,6 +264,11 @@ sudo yum install git flex bison gcc make arm-none-eabi-bintuils-cs arm-none-eabi
 ```
 
 ### Docker
+
+> [!CAUTION]
+> The Docker build method is currently unmaintained and unsupported. Proceed at
+> your own risk, and know that you may not receive much support from repository
+> maintainers.
 
 A `Dockerfile` is provided with the repository should you choose to build the
 project as a container. If you do not have `docker` installed on your machine
@@ -375,3 +384,33 @@ make update
 ```
 
 And then try rebuilding.
+
+### Meson Replies With `ERROR: Unknown compiler(s)`
+
+Example error message:
+
+```
+meson.build:1:0: ERROR: Unknown compiler(s): [['/mnt/c/pokeplatinum/tools/cw/mwrap', 'mwccarm']]
+```
+
+Meson provides some basic logging for its configuration process in
+`build/meson-logs/meson-log.txt`. In that file, you should see some entries that
+begin with `Detecting compiler via: ...`, which will give some insight into the
+root of the error. For example:
+
+```
+Detecting compiler via: `/mnt/c/pokeplatinum/tools/cw/mwrap mwccarm --version` -> 1
+stderr:
+wine: '/home/<USER>/.wine' is a 64-bit installation, it cannot be used with a 32-bit wineserver.
+-----------
+
+meson.build:1:0: ERROR: Unknown compiler(s): [['/mnt/c/pokeplatinum/tools/cw/mwrap', 'mwccarm']]
+```
+
+In this instance, the user has installed 64-bit `wine`. Ensure that you have
+installed 32-bit `wine`, then rebuild _after_ removing the prefix directory
+using the following command:
+
+```
+rm -rf ~/.wine
+```

--- a/generated/meson.build
+++ b/generated/meson.build
@@ -6,6 +6,8 @@
 
 # This must be declared here instead of in tools/meson.build, as some tools depend
 # on metang-generated constants.
+subproject('metang')
+
 metang_exe = find_program('metang', native: true)
 
 enum_generators = {

--- a/subprojects/metang.wrap
+++ b/subprojects/metang.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/lhearachel/metang.git
-revision = main
+revision = python
 depth = 1
 
 [provide]


### PR DESCRIPTION
Some native Windows users have reported seg-faults from `metang` when generating headers; this is a temporary hot-switch to a Python implementation until I have enough the time+means to investigate these errors.