### PR TITLE
Use a flag to forbid using ScriptEntry after ScriptEntryEnd

### DIFF
--- a/asm/macros/scrcmd.inc
+++ b/asm/macros/scrcmd.inc
@@ -4688,10 +4688,22 @@
     CallIf 1, \offset
     .endm
 
+    /*
+     * This flag is used by ScriptEntry and ScriptEntryEnd to control where
+     * a user can add ScriptEntry commands (i.e., only at the start of the
+     * input file). It is NOT meant for direct usage.
+     */
+    .set F_ACCEPT_SCRIPT_ENTRIES, TRUE
+
     .macro ScriptEntry name
-    .long \name-.-4
+    .if F_ACCEPT_SCRIPT_ENTRIES == TRUE
+        .long \name-.-4
+    .else
+        .error "cannot specify ScriptEntry after ScriptEntryEnd"
+    .endif
     .endm
 
     .macro ScriptEntryEnd
+    .set F_ACCEPT_SCRIPT_ENTRIES, FALSE
     .short 0xFD13
     .endm

--- a/tools/scripts/make_script_bin.sh
+++ b/tools/scripts/make_script_bin.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 help() {
     echo "Syntax: ./make_script_bin.sh [OPTIONS] FILE..."
     echo "options:"


### PR DESCRIPTION
This is a pretty simple change that alleviates a potential foot-gun scenario where a user could compile a field script that contained a `ScriptEntry` directive after terminating the entry-points table with `ScriptEntryEnd`. Such a field script previously would assemble totally fine and be perfectly usable in-game, but would result in entry-points within that file that cannot actually be used.

There is still a bit of a foot-gun scenario here where a user could totally just set this flag back to `TRUE` and add another entry anyways, but I feel that the documentation is appropriate enough to warn against them doing that.

## Test Cases

### Add a new `ScriptEntry` to a file before `ScriptEntryEnd`

```diff
diff --git a/res/field/scripts/scripts_pokemon_center_daily_trainers.s b/res/field/scripts/scripts_pokemon_center_daily_trainers.s
index 7a33e5227..f7aa43662 100644
--- a/res/field/scripts/scripts_pokemon_center_daily_trainers.s
+++ b/res/field/scripts/scripts_pokemon_center_daily_trainers.s
@@ -24,6 +24,7 @@
     ScriptEntry PokemonCenterDailyTrainers_CheckUnlockedVSSeeker
     ScriptEntry PokemonCenterDailyTrainers_FirstNPC
     ScriptEntry PokemonCenterDailyTrainers_SecondNPC
+    ScriptEntry PokemonCenterDailyTrainers_SecondNPC
     ScriptEntryEnd
 
 PokemonCenterDailyTrainers_CheckUnlockedVSSeeker:
```

```console
$ make rom
ninja -C build data
ninja: Entering directory `build'
[100% 2/2] Generating res/field/scripts/scr_seq.narc with a custom command
ninja -C build pokeplatinum.us.nds
ninja: Entering directory `build'
[100% 4/4] Generating pokeplatinum.us.nds with a custom command
```

### Add a new `ScriptEntry` to a file after `ScriptEntryEnd

```diff
diff --git a/res/field/scripts/scripts_pokemon_center_daily_trainers.s b/res/field/scripts/scripts_pokemon_center_daily_trainers.s
index 7a33e5227..19072747c 100644
--- a/res/field/scripts/scripts_pokemon_center_daily_trainers.s
+++ b/res/field/scripts/scripts_pokemon_center_daily_trainers.s
@@ -26,6 +26,8 @@
     ScriptEntry PokemonCenterDailyTrainers_SecondNPC
     ScriptEntryEnd
 
+    ScriptEntry PokemonCenterDailyTrainers_SecondNPC
+
 PokemonCenterDailyTrainers_CheckUnlockedVSSeeker:
     SetFlag 0x183
     SetFlag 0x184
```

```console
$ make rom
ninja -C build data
ninja: Entering directory `build'
[ 50% 1/2] Generating 'res/field/scripts/....p/scripts_pokemon_center_daily_trainers'
FAILED: res/field/scripts/scr_seq.narc.p/scripts_pokemon_center_daily_trainers
/Users/rachel/code/github.com/lhearachel/pokeplatinum/tools/scripts/make_script_bin.sh -i ../include -i ../asm -i ./res/text -i ./res -i . --depfile --assembler /opt/homebrew/bin/arm-none-eabi-gcc --objcopy /opt/homebrew/bin/arm-none-eabi-objcopy --depfile --out-dir res/field/scripts/scr_seq.narc.p ../res/field/scripts/scripts_pokemon_center_daily_trainers.s
../res/field/scripts/scripts_pokemon_center_daily_trainers.s: Assembler messages:
../res/field/scripts/scripts_pokemon_center_daily_trainers.s:4702: Error: cannot specify ScriptEntry after ScriptEntryEnd
../res/field/scripts/scripts_pokemon_center_daily_trainers.s:29:  Info: macro invoked from here
ninja: build stopped: subcommand failed.
make: *** [data] Error 1
```