### PR TITLE
Rename `ListMenuTemplate::tmp`

### DIFF
--- a/include/list_menu.h
+++ b/include/list_menu.h
@@ -43,7 +43,7 @@ enum ListMenuAttribute {
     LIST_MENU_FONT_ID,
     LIST_MENU_CURSOR_TYPE,
     LIST_MENU_WINDOW,
-    LIST_MENU_TMP,
+    LIST_MENU_PARENT,
 };
 
 typedef struct ListMenu ListMenu;
@@ -70,7 +70,7 @@ typedef struct ListMenuTemplate {
     u16 pagerMode : 2;
     u16 fontID : 6;
     u16 cursorType : 1;
-    void *tmp;
+    void *parent;
 } ListMenuTemplate;
 
 struct ListMenu {

--- a/src/list_menu.c
+++ b/src/list_menu.c
@@ -290,8 +290,8 @@ u32 ListMenu_GetAttribute(ListMenu *menu, u8 attribute)
         result = (u32)menu->template.window;
         break;
 
-    case LIST_MENU_TMP:
-        result = (u32)menu->template.tmp;
+    case LIST_MENU_PARENT:
+        result = (u32)menu->template.parent;
         break;
 
     default:

--- a/src/overlay005/ov5_021DC018.c
+++ b/src/overlay005/ov5_021DC018.c
@@ -493,7 +493,7 @@ static void ov5_021DC7E4(UnkStruct_ov5_021DC1A4 *param0)
     param0->unk_19C.pagerMode = PAGER_MODE_LEFT_RIGHT_PAD;
     param0->unk_19C.fontID = FONT_SYSTEM;
     param0->unk_19C.cursorType = 0;
-    param0->unk_19C.tmp = (void *)param0;
+    param0->unk_19C.parent = (void *)param0;
 
     return;
 }

--- a/src/overlay005/ov5_021EA874.c
+++ b/src/overlay005/ov5_021EA874.c
@@ -283,7 +283,7 @@ static BOOL ov5_021EAB58(UnkStruct_ov5_021EAE78 *param0)
     v1.choices = param0->unk_00;
     v1.window = &param0->unk_20;
     v1.cursorCallback = ov5_021EAF90;
-    v1.tmp = param0;
+    v1.parent = param0;
 
     param0->unk_04 = ListMenu_New(&v1, 0, 0, 4);
     Window_CopyToVRAM(&param0->unk_20);

--- a/src/overlay005/ov5_021F6454.c
+++ b/src/overlay005/ov5_021F6454.c
@@ -337,7 +337,7 @@ static void ov5_021F68BC(UnkStruct_ov5_021F6704 *param0)
     param0->unk_21C.pagerMode = PAGER_MODE_LEFT_RIGHT_PAD;
     param0->unk_21C.fontID = FONT_SYSTEM;
     param0->unk_21C.cursorType = 0;
-    param0->unk_21C.tmp = (void *)param0;
+    param0->unk_21C.parent = (void *)param0;
 
     return;
 }

--- a/src/overlay005/scrcmd_move_tutor.c
+++ b/src/overlay005/scrcmd_move_tutor.c
@@ -510,12 +510,12 @@ static void MoveTutorManager_InitMenuTemplate(MoveTutorManager *moveTutorManager
     moveTutorManager->menuTemplate.pagerMode = PAGER_MODE_LEFT_RIGHT_PAD;
     moveTutorManager->menuTemplate.fontID = FONT_SYSTEM;
     moveTutorManager->menuTemplate.cursorType = 0;
-    moveTutorManager->menuTemplate.tmp = (void *)moveTutorManager;
+    moveTutorManager->menuTemplate.parent = (void *)moveTutorManager;
 }
 
 static void MoveSelectionMenuCursorCallback(ListMenu *listMenu, u32 index, u8 onInit)
 {
-    MoveTutorManager *moveTutorManager = (MoveTutorManager *)ListMenu_GetAttribute(listMenu, LIST_MENU_TMP);
+    MoveTutorManager *moveTutorManager = (MoveTutorManager *)ListMenu_GetAttribute(listMenu, LIST_MENU_PARENT);
 }
 
 static void SysTaskCallback(SysTask *sysTask, void *_moveTutorManager)

