### PR TITLE
Mystery Gifts cleanup

### DIFF
--- a/include/mystery_gift.h
+++ b/include/mystery_gift.h
@@ -10,6 +10,14 @@
 
 #include "savedata.h"
 
+#define WONDERCARD_TITLE_LENGTH       36
+#define WONDERCARD_DESCRIPTION_LENGTH 250
+#define NUM_WONDERCARD_SPRITES        3
+
+#define WONDERCARD_ID_MAX    2048
+#define NUM_PGT_SLOTS        8
+#define NUM_WONDERCARD_SLOTS 3
+
 typedef struct MysteryGiftPokemonData {
     BOOL hasCustomOT;
     Pokemon pokemon;
@@ -50,15 +58,15 @@ typedef struct PGT {
 } PGT;
 
 typedef struct WonderCardMetadata {
-    u16 title[36];
+    u16 title[WONDERCARD_TITLE_LENGTH];
     u32 validGames; //!< A bit field of the games the WonderCard can be received on.
     u16 id;
     u8 unique : 1;
     u8 unk_4E_1 : 1;
     u8 saveWonderCard : 1; //!< If FALSE, savePgt is ignored and treated as TRUE.
     u8 savePgt : 1;
-    u8 redistributable : 1;
-    u8 isRedistribution : 1; //!< Whether or not the wonder card was obtained from another player redistributing it
+    u8 shareable : 1;
+    u8 fromSharing : 1; //!< Whether or not the wonder card was obtained from another player sharing it
     u8 : 2;
     u8 padding_4F;
 } WonderCardMetadata;
@@ -66,16 +74,16 @@ typedef struct WonderCardMetadata {
 typedef struct WonderCard {
     PGT pgt;
     WonderCardMetadata metadata;
-    u16 description[250];
+    u16 description[WONDERCARD_DESCRIPTION_LENGTH];
     u8 redistributionsLeft;
     u8 padding_349;
-    u16 spritesSpecies[3];
+    u16 spritesSpecies[NUM_WONDERCARD_SPRITES];
     u8 redistributionCount;
     u8 padding_351[3];
     s32 receivedDate;
 } WonderCard;
 
-enum MYSTERY_GIFT_TYPE {
+enum MysteryGiftType {
     MYST_GIFT_NONE = 0,
     MYST_GIFT_POKEMON,
     MYST_GIFT_EGG,
@@ -92,10 +100,6 @@ enum MYSTERY_GIFT_TYPE {
     MYST_GIFT_UNKNOWN,
     MYST_GIFT_TYPE_MAX = 14,
 };
-
-#define WONDERCARD_ID_MAX    2048
-#define NUM_PGT_SLOTS        8
-#define NUM_WONDERCARD_SLOTS 3
 
 typedef struct MysteryGift {
     u8 received[WONDERCARD_ID_MAX / 8];

--- a/src/overlay097/ov97_0222C174.c
+++ b/src/overlay097/ov97_0222C174.c
@@ -806,7 +806,7 @@ static void ov97_0222C974(UnkStruct_ov97_0222C388 *param0)
     v4->metadata.unk_4E_1 = 0;
     v4->metadata.saveWonderCard = 1;
     v4->metadata.savePgt = 1;
-    v4->metadata.isRedistribution = 0;
+    v4->metadata.fromSharing = 0;
 
     v1 = MessageUtil_ExpandedStrbuf(v2, v3, 75, param0->heapID);
 

--- a/src/overlay097/ov97_0222D30C.c
+++ b/src/overlay097/ov97_0222D30C.c
@@ -433,7 +433,7 @@ static void ov97_0222D658(OverlayManager *param0)
         v0 = 1;
         v4->redistributionCount = 0;
 
-        if (v3->redistributable == 0) {
+        if (v3->shareable == 0) {
             v4->redistributionsLeft = 0;
         }
 

--- a/src/overlay097/ov97_02230410.c
+++ b/src/overlay097/ov97_02230410.c
@@ -1262,8 +1262,8 @@ static int ov97_02231BD8(UnkStruct_ov97_02230868 *param0)
     memcpy(&param0->unk_04.unk_8C.unk_00, &v0->metadata, sizeof(WonderCardMetadata));
 
     param0->unk_04.unk_8C.unk_50.redistributionsLeft = 0;
-    param0->unk_04.unk_8C.unk_00.redistributable = 0;
-    param0->unk_04.unk_8C.unk_00.isRedistribution = 1;
+    param0->unk_04.unk_8C.unk_00.shareable = 0;
+    param0->unk_04.unk_8C.unk_00.fromSharing = 1;
 
     ov97_0222D1C4(&param0->unk_04, param0->unk_2C04, 15);
 

--- a/src/overlay097/ov97_02232054.c
+++ b/src/overlay097/ov97_02232054.c
@@ -167,7 +167,7 @@ int ov97_02232148(SaveData *param0, UnkStruct_ov97_0223829C *param1)
         return 3;
     }
 
-    if (param1->unk_00.isRedistribution == 1) {
+    if (param1->unk_00.fromSharing == 1) {
         return 5;
     }
 

--- a/src/scrcmd_mystery_gift.c
+++ b/src/scrcmd_mystery_gift.c
@@ -733,18 +733,19 @@ static void PrepCannotReceivePoketchAppMsg(MystGiftGiveMsgFormatter *formatter, 
     StringTemplate_SetPlayerName(formatter->stringTemplate, 0, SaveData_GetTrainerInfo(formatter->fieldSystem->saveData));
 }
 
-static const GiftHandler giftHandlers[] = {
-    { CanReceivePokemon, GivePokemon, PrepReceivedPokemonMsg, PrepCannotReceivePokemonMsg }, // Pokemon
-    { CanReceivePokemon, GiveEgg, PrepReceivedEggMsg, PrepCannotReceivePokemonMsg }, // Egg
-    { CanReceiveItem, GiveItem, PrepReceivedItemMsg, PrepCannotReceiveItemMsg }, // Item
-    { CanReceiveBattleReg, GiveBattleReg, PrepReceivedRulesMsg, PrepCannotReceiveRulesMsg }, // Battle regulation
-    { CanReceiveDecorationGood, GiveDecorationGood, PrepReceivedDecoGoodMsg, PrepCannotReceiveDecoGood }, // Underground decoration good
-    { CanReceiveCosmetic, GiveCosmetic, PrepReceivedCosmeticMsg, PrepCannotReceiveCosmeticMsg }, // Seal/Accessory/Backdrop
-    { CanReceivePokemon, GenerateManaphyEgg, PrepReceivedManaphyEggMsg, PrepCannotReceivePokemonMsg }, // Manaphy egg
-    { CanReceiveMemberCard, InitDarkraiEvent, PrepReceivedMemberCardMsg, PrepCannotReceiveMemberCardMsg }, // Member card
-    { CanReceiveOaksLetter, InitShayminEvent, PrepReceivedOaksLetterMsg, PrepCannotReceivedOaksLetterMsg }, // Oak's letter
-    { CanReceiveAzureFlute, InitArceusEvent, PrepReceivedAzureFluteMsg, PrepCannotReceiveAzureFluteMsg }, // Azure flute
-    { CanReceivePoketchApp, GivePoketchApp, PrepReceivedPoketchAppMsg, PrepCannotReceivePoketchAppMsg }, // Poketch app
-    { CanReceiveSecretKey, InitRotomEvent, PrepReceivedSecretKeyMsg, PrepCannotReceiveSecretKeyMsg }, // Secret key
-    { CanReceivePokemon, GivePokemon, PrepReceivedPokemonMsg, PrepCannotReceivePokemonMsg } // Same as Pokemon, likely unused
+// Mystery Gift type 0 has no handler because it signals an empty Wonder Card/PGT slot
+static const GiftHandler giftHandlers[MYST_GIFT_TYPE_MAX - 1] = {
+    [MYST_GIFT_POKEMON - 1] = { CanReceivePokemon, GivePokemon, PrepReceivedPokemonMsg, PrepCannotReceivePokemonMsg },
+    [MYST_GIFT_EGG - 1] = { CanReceivePokemon, GiveEgg, PrepReceivedEggMsg, PrepCannotReceivePokemonMsg },
+    [MYST_GIFT_ITEM - 1] = { CanReceiveItem, GiveItem, PrepReceivedItemMsg, PrepCannotReceiveItemMsg },
+    [MYST_GIFT_BATTLE_REG - 1] = { CanReceiveBattleReg, GiveBattleReg, PrepReceivedRulesMsg, PrepCannotReceiveRulesMsg },
+    [MYST_GIFT_DECORATION_GOOD - 1] = { CanReceiveDecorationGood, GiveDecorationGood, PrepReceivedDecoGoodMsg, PrepCannotReceiveDecoGood },
+    [MYST_GIFT_COSMETICS - 1] = { CanReceiveCosmetic, GiveCosmetic, PrepReceivedCosmeticMsg, PrepCannotReceiveCosmeticMsg }, // Seal/Accessory/Backdrop
+    [MYST_GIFT_MANAPHY_EGG - 1] = { CanReceivePokemon, GenerateManaphyEgg, PrepReceivedManaphyEggMsg, PrepCannotReceivePokemonMsg },
+    [MYST_GIFT_MEMBER_CARD - 1] = { CanReceiveMemberCard, InitDarkraiEvent, PrepReceivedMemberCardMsg, PrepCannotReceiveMemberCardMsg },
+    [MYST_GIFT_OAKS_LETTER - 1] = { CanReceiveOaksLetter, InitShayminEvent, PrepReceivedOaksLetterMsg, PrepCannotReceivedOaksLetterMsg },
+    [MYST_GIFT_AZURE_FLUTE - 1] = { CanReceiveAzureFlute, InitArceusEvent, PrepReceivedAzureFluteMsg, PrepCannotReceiveAzureFluteMsg },
+    [MYST_GIFT_POKETCH_APP - 1] = { CanReceivePoketchApp, GivePoketchApp, PrepReceivedPoketchAppMsg, PrepCannotReceivePoketchAppMsg },
+    [MYST_GIFT_SECRET_KEY - 1] = { CanReceiveSecretKey, InitRotomEvent, PrepReceivedSecretKeyMsg, PrepCannotReceiveSecretKeyMsg },
+    [MYST_GIFT_UNKNOWN - 1] = { CanReceivePokemon, GivePokemon, PrepReceivedPokemonMsg, PrepCannotReceivePokemonMsg } // Same as Pokemon, likely unused
 };


### PR DESCRIPTION
While working on the mystery gifts menu, I noticed a mistake (wrong case for an enum name) and some clean-up opportunities in my original mystery gifts documentation.

I could probably have bundled these changes with the mystery gifts menu documentation, but that might still take a while before it's ready, so I figured I might as well go ahead and PR them now.