--- a/src/overlay007/ov7_0224B4E8.c
+++ b/src/overlay007/ov7_0224B4E8.c
@@ -149,7 +149,7 @@ static void ov7_0224B5A8(UnkStruct_ov7_0224B4E8 *param0)
     v0.maxDisplay = v3 + 2;
     v0.choices = param0->unk_08;
     v0.window = &param0->unk_34;
-    v0.tmp = param0;
+    v0.parent = param0;
 
     param0->unk_00 = ListMenu_New(&v0, 0, param0->unk_78, 4);
     Window_CopyToVRAM(&param0->unk_34);
@@ -239,7 +239,7 @@ static void ov7_0224B788(UnkStruct_ov7_0224B4E8 *param0)
     v0.maxDisplay = v1;
     v0.choices = param0->unk_0C;
     v0.window = &param0->unk_44;
-    v0.tmp = param0;
+    v0.parent = param0;
 
     param0->unk_04 = ListMenu_New(&v0, 0, param0->unk_7A, 4);
     Window_CopyToVRAM(&param0->unk_44);

--- a/src/overlay007/ov7_0224CD28.c
+++ b/src/overlay007/ov7_0224CD28.c
@@ -642,7 +642,7 @@ static void ov7_0224D6BC(UnkStruct_ov7_0224D008 *param0)
     v2.choices = param0->unk_7C;
     v2.window = &param0->unk_08[0];
     v2.count = param0->unk_294 + 1;
-    v2.tmp = (void *)param0;
+    v2.parent = (void *)param0;
 
     param0->unk_78 = ListMenu_New(&v2, 0, 0, 11);
 }

--- a/src/overlay023/ov23_0224F294.c
+++ b/src/overlay023/ov23_0224F294.c
@@ -755,7 +755,7 @@ static void ov23_0224FBFC(UnkStruct_ov23_02250CD4 *param0, int param1)
     v0.maxDisplay = v1;
     v0.choices = param0->unk_44;
     v0.window = &param0->unk_20;
-    v0.tmp = param0;
+    v0.parent = param0;
 
     param0->unk_50 = ListMenu_New(&v0, 0, 0, 4);
 }
@@ -870,7 +870,7 @@ static void ov23_0224FE38(UnkStruct_ov23_02250CD4 *param0, UnkFuncPtr_ov23_02248
     v2.window = &param0->unk_10;
     v2.cursorCallback = param0->unk_60;
     v2.printCallback = param0->unk_64;
-    v2.tmp = param0;
+    v2.parent = param0;
 
     ov23_02251238(param0, v4, v2.count);
 
@@ -1064,7 +1064,7 @@ static void ov23_0225021C(UnkStruct_ov23_02250CD4 *param0, UnkFuncPtr_ov23_02248
     v3.choices = param0->unk_40;
     v3.window = &param0->unk_10;
     v3.cursorCallback = param0->unk_60;
-    v3.tmp = param0;
+    v3.parent = param0;
 
     ov23_02251238(param0, v5, v3.count);
 
@@ -1236,7 +1236,7 @@ static void ov23_022505EC(UnkStruct_ov23_02250CD4 *param0, UnkFuncPtr_ov23_02248
     v2.choices = param0->unk_40;
     v2.window = &param0->unk_10;
     v2.cursorCallback = param0->unk_60;
-    v2.tmp = param0;
+    v2.parent = param0;
 
     ov23_02251238(param0, v4, v2.count);
 
@@ -1638,7 +1638,7 @@ static void ov23_02250D90(UnkStruct_ov23_02250CD4 *param0, UnkFuncPtr_ov23_02248
     v2.choices = param0->unk_40;
     v2.window = &param0->unk_10;
     v2.cursorCallback = param0->unk_60;
-    v2.tmp = param0;
+    v2.parent = param0;
 
     ov23_02251238(param0, v4, v2.count);
 

--- a/src/overlay023/ov23_0225128C.c
+++ b/src/overlay023/ov23_0225128C.c
@@ -385,7 +385,7 @@ static void ov23_022515D8(UnkStruct_ov23_02250CD4 *param0, int param1, int param
         v0.cursorCallback = param3;
     }
 
-    v0.tmp = param0;
+    v0.parent = param0;
     ov23_02251238(param0, v1, v0.count);
     param0->unk_48 = ListMenu_New(&v0, param0->unk_294, param0->unk_290, 4);
 }
@@ -431,7 +431,7 @@ static void ov23_022516E8(UnkStruct_ov23_02250CD4 *param0, int param1, int param
         v0.cursorCallback = param3;
     }
 
-    v0.tmp = param0;
+    v0.parent = param0;
     ov23_02251238(param0, v1, v0.count);
     param0->unk_48 = ListMenu_New(&v0, param0->unk_294, param0->unk_290, 4);
 }

--- a/src/overlay023/ov23_022521F0.c
+++ b/src/overlay023/ov23_022521F0.c
@@ -431,7 +431,7 @@ static void ov23_02252A18(UnkStruct_ov23_02250CD4 *param0)
     v0.count = v1;
     v0.maxDisplay = v1;
     v0.cursorCallback = ov23_0225265C;
-    v0.tmp = param0;
+    v0.parent = param0;
 
     param0->unk_268 = ov23_02252A04;
     param0->unk_294 = ov23_02243154(13 + param0->unk_2AC);

--- a/src/overlay023/ov23_022542CC.c
+++ b/src/overlay023/ov23_022542CC.c
@@ -478,7 +478,7 @@ static void ov23_022546E0(UnkStruct_ov23_02254594 *param0)
     v1.choices = param0->unk_28;
     v1.window = &param0->unk_08;
     v1.cursorCallback = ov23_022546A0;
-    v1.tmp = v0;
+    v1.parent = v0;
 
     param0->unk_2C = ov23_02248C08(&v1, *(param0->unk_38), *(param0->unk_3C), 4, sub_02028A10, v0, 1);
 

--- a/src/overlay079/ov79_021D183C.c
+++ b/src/overlay079/ov79_021D183C.c
@@ -183,7 +183,7 @@ void ov79_021D196C(UnkStruct_ov79_021D0E1C *param0)
 
     param0->unk_84.window = &(param0->unk_E8[0]);
     param0->unk_84.choices = param0->unk_CC;
-    param0->unk_84.tmp = (void *)param0;
+    param0->unk_84.parent = (void *)param0;
     param0->unk_84.count = param0->unk_1C;
     param0->unk_16 = 0;
     param0->unk_C4 = ListMenu_New(&param0->unk_84, param0->unk_80, param0->unk_82, param0->unk_00);
@@ -377,7 +377,7 @@ void ov79_021D1ED8(UnkStruct_ov79_021D0E1C *param0)
 
     param0->unk_A4.window = &(param0->unk_E8[3]);
     param0->unk_A4.choices = param0->unk_D0;
-    param0->unk_A4.tmp = (void *)param0;
+    param0->unk_A4.parent = (void *)param0;
     param0->unk_A4.count = 3;
 
     Window_DrawStandardFrame(&param0->unk_E8[3], 1, 1 + 18 + 12, 15);

--- a/src/overlay084/ov84_0223B5A0.c
+++ b/src/overlay084/ov84_0223B5A0.c
@@ -1072,7 +1072,7 @@ static void ov84_0223C224(UnkStruct_ov84_0223B5A0 *param0, u16 param1, u16 param
     v0.choices = param0->unk_160;
     v0.window = &param0->unk_04[0];
     v0.count = param0->unk_C4->unk_04[param0->unk_C4->unk_64].unk_09;
-    v0.tmp = (void *)param0;
+    v0.parent = (void *)param0;
 
     if ((param0->unk_C4->unk_04[param0->unk_C4->unk_64].unk_08 == 3) || (param0->unk_C4->unk_04[param0->unk_C4->unk_64].unk_08 == 4)) {
         v0.textXOffset = (32 + 3);

--- a/src/overlay091/ov91_021D0D80.c
+++ b/src/overlay091/ov91_021D0D80.c
@@ -926,7 +926,7 @@ static void ov91_021D1784(UnkStruct_ov91_021D0ED8 *param0)
     v1.choices = param0->unk_108;
     v1.window = &param0->unk_08[13];
     v1.count = param0->unk_184;
-    v1.tmp = (void *)param0;
+    v1.parent = (void *)param0;
 
     param0->unk_104 = ListMenu_New(&v1, param0->unk_00->unk_12, param0->unk_00->unk_10, 67);
 

--- a/src/overlay104/ov104_02231F74.c
+++ b/src/overlay104/ov104_02231F74.c
@@ -591,7 +591,7 @@ static void ov104_02232830(UnkStruct_ov104_02232B5C *param0)
     param0->unk_194.fontID = FONT_SYSTEM;
     param0->unk_194.cursorType = 0;
 
-    param0->unk_194.tmp = (void *)param0;
+    param0->unk_194.parent = (void *)param0;
     return;
 }
 

--- a/src/overlay107/ov107_02241AE0.c
+++ b/src/overlay107/ov107_02241AE0.c
@@ -1813,7 +1813,7 @@ static u8 ov107_022437CC (UnkStruct_ov107_02241D6C * param0, Window * param1, in
     Window_FillTilemap(param1, param8);
     MessageLoader_GetStrbuf(param0->unk_20, param2, param0->unk_2C);
     StringTemplate_Format(param0->unk_24, param0->unk_28, param0->unk_2C);
-    
+
     switch (param10) {
     case 1:
         param3 -= (Font_CalcStrbufWidth(FONT_SYSTEM, param0->unk_28, 0) + 1) / 2;
@@ -1839,7 +1839,7 @@ static u8 ov107_02243890 (UnkStruct_ov107_02241D6C * param0, Window * param1, in
     u8 v0;
     MessageLoader_GetStrbuf(param0->unk_20, param2, param0->unk_2C);
     StringTemplate_Format(param0->unk_24, param0->unk_28, param0->unk_2C);
-    
+
     switch (param10) {
     case 1:
         param3 -= (Font_CalcStrbufWidth(FONT_SYSTEM, param0->unk_28, 0) + 1) / 2;
@@ -2479,7 +2479,7 @@ static void ov107_02244240 (UnkStruct_ov107_02241D6C * param0, u8 param1)
     param0->unk_1A0 = Unk_ov107_02249EE4;
     param0->unk_1A0.choices = param0->unk_19C;
     param0->unk_1A0.window = &param0->unk_50[5];
-    param0->unk_1A0.tmp = param0;
+    param0->unk_1A0.parent = param0;
     param0->unk_1A0.cursorCallback = ov107_0224440C;
     param0->unk_1A0.printCallback = ov107_02244560;
     param0->unk_1A0.count = (v1 + 1);
@@ -2573,7 +2573,7 @@ static void ov107_022445C4 (UnkStruct_ov107_02241D6C * param0)
     param0->unk_1A0 = Unk_ov107_02249EE4;
     param0->unk_1A0.choices = param0->unk_19C;
     param0->unk_1A0.window = &param0->unk_50[10];
-    param0->unk_1A0.tmp = param0;
+    param0->unk_1A0.parent = param0;
     param0->unk_1A0.cursorCallback = ov107_02244690;
     param0->unk_1A0.printCallback = ov107_02244708;
     param0->unk_1A0.count = (NELEMS(Unk_ov107_02249FF0));
@@ -2681,7 +2681,7 @@ static void ov107_02244780 (UnkStruct_ov107_02241D6C * param0)
     param0->unk_1A0 = Unk_ov107_02249EE4;
     param0->unk_1A0.choices = param0->unk_19C;
     param0->unk_1A0.window = &param0->unk_50[11];
-    param0->unk_1A0.tmp = param0;
+    param0->unk_1A0.parent = param0;
     param0->unk_1A0.cursorCallback = ov107_0224486C;
     param0->unk_1A0.printCallback = ov107_022448E8;
     param0->unk_1A0.count = (NELEMS(Unk_ov107_02249F54));
@@ -2797,13 +2797,13 @@ static void ov107_02244944 (UnkStruct_ov107_02241D6C * param0)
     param0->unk_1A0 = Unk_ov107_02249EE4;
     param0->unk_1A0.choices = param0->unk_19C;
     param0->unk_1A0.window = &param0->unk_50[9];
-    param0->unk_1A0.tmp = param0;
+    param0->unk_1A0.parent = param0;
     param0->unk_1A0.cursorCallback = ov107_02244A1C;
     param0->unk_1A0.printCallback = NULL;
     param0->unk_1A0.count = 5;
     param0->unk_1A0.maxDisplay = 5;
     param0->unk_1A0.textColorBg = 15;
-    param0->unk_1A0.tmp = param0;
+    param0->unk_1A0.parent = param0;
     param0->unk_198 = ListMenu_New(&param0->unk_1A0, param0->unk_18, param0->unk_1A, 100);
 
     ov107_02245650(param0, &param0->unk_50[9]);

--- a/src/overlay107/ov107_02245EB0.c
+++ b/src/overlay107/ov107_02245EB0.c
@@ -1472,7 +1472,7 @@ static u8 ov107_02247680 (UnkStruct_ov107_02246170 * param0, Window * param1, in
     Window_FillTilemap(param1, param8);
     MessageLoader_GetStrbuf(param0->unk_20, param2, param0->unk_2C);
     StringTemplate_Format(param0->unk_24, param0->unk_28, param0->unk_2C);
-    
+
     switch (param10) {
     case 1:
         param3 -= (Font_CalcStrbufWidth(FONT_SYSTEM, param0->unk_28, 0) + 1) / 2;
@@ -1498,7 +1498,7 @@ static u8 ov107_02247744 (UnkStruct_ov107_02246170 * param0, Window * param1, in
     u8 v0;
     MessageLoader_GetStrbuf(param0->unk_20, param2, param0->unk_2C);
     StringTemplate_Format(param0->unk_24, param0->unk_28, param0->unk_2C);
-    
+
     switch (param10) {
     case 1:
         param3 -= (Font_CalcStrbufWidth(FONT_SYSTEM, param0->unk_28, 0) + 1) / 2;
@@ -1975,7 +1975,7 @@ static void ov107_02247E5C (UnkStruct_ov107_02246170 * param0)
 
     v1.choices = param0->unk_13C;
     v1.window = &param0->unk_50[5];
-    v1.tmp = param0;
+    v1.parent = param0;
     v1.cursorCallback = ov107_02247F14;
     v1.printCallback = NULL;
     v1.count = (NELEMS(Unk_ov107_0224A1BC));
@@ -2037,7 +2037,7 @@ static void ov107_02247F6C (UnkStruct_ov107_02246170 * param0)
 
     v1.choices = param0->unk_13C;
     v1.window = &param0->unk_50[6];
-    v1.tmp = param0;
+    v1.parent = param0;
     v1.cursorCallback = ov107_02248028;
     v1.printCallback = ov107_022480A0;
     v1.count = (NELEMS(Unk_ov107_0224A19C));

--- a/src/unk_0206F314.c
+++ b/src/unk_0206F314.c
@@ -694,7 +694,7 @@ static void sub_0206FDC0(UnkStruct_0206F7F8 *param0, u16 param1, u16 param2)
 
     param0->unk_A0.window = &(param0->unk_D4);
     param0->unk_A0.choices = param0->unk_C4;
-    param0->unk_A0.tmp = (void *)param0;
+    param0->unk_A0.parent = (void *)param0;
     param0->unk_A0.count = v1;
     param0->unk_A0.yOffset = 0;
     param0->unk_A0.cursorCallback = sub_0206FF60;

--- a/src/unk_020722AC.c
+++ b/src/unk_020722AC.c
@@ -702,7 +702,7 @@ static void sub_020729B4(UnkStruct_02072334 *param0)
 
     param0->unk_140.window = &(param0->unk_174);
     param0->unk_140.choices = param0->unk_164;
-    param0->unk_140.tmp = (void *)param0;
+    param0->unk_140.parent = (void *)param0;
     param0->unk_140.count = v1;
     param0->unk_140.yOffset = 6;
     param0->unk_140.cursorCallback = sub_02072C0C;
@@ -799,7 +799,7 @@ static void sub_02072C98(UnkStruct_02072334 *param0, u8 param1, u8 param2)
 
     param0->unk_140.window = &(param0->unk_174);
     param0->unk_140.choices = param0->unk_164;
-    param0->unk_140.tmp = (void *)param0;
+    param0->unk_140.parent = (void *)param0;
     param0->unk_140.count = v1;
     param0->unk_140.maxDisplay = 4;
     param0->unk_140.pagerMode = PAGER_MODE_NONE;


### PR DESCRIPTION
A common pattern in the codebase is to have some struct `Foo` managing some state including (at least) one `ListMenu`, ie:
```C
struct Foo {
    ...
    ListMenuTemplate *template,
    ListMenu *menu,
    ...
```

Sometimes, there's a need to access the instance managing a `ListMenu` in the menu's callbacks. To do this, a pointer to that `struct Foo` instance is stored (as a `void *`) in `template.tmp`, which can then be retrieved with `ListMenu_GetAttribute(menu, LIST_MENU_TMP)` (`ListMenu_GetAttribute(menu, 19)` where the literal hasn't been replaced yet).

I therefore propose to rename `ListMenuTemplate::tmp` to `ListMenuTemplate::parent`, and rename `LIST_MENU_TMP` to `LIST_MENU_PARENT` accordingly.