### PR TITLE
Add exception handling to json data parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ data: $(BUILD)/build.ninja
 	$(NINJA) -C $(BUILD) data
 
 target: $(BUILD)/build.ninja
-	$(NINJA) -C $(BUILD) $(MESON_TARGET)
+	$(MESON) compile -C $(BUILD) $(MESON_TARGET)
 
 format: $(BUILD)/build.ninja
 	$(NINJA) -C $(BUILD) clang-format

--- a/include/inlines.h
+++ b/include/inlines.h
@@ -15,7 +15,7 @@
 #include "heap.h"
 #include "location.h"
 #include "map_header.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "palette.h"
 #include "script_manager.h"

--- a/include/math_util.h
+++ b/include/math_util.h
@@ -1,5 +1,5 @@
-#ifndef POKEPLATINUM_MATH_H
-#define POKEPLATINUM_MATH_H
+#ifndef POKEPLATINUM_MATH_UTIL_H
+#define POKEPLATINUM_MATH_UTIL_H
 
 #include <nitro/fx/fx.h>
 
@@ -41,4 +41,4 @@ void DecodeData(void *data, u32 size, u32 seed);
 u16 CalcCRC16Checksum(const void *data, u32 dataLen);
 void InitCRC16Table(enum HeapId heapID);
 
-#endif // POKEPLATINUM_MATH_H
+#endif // POKEPLATINUM_MATH_UTIL_H

--- a/platinum.us/main.lsf
+++ b/platinum.us/main.lsf
@@ -73,7 +73,7 @@ Static main
 	Object main.nef.p/src_sys_task_manager.c.o
 	Object main.nef.p/src_unk_0201CED8.c.o
 	Object main.nef.p/src_charcode.c.o
-	Object main.nef.p/src_math.c.o
+	Object main.nef.p/src_math_util.c.o
 	Object main.nef.p/src_text.c.o
 	Object main.nef.p/src_vram_transfer.c.o
 	Object main.nef.p/src_cell_transfer.c.o

--- a/src/battle/healthbar.c
+++ b/src/battle/healthbar.c
@@ -12,7 +12,7 @@
 #include "assert.h"
 #include "bg_window.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "palette.h"

--- a/src/battle/ov16_0223B140.c
+++ b/src/battle/ov16_0223B140.c
@@ -48,7 +48,7 @@
 #include "gx_layers.h"
 #include "hardware_palette.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "overlay_manager.h"

--- a/src/battle/ov16_02264798.c
+++ b/src/battle/ov16_02264798.c
@@ -9,7 +9,7 @@
 #include "battle/struct_ov16_0225BFFC_decl.h"
 #include "battle/struct_ov16_0225BFFC_t.h"
 
-#include "math.h"
+#include "math_util.h"
 #include "pokemon_sprite.h"
 #include "sys_task.h"
 #include "sys_task_manager.h"

--- a/src/battle/ov16_0226871C.c
+++ b/src/battle/ov16_0226871C.c
@@ -31,7 +31,7 @@
 #include "graphics.h"
 #include "heap.h"
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "message_util.h"
 #include "move_table.h"

--- a/src/battle/ov16_0226DE44.c
+++ b/src/battle/ov16_0226DE44.c
@@ -4,7 +4,7 @@
 #include <string.h>
 
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "palette.h"
 #include "sprite_system.h"

--- a/src/bg_window.c
+++ b/src/bg_window.c
@@ -7,7 +7,7 @@
 
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 
 static u8 ConvertToGxBgScreenSize(u8 bgScreenSize, u8 bgType);
 static void GetBgScreenTileDimensions(u8 bgScreenSize, u8 *outXTiles, u8 *outYTiles);

--- a/src/fx_util.c
+++ b/src/fx_util.c
@@ -5,7 +5,7 @@
 #include <nnsys.h>
 #include <string.h>
 
-#include "math.h"
+#include "math_util.h"
 
 #define F32_PI               ((f32)3.14159265358979323846)
 #define FX_F32_RAD_TO_IDX(f) ((u16)(FX_RAD_TO_IDX(FX32_CONST(f))))

--- a/src/game_records.c
+++ b/src/game_records.c
@@ -5,7 +5,7 @@
 #include "generated/game_records.h"
 #include "generated/trainer_score_events.h"
 
-#include "math.h"
+#include "math_util.h"
 #include "pokedex.h"
 
 #define START_ENCODED_RECORDS RECORD_TRAINER_SCORE

--- a/src/game_start.c
+++ b/src/game_start.c
@@ -8,7 +8,7 @@
 #include "heap.h"
 #include "location.h"
 #include "main.h"
-#include "math.h"
+#include "math_util.h"
 #include "overlay_manager.h"
 #include "party.h"
 #include "pokemon.h"

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@
 #include "game_overlay.h"
 #include "game_start.h"
 #include "main.h"
-#include "math.h"
+#include "math_util.h"
 #include "overlay_manager.h"
 #include "rtc.h"
 #include "save_player.h"

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -1,4 +1,4 @@
-#include "math.h"
+#include "math_util.h"
 
 #include <nitro/math/crc.h>
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -68,7 +68,7 @@ pokeplatinum_c = files(
     'sys_task_manager.c',
     'unk_0201CED8.c',
     'charcode.c',
-    'math.c',
+    'math_util.c',
     'text.c',
     'vram_transfer.c',
     'cell_transfer.c',

--- a/src/overlay005/daycare.c
+++ b/src/overlay005/daycare.c
@@ -19,7 +19,7 @@
 #include "game_records.h"
 #include "heap.h"
 #include "item.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "message_util.h"
 #include "party.h"

--- a/src/overlay005/ov5_021D5EB8.c
+++ b/src/overlay005/ov5_021D5EB8.c
@@ -17,7 +17,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "render_oam.h"
 #include "render_view.h"

--- a/src/overlay005/ov5_021EB1A0.c
+++ b/src/overlay005/ov5_021EB1A0.c
@@ -19,7 +19,7 @@
 #include "overlay101/struct_ov101_021D5D90_decl.h"
 
 #include "map_object.h"
-#include "math.h"
+#include "math_util.h"
 #include "unk_02020AEC.h"
 
 typedef struct {

--- a/src/overlay005/ov5_021F08CC.c
+++ b/src/overlay005/ov5_021F08CC.c
@@ -22,7 +22,7 @@
 #include "game_records.h"
 #include "heap.h"
 #include "map_object.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "party.h"
 #include "player_avatar.h"

--- a/src/overlay005/ov5_021F6454.c
+++ b/src/overlay005/ov5_021F6454.c
@@ -28,7 +28,7 @@
 #include "inlines.h"
 #include "list_menu.h"
 #include "map_object.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "party.h"

--- a/src/overlay005/ov5_021F8560.c
+++ b/src/overlay005/ov5_021F8560.c
@@ -16,7 +16,7 @@
 #include "overlay101/struct_ov101_021D86B0.h"
 
 #include "map_object.h"
-#include "math.h"
+#include "math_util.h"
 #include "player_avatar.h"
 #include "unk_020711EC.h"
 #include "unk_02073838.h"

--- a/src/overlay005/vs_seeker.c
+++ b/src/overlay005/vs_seeker.c
@@ -14,7 +14,7 @@
 #include "heap.h"
 #include "map_header_data.h"
 #include "map_object.h"
-#include "math.h"
+#include "math_util.h"
 #include "player_avatar.h"
 #include "script_manager.h"
 #include "sound_playback.h"

--- a/src/overlay006/ov6_0223E140.c
+++ b/src/overlay006/ov6_0223E140.c
@@ -30,7 +30,7 @@
 #include "gx_layers.h"
 #include "heap.h"
 #include "map_object.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "player_avatar.h"
 #include "sound_playback.h"

--- a/src/overlay006/ov6_022426AC.c
+++ b/src/overlay006/ov6_022426AC.c
@@ -7,7 +7,7 @@
 #include "generated/genders.h"
 
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "pokemon.h"
 #include "sprite.h"

--- a/src/overlay006/ov6_02243258.c
+++ b/src/overlay006/ov6_02243258.c
@@ -16,7 +16,7 @@
 #include "gx_layers.h"
 #include "heap.h"
 #include "map_object.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "player_avatar.h"
 #include "pokemon.h"

--- a/src/overlay006/ov6_022465FC.c
+++ b/src/overlay006/ov6_022465FC.c
@@ -10,7 +10,7 @@
 #include "overlay006/struct_ov6_022465F4_decl.h"
 #include "savedata/save_table.h"
 
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "rtc.h"
 #include "unk_0202E2CC.h"

--- a/src/overlay006/ov6_02246A30.c
+++ b/src/overlay006/ov6_02246A30.c
@@ -10,7 +10,7 @@
 #include "field/field_system.h"
 
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "pokedex.h"
 #include "save_player.h"
 #include "system_flags.h"

--- a/src/overlay006/wild_encounters.c
+++ b/src/overlay006/wild_encounters.c
@@ -36,7 +36,7 @@
 #include "map_header.h"
 #include "map_header_data.h"
 #include "map_tile_behavior.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "party.h"
 #include "player_avatar.h"

--- a/src/overlay008/ov8_02249960.c
+++ b/src/overlay008/ov8_02249960.c
@@ -43,7 +43,7 @@
 #include "map_object.h"
 #include "map_object_move.h"
 #include "map_tile_behavior.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "persisted_map_features.h"
 #include "player_avatar.h"

--- a/src/overlay009/ov9_02249960.c
+++ b/src/overlay009/ov9_02249960.c
@@ -49,7 +49,7 @@
 #include "map_object.h"
 #include "map_object_move.h"
 #include "map_tile_behavior.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "persisted_map_features.h"
 #include "player_avatar.h"

--- a/src/overlay010/ov10_0221F800.c
+++ b/src/overlay010/ov10_0221F800.c
@@ -27,7 +27,7 @@
 #include "item.h"
 #include "journal.h"
 #include "map_header.h"
-#include "math.h"
+#include "math_util.h"
 #include "menu.h"
 #include "message.h"
 #include "narc.h"

--- a/src/overlay012/ov12_02226B84.c
+++ b/src/overlay012/ov12_02226B84.c
@@ -23,7 +23,7 @@
 #include "graphics.h"
 #include "heap.h"
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "palette.h"
 #include "pltt_transfer.h"
 #include "pokemon_sprite.h"

--- a/src/overlay012/ov12_0222D6B0.c
+++ b/src/overlay012/ov12_0222D6B0.c
@@ -16,7 +16,7 @@
 
 #include "bg_window.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "pokemon_sprite.h"
 #include "sprite_system.h"
 #include "sys_task_manager.h"

--- a/src/overlay012/ov12_02235E94.c
+++ b/src/overlay012/ov12_02235E94.c
@@ -22,7 +22,7 @@
 #include "overlay012/struct_ov12_02237728.h"
 
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "palette.h"
 #include "pokemon.h"

--- a/src/overlay017/ov17_022413D8.c
+++ b/src/overlay017/ov17_022413D8.c
@@ -26,7 +26,7 @@
 #include "graphics.h"
 #include "heap.h"
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "palette.h"

--- a/src/overlay017/ov17_022476F8.c
+++ b/src/overlay017/ov17_022476F8.c
@@ -11,7 +11,7 @@
 #include "bg_window.h"
 #include "game_options.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "pokemon.h"

--- a/src/overlay017/ov17_0224A0FC.c
+++ b/src/overlay017/ov17_0224A0FC.c
@@ -33,7 +33,7 @@
 #include "game_options.h"
 #include "heap.h"
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "palette.h"

--- a/src/overlay017/ov17_02250744.c
+++ b/src/overlay017/ov17_02250744.c
@@ -18,7 +18,7 @@
 #include "game_options.h"
 #include "graphics.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "palette.h"

--- a/src/overlay019/ov19_021D8B54.c
+++ b/src/overlay019/ov19_021D8B54.c
@@ -19,7 +19,7 @@
 
 #include "graphics.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "sprite.h"
 #include "sys_task.h"

--- a/src/overlay019/ov19_021DCF88.c
+++ b/src/overlay019/ov19_021DCF88.c
@@ -15,7 +15,7 @@
 #include "enums.h"
 #include "graphics.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "pc_boxes.h"
 #include "sprite.h"

--- a/src/overlay021/ov21_021D76B0.c
+++ b/src/overlay021/ov21_021D76B0.c
@@ -25,7 +25,7 @@
 #include "bg_window.h"
 #include "brightness_controller.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "pltt_transfer.h"
 #include "sound_playback.h"

--- a/src/overlay021/ov21_021E4CA4.c
+++ b/src/overlay021/ov21_021E4CA4.c
@@ -23,7 +23,7 @@
 #include "bg_window.h"
 #include "brightness_controller.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "pltt_transfer.h"
 #include "sound.h"

--- a/src/overlay022/ov22_02257F50.c
+++ b/src/overlay022/ov22_02257F50.c
@@ -18,7 +18,7 @@
 #include "overlay022/struct_ov22_022599A0.h"
 
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "sys_task_manager.h"
 #include "touch_screen.h"
 #include "unk_0200679C.h"

--- a/src/overlay022/ov22_022589E0.c
+++ b/src/overlay022/ov22_022589E0.c
@@ -19,7 +19,7 @@
 #include "overlay022/struct_ov22_0225A428.h"
 
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "sound_playback.h"
 #include "sys_task_manager.h"
 #include "system.h"

--- a/src/overlay023/ov23_0223E140.c
+++ b/src/overlay023/ov23_0223E140.c
@@ -37,7 +37,7 @@
 #include "heap.h"
 #include "journal.h"
 #include "map_matrix.h"
-#include "math.h"
+#include "math_util.h"
 #include "menu.h"
 #include "narc.h"
 #include "pltt_transfer.h"

--- a/src/overlay023/ov23_0224340C.c
+++ b/src/overlay023/ov23_0224340C.c
@@ -35,7 +35,7 @@
 #include "gx_layers.h"
 #include "heap.h"
 #include "map_object_move.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "player_avatar.h"
 #include "pltt_transfer.h"

--- a/src/overlay023/ov23_02248F1C.c
+++ b/src/overlay023/ov23_02248F1C.c
@@ -15,7 +15,7 @@
 #include "field_message.h"
 #include "graphics.h"
 #include "gx_layers.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "player_avatar.h"
 #include "render_window.h"

--- a/src/overlay023/ov23_0224DC40.c
+++ b/src/overlay023/ov23_0224DC40.c
@@ -21,7 +21,7 @@
 #include "game_records.h"
 #include "heap.h"
 #include "list_menu.h"
-#include "math.h"
+#include "math_util.h"
 #include "menu.h"
 #include "message.h"
 #include "render_window.h"

--- a/src/overlay033/ov33_02256474.c
+++ b/src/overlay033/ov33_02256474.c
@@ -18,7 +18,7 @@
 #include "graphics.h"
 #include "heap.h"
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "pokemon.h"
 #include "pokemon_icon.h"

--- a/src/overlay041/ov41_022567B0.c
+++ b/src/overlay041/ov41_022567B0.c
@@ -17,7 +17,7 @@
 #include "bg_window.h"
 #include "graphics.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "poketch_memory.h"
 #include "sys_task_manager.h"
 

--- a/src/overlay042/ov42_022561C0.c
+++ b/src/overlay042/ov42_022561C0.c
@@ -9,7 +9,7 @@
 
 #include "bg_window.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "poketch_memory.h"
 #include "sys_task.h"
 #include "sys_task_manager.h"

--- a/src/overlay053/ov53_02256420.c
+++ b/src/overlay053/ov53_02256420.c
@@ -17,7 +17,7 @@
 #include "bg_window.h"
 #include "graphics.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "pokemon_icon.h"
 #include "sys_task_manager.h"
 

--- a/src/overlay058/ov58_021D0D80.c
+++ b/src/overlay058/ov58_021D0D80.c
@@ -24,7 +24,7 @@
 #include "gx_layers.h"
 #include "heap.h"
 #include "journal.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "overlay_manager.h"

--- a/src/overlay059/ov59_021D0D80.c
+++ b/src/overlay059/ov59_021D0D80.c
@@ -25,7 +25,7 @@
 #include "gx_layers.h"
 #include "heap.h"
 #include "journal.h"
-#include "math.h"
+#include "math_util.h"
 #include "menu.h"
 #include "message.h"
 #include "message_util.h"

--- a/src/overlay062/ov62_022300D8.c
+++ b/src/overlay062/ov62_022300D8.c
@@ -18,7 +18,7 @@
 #include "bg_window.h"
 #include "char_transfer.h"
 #include "graphics.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "palette.h"

--- a/src/overlay062/ov62_02234A10.c
+++ b/src/overlay062/ov62_02234A10.c
@@ -15,7 +15,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "palette.h"
 #include "sound_playback.h"

--- a/src/overlay062/ov62_02236CBC.c
+++ b/src/overlay062/ov62_02236CBC.c
@@ -16,7 +16,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "palette.h"
 #include "sound_playback.h"

--- a/src/overlay065/ov65_02235060.c
+++ b/src/overlay065/ov65_02235060.c
@@ -25,7 +25,7 @@
 #include "bg_window.h"
 #include "graphics.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "sprite.h"
 #include "sprite_resource.h"

--- a/src/overlay066/ov66_0222DDF0.c
+++ b/src/overlay066/ov66_0222DDF0.c
@@ -47,7 +47,7 @@
 #include "heap.h"
 #include "inlines.h"
 #include "journal.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "party.h"
 #include "pokedex.h"

--- a/src/overlay069/ov69_0225C700.c
+++ b/src/overlay069/ov69_0225C700.c
@@ -29,7 +29,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "overlay_manager.h"

--- a/src/overlay070/ov70_0225C9B4.c
+++ b/src/overlay070/ov70_0225C9B4.c
@@ -21,7 +21,7 @@
 #include "overlay070/struct_ov70_0225C894_decl.h"
 
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "sound_playback.h"
 #include "system.h"
 

--- a/src/overlay070/ov70_02260B44.c
+++ b/src/overlay070/ov70_02260B44.c
@@ -13,7 +13,7 @@
 #include "easy3d_object.h"
 #include "graphics.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 
 typedef struct {

--- a/src/overlay070/ov70_022630A4.c
+++ b/src/overlay070/ov70_022630A4.c
@@ -35,7 +35,7 @@
 
 #include "enums.h"
 #include "list_menu.h"
-#include "math.h"
+#include "math_util.h"
 #include "sound_playback.h"
 #include "strbuf.h"
 #include "system.h"

--- a/src/overlay070/ov70_02266E9C.c
+++ b/src/overlay070/ov70_02266E9C.c
@@ -20,7 +20,7 @@
 
 #include "enums.h"
 #include "list_menu.h"
-#include "math.h"
+#include "math_util.h"
 #include "sound_playback.h"
 #include "strbuf.h"
 

--- a/src/overlay070/ov70_0226CE54.c
+++ b/src/overlay070/ov70_0226CE54.c
@@ -14,7 +14,7 @@
 #include "overlay070/struct_ov70_02261E10_decl.h"
 
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "sound_playback.h"
 
 typedef struct {

--- a/src/overlay072/ov72_0223D7A0.c
+++ b/src/overlay072/ov72_0223D7A0.c
@@ -27,7 +27,7 @@
 #include "gx_layers.h"
 #include "heap.h"
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "overlay_manager.h"

--- a/src/overlay077/ov77_021D0D80.c
+++ b/src/overlay077/ov77_021D0D80.c
@@ -21,7 +21,7 @@
 #include "gx_layers.h"
 #include "heap.h"
 #include "main.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "overlay_manager.h"

--- a/src/overlay077/ov77_021D25B0.c
+++ b/src/overlay077/ov77_021D25B0.c
@@ -24,7 +24,7 @@
 #include "gx_layers.h"
 #include "heap.h"
 #include "main.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "overlay_manager.h"
 #include "render_oam.h"

--- a/src/overlay077/ov77_021D6670.c
+++ b/src/overlay077/ov77_021D6670.c
@@ -6,7 +6,7 @@
 #include "char_transfer.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "pltt_transfer.h"
 #include "render_oam.h"
 #include "sprite.h"

--- a/src/overlay079/ov79_021D2268.c
+++ b/src/overlay079/ov79_021D2268.c
@@ -18,7 +18,7 @@
 #include "font.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "overlay_manager.h"

--- a/src/overlay083/ov83_0223D6A8.c
+++ b/src/overlay083/ov83_0223D6A8.c
@@ -43,7 +43,7 @@
 #include "gx_layers.h"
 #include "heap.h"
 #include "int_distance.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "render_window.h"
 #include "sound_playback.h"

--- a/src/overlay083/ov83_0223F7F4.c
+++ b/src/overlay083/ov83_0223F7F4.c
@@ -19,7 +19,7 @@
 #include "berry_data.h"
 #include "heap.h"
 #include "int_distance.h"
-#include "math.h"
+#include "math_util.h"
 #include "poffin.h"
 #include "system.h"
 

--- a/src/overlay084/ov84_0223B5A0.c
+++ b/src/overlay084/ov84_0223B5A0.c
@@ -27,7 +27,7 @@
 #include "heap.h"
 #include "item.h"
 #include "list_menu.h"
-#include "math.h"
+#include "math_util.h"
 #include "menu.h"
 #include "message.h"
 #include "narc.h"

--- a/src/overlay086/ov86_0223B140.c
+++ b/src/overlay086/ov86_0223B140.c
@@ -19,7 +19,7 @@
 #include "gx_layers.h"
 #include "heap.h"
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "overlay_manager.h"

--- a/src/overlay088/ov88_0223B140.c
+++ b/src/overlay088/ov88_0223B140.c
@@ -35,7 +35,7 @@
 #include "item.h"
 #include "journal.h"
 #include "list_menu.h"
-#include "math.h"
+#include "math_util.h"
 #include "menu.h"
 #include "message.h"
 #include "message_util.h"

--- a/src/overlay092/ov92_021D0D80.c
+++ b/src/overlay092/ov92_021D0D80.c
@@ -20,7 +20,7 @@
 #include "gx_layers.h"
 #include "heap.h"
 #include "list_menu.h"
-#include "math.h"
+#include "math_util.h"
 #include "menu.h"
 #include "message.h"
 #include "narc.h"

--- a/src/overlay095/ov95_02248590.c
+++ b/src/overlay095/ov95_02248590.c
@@ -20,7 +20,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "sound_playback.h"
 #include "sprite.h"
 #include "sys_task.h"

--- a/src/overlay095/ov95_02249740.c
+++ b/src/overlay095/ov95_02249740.c
@@ -18,7 +18,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "sound_playback.h"
 #include "sprite.h"
 #include "sys_task.h"

--- a/src/overlay095/ov95_0224A390.c
+++ b/src/overlay095/ov95_0224A390.c
@@ -18,7 +18,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "sound_playback.h"
 #include "sprite.h"
 #include "sys_task.h"

--- a/src/overlay097/ov97_0222D30C.c
+++ b/src/overlay097/ov97_0222D30C.c
@@ -24,7 +24,7 @@
 #include "heap.h"
 #include "list_menu.h"
 #include "main.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "message_util.h"
 #include "mystery_gift.h"

--- a/src/overlay099/ov99_021D2C08.c
+++ b/src/overlay099/ov99_021D2C08.c
@@ -11,7 +11,7 @@
 
 #include "bg_window.h"
 #include "brightness_controller.h"
-#include "math.h"
+#include "math_util.h"
 #include "sprite_system.h"
 
 typedef struct {

--- a/src/overlay099/ov99_021D2E28.c
+++ b/src/overlay099/ov99_021D2E28.c
@@ -11,7 +11,7 @@
 
 #include "bg_window.h"
 #include "brightness_controller.h"
-#include "math.h"
+#include "math_util.h"
 #include "palette.h"
 #include "sprite_system.h"
 

--- a/src/overlay099/ov99_021D340C.c
+++ b/src/overlay099/ov99_021D340C.c
@@ -11,7 +11,7 @@
 #include "overlay099/struct_ov99_021D3A40.h"
 
 #include "brightness_controller.h"
-#include "math.h"
+#include "math_util.h"
 #include "palette.h"
 #include "sprite_system.h"
 

--- a/src/overlay099/ov99_021D4134.c
+++ b/src/overlay099/ov99_021D4134.c
@@ -10,7 +10,7 @@
 #include "easy3d_object.h"
 #include "graphics.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "palette.h"
 #include "sprite.h"
 #include "sprite_system.h"

--- a/src/overlay100/ov100_021D13E4.c
+++ b/src/overlay100/ov100_021D13E4.c
@@ -17,7 +17,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "palette.h"
 #include "sound.h"

--- a/src/overlay100/ov100_021D1C44.c
+++ b/src/overlay100/ov100_021D1C44.c
@@ -19,7 +19,7 @@
 #include "easy3d_object.h"
 #include "graphics.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "palette.h"
 #include "sound.h"

--- a/src/overlay100/ov100_021D400C.c
+++ b/src/overlay100/ov100_021D400C.c
@@ -5,7 +5,7 @@
 
 #include "overlay100/struct_ov100_021D4104.h"
 
-#include "math.h"
+#include "math_util.h"
 #include "sprite_system.h"
 #include "sys_task_manager.h"
 

--- a/src/overlay101/ov101_021D1A28.c
+++ b/src/overlay101/ov101_021D1A28.c
@@ -37,7 +37,7 @@
 #include "bg_window.h"
 #include "enums.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "sound_playback.h"
 #include "sys_task.h"
 #include "sys_task_manager.h"

--- a/src/overlay101/ov101_021D59AC.c
+++ b/src/overlay101/ov101_021D59AC.c
@@ -15,7 +15,7 @@
 #include "overlay101/struct_ov101_021D93D4.h"
 
 #include "enums.h"
-#include "math.h"
+#include "math_util.h"
 #include "sound_playback.h"
 #include "sprite.h"
 #include "sys_task.h"

--- a/src/overlay104/ov104_0222DCE0.c
+++ b/src/overlay104/ov104_0222DCE0.c
@@ -21,7 +21,7 @@
 #include "flags.h"
 #include "heap.h"
 #include "map_header.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "party.h"

--- a/src/overlay104/ov104_0222FBE4.c
+++ b/src/overlay104/ov104_0222FBE4.c
@@ -63,7 +63,7 @@
 #include "field_comm_manager.h"
 #include "game_records.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "menu.h"
 #include "message.h"
 #include "narc.h"

--- a/src/overlay104/ov104_022339B4.c
+++ b/src/overlay104/ov104_022339B4.c
@@ -21,7 +21,7 @@
 
 #include "game_records.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "party.h"
 #include "pokemon.h"
 #include "savedata.h"

--- a/src/overlay104/ov104_02237DD8.c
+++ b/src/overlay104/ov104_02237DD8.c
@@ -24,7 +24,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "palette.h"
 #include "party.h"

--- a/src/overlay104/ov104_0223A7F4.c
+++ b/src/overlay104/ov104_0223A7F4.c
@@ -17,7 +17,7 @@
 #include "communication_system.h"
 #include "field_battle_data_transfer.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "party.h"
 #include "pokemon.h"

--- a/src/overlay104/ov104_0223AF58.c
+++ b/src/overlay104/ov104_0223AF58.c
@@ -15,7 +15,7 @@
 #include "communication_system.h"
 #include "field_battle_data_transfer.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "party.h"
 #include "pokemon.h"
 #include "trainer_info.h"

--- a/src/overlay104/ov104_0223B6F4.c
+++ b/src/overlay104/ov104_0223B6F4.c
@@ -16,7 +16,7 @@
 #include "communication_system.h"
 #include "field_battle_data_transfer.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "party.h"
 #include "pokemon.h"

--- a/src/overlay104/ov104_0223BCBC.c
+++ b/src/overlay104/ov104_0223BCBC.c
@@ -14,7 +14,7 @@
 #include "communication_system.h"
 #include "field_battle_data_transfer.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "party.h"
 #include "pokemon.h"

--- a/src/overlay108/ov108_02241AE0.c
+++ b/src/overlay108/ov108_02241AE0.c
@@ -25,7 +25,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "menu.h"
 #include "message.h"
 #include "narc.h"

--- a/src/overlay109/ov109_021D0D80.c
+++ b/src/overlay109/ov109_021D0D80.c
@@ -31,7 +31,7 @@
 #include "gx_layers.h"
 #include "heap.h"
 #include "journal.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "overlay_manager.h"

--- a/src/overlay109/ov109_021D3D50.c
+++ b/src/overlay109/ov109_021D3D50.c
@@ -25,7 +25,7 @@
 #include "gx_layers.h"
 #include "heap.h"
 #include "journal.h"
-#include "math.h"
+#include "math_util.h"
 #include "menu.h"
 #include "message.h"
 #include "message_util.h"

--- a/src/overlay111/ov111_021D0D80.c
+++ b/src/overlay111/ov111_021D0D80.c
@@ -24,7 +24,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "overlay_manager.h"

--- a/src/overlay113/ov113_0225E368.c
+++ b/src/overlay113/ov113_0225E368.c
@@ -29,7 +29,7 @@
 #include "easy3d_object.h"
 #include "graphics.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "pokemon.h"
 #include "sound_playback.h"

--- a/src/overlay114/ov114_0225C700.c
+++ b/src/overlay114/ov114_0225C700.c
@@ -28,7 +28,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "pltt_transfer.h"

--- a/src/overlay115/ov115_02260CEC.c
+++ b/src/overlay115/ov115_02260CEC.c
@@ -31,7 +31,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "pltt_transfer.h"

--- a/src/overlay116/ov116_02260440.c
+++ b/src/overlay116/ov116_02260440.c
@@ -12,7 +12,7 @@
 #include "overlay116/struct_ov116_02260498.h"
 #include "overlay116/struct_ov116_0226139C.h"
 
-#include "math.h"
+#include "math_util.h"
 #include "unk_02032798.h"
 
 static void ov116_02260440(int param0, int param1, void *param2, void *param3);

--- a/src/overlay116/ov116_022604C4.c
+++ b/src/overlay116/ov116_022604C4.c
@@ -29,7 +29,7 @@
 #include "easy3d_object.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "overlay_manager.h"
 #include "palette.h"

--- a/src/overlay116/ov116_02262A8C.c
+++ b/src/overlay116/ov116_02262A8C.c
@@ -18,7 +18,7 @@
 #include "easy3d_object.h"
 #include "heap.h"
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "sound_playback.h"
 #include "sprite.h"
 #include "sprite_system.h"

--- a/src/overlay116/ov116_0226432C.c
+++ b/src/overlay116/ov116_0226432C.c
@@ -22,7 +22,7 @@
 #include "easy3d_object.h"
 #include "heap.h"
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "palette.h"
 #include "sound_playback.h"
 #include "sprite_system.h"

--- a/src/overlay117/ov117_02263AF0.c
+++ b/src/overlay117/ov117_02263AF0.c
@@ -33,7 +33,7 @@
 #include "error_handling.h"
 #include "font.h"
 #include "graphics.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "palette.h"

--- a/src/poffin.c
+++ b/src/poffin.c
@@ -4,7 +4,7 @@
 #include <string.h>
 
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "savedata.h"
 
 #define FLAVOR_NONE 30

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -34,7 +34,7 @@
 #include "heap.h"
 #include "inlines.h"
 #include "item.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "message_util.h"
 #include "move_table.h"

--- a/src/record_mixed_rng.c
+++ b/src/record_mixed_rng.c
@@ -6,7 +6,7 @@
 
 #include "charcode.h"
 #include "charcode_util.h"
-#include "math.h"
+#include "math_util.h"
 #include "savedata.h"
 #include "strbuf.h"
 

--- a/src/savedata.c
+++ b/src/savedata.c
@@ -9,7 +9,7 @@
 
 #include "heap.h"
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "savedata_misc.h"
 #include "system.h"
 #include "unk_0209A74C.h"

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -118,7 +118,7 @@
 #include "map_header_data.h"
 #include "map_object.h"
 #include "map_object_move.h"
-#include "math.h"
+#include "math_util.h"
 #include "menu.h"
 #include "message.h"
 #include "message_util.h"

--- a/src/scrcmd_amity_square.c
+++ b/src/scrcmd_amity_square.c
@@ -8,7 +8,7 @@
 
 #include "field_script_context.h"
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "system_vars.h"
 #include "vars_flags.h"
 

--- a/src/scrcmd_mystery_gift.c
+++ b/src/scrcmd_mystery_gift.c
@@ -16,7 +16,7 @@
 #include "field_script_context.h"
 #include "heap.h"
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "mystery_gift.h"
 #include "party.h"
 #include "pokemon.h"

--- a/src/script_manager.c
+++ b/src/script_manager.c
@@ -15,7 +15,7 @@
 #include "map_header.h"
 #include "map_header_data.h"
 #include "map_object.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "player_avatar.h"

--- a/src/sound_chatot.c
+++ b/src/sound_chatot.c
@@ -7,7 +7,7 @@
 
 #include "struct_defs/chatot_cry.h"
 
-#include "math.h"
+#include "math_util.h"
 #include "sound.h"
 #include "sound_playback.h"
 #include "sound_system.h"

--- a/src/special_encounter.c
+++ b/src/special_encounter.c
@@ -6,7 +6,7 @@
 #include "struct_defs/radar_chain_records.h"
 #include "struct_defs/special_encounter.h"
 
-#include "math.h"
+#include "math_util.h"
 #include "roaming_pokemon.h"
 #include "savedata.h"
 

--- a/src/system.c
+++ b/src/system.c
@@ -8,7 +8,7 @@
 
 #include "boot.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "sys_task_manager.h"
 
 #define MAIN_TASK_MAX        160

--- a/src/system_vars.c
+++ b/src/system_vars.c
@@ -6,7 +6,7 @@
 
 #include "field_overworld_state.h"
 #include "location.h"
-#include "math.h"
+#include "math_util.h"
 #include "record_mixed_rng.h"
 #include "savedata.h"
 #include "system_flags.h"

--- a/src/trainer_data.c
+++ b/src/trainer_data.c
@@ -11,7 +11,7 @@
 #include "charcode_util.h"
 #include "field_battle_data_transfer.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "party.h"

--- a/src/unk_02014D38.c
+++ b/src/unk_02014D38.c
@@ -5,7 +5,7 @@
 
 #include "graphics.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "savedata.h"

--- a/src/unk_0202854C.c
+++ b/src/unk_0202854C.c
@@ -10,7 +10,7 @@
 #include "struct_defs/struct_020298B0.h"
 
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "rtc.h"
 #include "savedata.h"
 #include "system.h"

--- a/src/unk_0202F1D4.c
+++ b/src/unk_0202F1D4.c
@@ -21,7 +21,7 @@
 #include "field_battle_data_transfer.h"
 #include "game_options.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "party.h"
 #include "pokedex.h"
 #include "pokemon.h"

--- a/src/unk_02030CE8.c
+++ b/src/unk_02030CE8.c
@@ -9,7 +9,7 @@
 #include "overlay096/struct_ov96_0223B574.h"
 
 #include "charcode_util.h"
-#include "math.h"
+#include "math_util.h"
 #include "save_player.h"
 #include "savedata.h"
 #include "trainer_info.h"

--- a/src/unk_0203D1B8.c
+++ b/src/unk_0203D1B8.c
@@ -95,7 +95,7 @@
 #include "game_options.h"
 #include "game_records.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "overlay_manager.h"
 #include "party.h"
 #include "player_avatar.h"

--- a/src/unk_02048BD0.c
+++ b/src/unk_02048BD0.c
@@ -5,7 +5,7 @@
 
 #include "field_script_context.h"
 #include "inlines.h"
-#include "math.h"
+#include "math_util.h"
 #include "record_mixed_rng.h"
 #include "save_player.h"
 #include "savedata.h"

--- a/src/unk_02049D08.c
+++ b/src/unk_02049D08.c
@@ -25,7 +25,7 @@
 #include "inlines.h"
 #include "journal.h"
 #include "location.h"
-#include "math.h"
+#include "math_util.h"
 #include "party.h"
 #include "player_avatar.h"
 #include "pokemon.h"

--- a/src/unk_0205B33C.c
+++ b/src/unk_0205B33C.c
@@ -18,7 +18,7 @@
 #include "field_task.h"
 #include "heap.h"
 #include "journal.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "save_player.h"
 #include "savedata.h"

--- a/src/unk_0205DFC4.c
+++ b/src/unk_0205DFC4.c
@@ -13,7 +13,7 @@
 #include "field_task.h"
 #include "heap.h"
 #include "map_object.h"
-#include "math.h"
+#include "math_util.h"
 #include "party.h"
 #include "pokemon.h"
 #include "save_player.h"

--- a/src/unk_0206450C.c
+++ b/src/unk_0206450C.c
@@ -10,7 +10,7 @@
 
 #include "map_object.h"
 #include "map_object_move.h"
-#include "math.h"
+#include "math_util.h"
 #include "player_avatar.h"
 #include "unk_0205F180.h"
 #include "unk_020655F4.h"

--- a/src/unk_0206CCB0.c
+++ b/src/unk_0206CCB0.c
@@ -39,7 +39,7 @@
 #include "inlines.h"
 #include "map_header.h"
 #include "map_header_util.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "party.h"
 #include "pokedex.h"

--- a/src/unk_0208694C.c
+++ b/src/unk_0208694C.c
@@ -17,7 +17,7 @@
 #include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "message_util.h"
 #include "narc.h"

--- a/src/unk_0208B284.c
+++ b/src/unk_0208B284.c
@@ -7,7 +7,7 @@
 #include "struct_defs/struct_0208B878.h"
 
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "narc.h"
 #include "palette.h"
 #include "sprite_system.h"

--- a/src/unk_020933F8.c
+++ b/src/unk_020933F8.c
@@ -35,7 +35,7 @@
 #include "game_records.h"
 #include "heap.h"
 #include "journal.h"
-#include "math.h"
+#include "math_util.h"
 #include "party.h"
 #include "pokedex.h"
 #include "pokemon.h"

--- a/src/unk_02094EDC.c
+++ b/src/unk_02094EDC.c
@@ -13,7 +13,7 @@
 
 #include "graphics.h"
 #include "heap.h"
-#include "math.h"
+#include "math_util.h"
 #include "message.h"
 #include "narc.h"
 #include "pokemon.h"

--- a/src/unk_020961E8.c
+++ b/src/unk_020961E8.c
@@ -11,7 +11,7 @@
 #include "overlay059/struct_ov59_021D30E0.h"
 
 #include "communication_system.h"
-#include "math.h"
+#include "math_util.h"
 #include "sound_playback.h"
 #include "unk_02030EE0.h"
 #include "unk_02032798.h"

--- a/tools/datagen/datagen.h
+++ b/tools/datagen/datagen.h
@@ -159,9 +159,15 @@ static inline std::string ReadWholeFile(std::ifstream &ifs)
 }
 
 // Read a whole file into a C++-string.
+// This routine is a potential exit-point if the file cannot be loaded for reading.
 static inline std::string ReadWholeFile(fs::path &fname)
 {
-    std::ifstream ifs(fname);
+    std::ifstream ifs(fname, std::ios::in);
+    if (ifs.fail()) {
+        std::cerr << "could not open file " << fs::relative(fname).generic_string() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+
     return ReadWholeFile(ifs);
 }
 

--- a/tools/datagen/datagen_species.cpp
+++ b/tools/datagen/datagen_species.cpp
@@ -429,8 +429,6 @@ static ArchivedPokeSpriteData ParsePokeSprite(const rapidjson::Document &root)
     const rapidjson::Value &back = root["back"];
     const rapidjson::Value &shadow = root["shadow"];
 
-    std::cout << "here" << std::endl;
-
     data.faces[0] = ParsePokeSpriteFace(front);
     data.faces[1] = ParsePokeSpriteFace(back);
     data.yOffset = front["addl_y_offset"].GetInt();

--- a/tools/datagen/datagen_species.cpp
+++ b/tools/datagen/datagen_species.cpp
@@ -500,7 +500,11 @@ int main(int argc, char **argv)
         try {
             fs::path speciesDataPath = dataRoot / species / "data.json";
             std::string json = ReadWholeFile(speciesDataPath);
-            doc.Parse(json.c_str());
+            rapidjson::ParseResult ok = doc.Parse(json.c_str(), json.length());
+            if (!ok) {
+                ReportJsonError(ok, json, speciesDataPath);
+                std::exit(EXIT_FAILURE);
+            }
 
             SpeciesData data = ParseSpeciesData(doc);
             SpeciesEvolutionList evos = ParseEvolutions(doc);

--- a/tools/datagen/datagen_species.cpp
+++ b/tools/datagen/datagen_species.cpp
@@ -497,15 +497,15 @@ int main(int argc, char **argv)
 
     rapidjson::Document doc;
     for (auto &species : speciesRegistry) {
-        try {
-            fs::path speciesDataPath = dataRoot / species / "data.json";
-            std::string json = ReadWholeFile(speciesDataPath);
-            rapidjson::ParseResult ok = doc.Parse(json.c_str(), json.length());
-            if (!ok) {
-                ReportJsonError(ok, json, speciesDataPath);
-                std::exit(EXIT_FAILURE);
-            }
+        fs::path speciesDataPath = dataRoot / species / "data.json";
+        std::string json = ReadWholeFile(speciesDataPath);
+        rapidjson::ParseResult ok = doc.Parse(json.c_str(), json.length());
+        if (!ok) {
+            ReportJsonError(ok, json, speciesDataPath);
+            std::exit(EXIT_FAILURE);
+        }
 
+        try {
             SpeciesData data = ParseSpeciesData(doc);
             SpeciesEvolutionList evos = ParseEvolutions(doc);
             SpeciesLearnsetWithSize sizedLearnset = ParseLevelUpLearnset(doc);
@@ -521,11 +521,16 @@ int main(int argc, char **argv)
                 palParkData.emplace_back(palPark.value());
             }
 
+            // Mechanically-distinct forms do not have sprite_data.json files
             fs::path speciesSpriteDataPath = dataRoot / species / "sprite_data.json";
-            std::ifstream spriteDataIFS(speciesSpriteDataPath);
+            std::ifstream spriteDataIFS(speciesSpriteDataPath, std::ios::in);
             if (spriteDataIFS.good()) {
                 std::string spriteData = ReadWholeFile(spriteDataIFS);
-                doc.Parse(spriteData.c_str());
+                ok = doc.Parse(spriteData.c_str());
+                if (!ok) {
+                    ReportJsonError(ok, json, speciesSpriteDataPath);
+                    std::exit(EXIT_FAILURE);
+                }
 
                 u8 genderRatio = species != "none" ? data.genderRatio : GENDER_RATIO_FEMALE_50; // treat SPECIES_NONE as if it has two genders.
                 PackHeights(heightVFS, doc, genderRatio);
@@ -533,8 +538,7 @@ int main(int argc, char **argv)
                 ArchivedPokeSpriteData pokeSprite = ParsePokeSprite(doc);
                 pokeSpriteData.emplace_back(pokeSprite);
             }
-        } catch (std::exception &e) {
-            std::cerr << "exception parsing data file for " + species << std::endl;
+        } catch (const std::exception &e) {
             std::cerr << e.what() << std::endl;
             std::exit(EXIT_FAILURE);
         }

--- a/tools/datagen/datagen_trainer.cpp
+++ b/tools/datagen/datagen_trainer.cpp
@@ -215,7 +215,11 @@ int main(int argc, char **argv)
         try {
             fs::path trainerDataPath = dataRoot / (trainerStem + ".json");
             std::string json = ReadWholeFile(trainerDataPath);
-            doc.Parse(json.c_str(), json.length());
+            rapidjson::ParseResult ok = doc.Parse(json.c_str(), json.length());
+            if (!ok) {
+                ReportJsonError(ok, json, trainerDataPath);
+                std::exit(EXIT_FAILURE);
+            }
 
             TrainerHeader trdata = ParseTrainerData(doc);
             narc_pack_file_copy(trdataVFS, reinterpret_cast<unsigned char *>(&trdata), sizeof(trdata));

--- a/tools/datagen/datagen_trainer.cpp
+++ b/tools/datagen/datagen_trainer.cpp
@@ -212,20 +212,19 @@ int main(int argc, char **argv)
 
     rapidjson::Document doc;
     for (auto &trainerStem : trainerRegistry) {
-        try {
-            fs::path trainerDataPath = dataRoot / (trainerStem + ".json");
-            std::string json = ReadWholeFile(trainerDataPath);
-            rapidjson::ParseResult ok = doc.Parse(json.c_str(), json.length());
-            if (!ok) {
-                ReportJsonError(ok, json, trainerDataPath);
-                std::exit(EXIT_FAILURE);
-            }
+        fs::path trainerDataPath = dataRoot / (trainerStem + ".json");
+        std::string json = ReadWholeFile(trainerDataPath);
+        rapidjson::ParseResult ok = doc.Parse(json.c_str(), json.length());
+        if (!ok) {
+            ReportJsonError(ok, json, trainerDataPath);
+            std::exit(EXIT_FAILURE);
+        }
 
+        try {
             TrainerHeader trdata = ParseTrainerData(doc);
             narc_pack_file_copy(trdataVFS, reinterpret_cast<unsigned char *>(&trdata), sizeof(trdata));
             ParseAndPackParty(doc, static_cast<TrainerDataType>(trdata.monDataType), trdata.partySize, trpokeVFS);
-        } catch (std::exception &e) {
-            std::cerr << "exception parsing data file for " + trainerStem << std::endl;
+        } catch (const std::exception &e) {
             std::cerr << e.what() << std::endl;
             std::exit(EXIT_FAILURE);
         }

--- a/tools/devtools/gen_compile_commands.py
+++ b/tools/devtools/gen_compile_commands.py
@@ -255,6 +255,7 @@ datagen_cpp_commands = [
             f"-I{builddir}",  # metang-generated headers (constants)
             "-std=c++17",
             "-Wno-deprecated-declarations",
+            "-o",
             file.with_suffix(".o"),
             file.resolve(),
         ],

--- a/tools/json2bin/encdata_ex_elusive_rod.py
+++ b/tools/json2bin/encdata_ex_elusive_rod.py
@@ -14,10 +14,21 @@ input_path = pathlib.Path(sys.argv[1])
 output_path_species = pathlib.Path(sys.argv[2])
 output_path_tiles = pathlib.Path(sys.argv[3])
 
+try:
+    data = {}
+    with open(input_path, 'r', encoding='utf-8') as input_file:
+        data = json.load(input_file)
+except json.decoder.JSONDecodeError as e:
+    docLines = e.doc.splitlines()
+    startLine = max(e.lineno-2, 0)
+    endLine = min(e.lineno+1, len(docLines))
+    
+    errorLines = [f"{lineNum:>4} {line}" for lineNum, line in zip(list(range(startLine+1, endLine+1)), docLines[startLine : endLine])][ : endLine - startLine]
+    errorLineIndex = e.lineno - startLine - 1
+    errorLines[errorLineIndex] = errorLines[errorLineIndex][ : 5] + f"\033[31m{errorLines[errorLineIndex][5 : ]}\033[0m"
 
-data = {}
-with open(input_path, 'r', encoding='utf-8') as input_file:
-    data = json.load(input_file)
+    print(f"{input_path}:{e.lineno}:{e.colno}\033[31m error: \033[0m{e.msg}\n{'\n'.join(errorLines)}\n", file=sys.stderr)
+    sys.exit(1)
 data = data['elusive_rod_encounter']
 
 packables = bytearray([])

--- a/tools/json2bin/encdata_ex_great_marsh.py
+++ b/tools/json2bin/encdata_ex_great_marsh.py
@@ -15,10 +15,21 @@ output_path_natdex = pathlib.Path(sys.argv[2])
 output_path_local = pathlib.Path(sys.argv[3])
 output_path_coords = pathlib.Path(sys.argv[4])
 
-data = {}
-with open(input_path, 'r', encoding='utf-8') as input_file:
-    data = json.load(input_file)
+try:
+    data = {}
+    with open(input_path, 'r', encoding='utf-8') as input_file:
+        data = json.load(input_file)
+except json.decoder.JSONDecodeError as e:
+    docLines = e.doc.splitlines()
+    startLine = max(e.lineno-2, 0)
+    endLine = min(e.lineno+1, len(docLines))
+    
+    errorLines = [f"{lineNum:>4} {line}" for lineNum, line in zip(list(range(startLine+1, endLine+1)), docLines[startLine : endLine])][ : endLine - startLine]
+    errorLineIndex = e.lineno - startLine - 1
+    errorLines[errorLineIndex] = errorLines[errorLineIndex][ : 5] + f"\033[31m{errorLines[errorLineIndex][5 : ]}\033[0m"
 
+    print(f"{input_path}:{e.lineno}:{e.colno}\033[31m error: \033[0m{e.msg}\n{'\n'.join(errorLines)}\n", file=sys.stderr)
+    sys.exit(1)
 
 packables = bytearray([])
 for i in range(32):

--- a/tools/json2bin/encdata_ex_honey_trees.py
+++ b/tools/json2bin/encdata_ex_honey_trees.py
@@ -15,11 +15,21 @@ output_path_common = pathlib.Path(sys.argv[2])
 output_path_uncommon = pathlib.Path(sys.argv[3])
 output_path_rare = pathlib.Path(sys.argv[4])
 
+try:
+    data = {}
+    with open(input_path, 'r', encoding='utf-8') as input_file:
+        data = json.load(input_file)
+except json.decoder.JSONDecodeError as e:
+    docLines = e.doc.splitlines()
+    startLine = max(e.lineno-2, 0)
+    endLine = min(e.lineno+1, len(docLines))
+    
+    errorLines = [f"{lineNum:>4} {line}" for lineNum, line in zip(list(range(startLine+1, endLine+1)), docLines[startLine : endLine])][ : endLine - startLine]
+    errorLineIndex = e.lineno - startLine - 1
+    errorLines[errorLineIndex] = errorLines[errorLineIndex][ : 5] + f"\033[31m{errorLines[errorLineIndex][5 : ]}\033[0m"
 
-data = {}
-with open(input_path, 'r', encoding='utf-8') as input_file:
-    data = json.load(input_file)
-
+    print(f"{input_path}:{e.lineno}:{e.colno}\033[31m error: \033[0m{e.msg}\n{'\n'.join(errorLines)}\n", file=sys.stderr)
+    sys.exit(1)
 
 packables = bytearray([])
 for i in range(6):

--- a/tools/json2bin/encdata_ex_trophy_garden.py
+++ b/tools/json2bin/encdata_ex_trophy_garden.py
@@ -13,9 +13,21 @@ def as_species(s: str) -> bytes:
 input_path = pathlib.Path(sys.argv[1])
 output_path = pathlib.Path(sys.argv[2])
 
-data = {}
-with open(input_path, 'r', encoding='utf-8') as input_file:
-    data = json.load(input_file)
+try:
+    data = {}
+    with open(input_path, 'r', encoding='utf-8') as input_file:
+        data = json.load(input_file)
+except json.decoder.JSONDecodeError as e:
+    docLines = e.doc.splitlines()
+    startLine = max(e.lineno-2, 0)
+    endLine = min(e.lineno+1, len(docLines))
+    
+    errorLines = [f"{lineNum:>4} {line}" for lineNum, line in zip(list(range(startLine+1, endLine+1)), docLines[startLine : endLine])][ : endLine - startLine]
+    errorLineIndex = e.lineno - startLine - 1
+    errorLines[errorLineIndex] = errorLines[errorLineIndex][ : 5] + f"\033[31m{errorLines[errorLineIndex][5 : ]}\033[0m"
+
+    print(f"{input_path}:{e.lineno}:{e.colno}\033[31m error: \033[0m{e.msg}\n{'\n'.join(errorLines)}\n", file=sys.stderr)
+    sys.exit(1)
 
 packables = bytearray([])
 for i in range(16):

--- a/tools/json2bin/encounter.py
+++ b/tools/json2bin/encounter.py
@@ -34,9 +34,21 @@ def convert_water(encs: list) -> bytes:
 input_path = pathlib.Path(sys.argv[1])
 output_path = pathlib.Path(sys.argv[2])
 
-data = {}
-with open(input_path, 'r', encoding='utf-8') as input_file:
-    data = json.load(input_file)
+try:
+    data = {}
+    with open(input_path, 'r', encoding='utf-8') as input_file:
+        data = json.load(input_file)
+except json.decoder.JSONDecodeError as e:
+    docLines = e.doc.splitlines()
+    startLine = max(e.lineno-2, 0)
+    endLine = min(e.lineno+1, len(docLines))
+    
+    errorLines = [f"{lineNum:>4} {line}" for lineNum, line in zip(list(range(startLine+1, endLine+1)), docLines[startLine : endLine])][ : endLine - startLine]
+    errorLineIndex = e.lineno - startLine - 1
+    errorLines[errorLineIndex] = errorLines[errorLineIndex][ : 5] + f"\033[31m{errorLines[errorLineIndex][5 : ]}\033[0m"
+
+    print(f"{input_path}:{e.lineno}:{e.colno}\033[31m error: \033[0m{e.msg}\n{'\n'.join(errorLines)}\n", file=sys.stderr)
+    sys.exit(1)
 
 packables = bytearray([])
 packables.extend(u32(data['land_rate']))

--- a/tools/json2bin/event.py
+++ b/tools/json2bin/event.py
@@ -116,9 +116,21 @@ def parse_coord_events(coord_events: list[dict]) -> bytes:
 input_path = pathlib.Path(sys.argv[1])
 output_path = pathlib.Path(sys.argv[2])
 
-data = {}
-with open(input_path, "r", encoding="utf-8") as input_file:
-    data = json.load(input_file)
+try:
+    data = {}
+    with open(input_path, 'r', encoding='utf-8') as input_file:
+        data = json.load(input_file)
+except json.decoder.JSONDecodeError as e:
+    docLines = e.doc.splitlines()
+    startLine = max(e.lineno-2, 0)
+    endLine = min(e.lineno+1, len(docLines))
+    
+    errorLines = [f"{lineNum:>4} {line}" for lineNum, line in zip(list(range(startLine+1, endLine+1)), docLines[startLine : endLine])][ : endLine - startLine]
+    errorLineIndex = e.lineno - startLine - 1
+    errorLines[errorLineIndex] = errorLines[errorLineIndex][ : 5] + f"\033[31m{errorLines[errorLineIndex][5 : ]}\033[0m"
+
+    print(f"{input_path}:{e.lineno}:{e.colno}\033[31m error: \033[0m{e.msg}\n{'\n'.join(errorLines)}\n", file=sys.stderr)
+    sys.exit(1)
 
 packable = bytearray([])
 packable.extend(parse_bg_events(data["bg_events"]))

--- a/tools/json2bin/map_matrix.py
+++ b/tools/json2bin/map_matrix.py
@@ -27,9 +27,21 @@ def parse_matrix(data) -> bytes:
 input_path = pathlib.Path(sys.argv[1])
 output_path = pathlib.Path(sys.argv[2])
 
-data = {}
-with open(input_path, "r", encoding="utf-8") as input_file:
-    data = json.load(input_file)
+try:
+    data = {}
+    with open(input_path, 'r', encoding='utf-8') as input_file:
+        data = json.load(input_file)
+except json.decoder.JSONDecodeError as e:
+    docLines = e.doc.splitlines()
+    startLine = max(e.lineno-2, 0)
+    endLine = min(e.lineno+1, len(docLines))
+    
+    errorLines = [f"{lineNum:>4} {line}" for lineNum, line in zip(list(range(startLine+1, endLine+1)), docLines[startLine : endLine])][ : endLine - startLine]
+    errorLineIndex = e.lineno - startLine - 1
+    errorLines[errorLineIndex] = errorLines[errorLineIndex][ : 5] + f"\033[31m{errorLines[errorLineIndex][5 : ]}\033[0m"
+
+    print(f"{input_path}:{e.lineno}:{e.colno}\033[31m error: \033[0m{e.msg}\n{'\n'.join(errorLines)}\n", file=sys.stderr)
+    sys.exit(1)
 
 with open(output_path, "wb") as output_file:
     output_file.write(parse_matrix(data))

--- a/tools/json2bin/npc_trades.py
+++ b/tools/json2bin/npc_trades.py
@@ -32,9 +32,21 @@ def parse_npc_trade(data) -> bytes:
 input_path = pathlib.Path(sys.argv[1])
 output_path = pathlib.Path(sys.argv[2])
 
-data = {}
-with open(input_path, "r", encoding="utf-8") as input_file:
-    data = json.load(input_file)
+try:
+    data = {}
+    with open(input_path, 'r', encoding='utf-8') as input_file:
+        data = json.load(input_file)
+except json.decoder.JSONDecodeError as e:
+    docLines = e.doc.splitlines()
+    startLine = max(e.lineno-2, 0)
+    endLine = min(e.lineno+1, len(docLines))
+    
+    errorLines = [f"{lineNum:>4} {line}" for lineNum, line in zip(list(range(startLine+1, endLine+1)), docLines[startLine : endLine])][ : endLine - startLine]
+    errorLineIndex = e.lineno - startLine - 1
+    errorLines[errorLineIndex] = errorLines[errorLineIndex][ : 5] + f"\033[31m{errorLines[errorLineIndex][5 : ]}\033[0m"
+
+    print(f"{input_path}:{e.lineno}:{e.colno}\033[31m error: \033[0m{e.msg}\n{'\n'.join(errorLines)}\n", file=sys.stderr)
+    sys.exit(1)
 
 with open(output_path, "wb") as output_file:
     output_file.write(parse_npc_trade(data))

--- a/tools/scripts/make_pl_pokezukan.py
+++ b/tools/scripts/make_pl_pokezukan.py
@@ -3,6 +3,7 @@ import argparse
 import json
 import pathlib
 import subprocess
+import sys
 
 from generated.species import Species
 
@@ -37,10 +38,22 @@ NUM_POKEMON = 494
 
 pokedex = [0 for i in range(NUM_POKEMON)]
 
-with open(args.pokedex) as data_file:
-    dex_data = json.load(data_file)
-    for i, mon in enumerate(dex_data):
-        pokedex[Species[mon].value] = i
+try:
+    with open(args.pokedex) as data_file:
+        dex_data = json.load(data_file)
+        for i, mon in enumerate(dex_data):
+            pokedex[Species[mon].value] = i
+except json.decoder.JSONDecodeError as e:
+    docLines = e.doc.splitlines()
+    startLine = max(e.lineno-2, 0)
+    endLine = min(e.lineno+1, len(docLines))
+    
+    errorLines = [f"{lineNum:>4} {line}" for lineNum, line in zip(list(range(startLine+1, endLine+1)), docLines[startLine : endLine])][ : endLine - startLine]
+    errorLineIndex = e.lineno - startLine - 1
+    errorLines[errorLineIndex] = errorLines[errorLineIndex][ : 5] + f"\033[31m{errorLines[errorLineIndex][5 : ]}\033[0m"
+
+    print(f"{args.pokedex}:{e.lineno}:{e.colno}\033[31m error: \033[0m{e.msg}\n{'\n'.join(errorLines)}\n", file=sys.stderr)
+    sys.exit(1)
 
 target_fname = private_dir / 'pl_pokezukan_0.bin'
 with open(target_fname, 'wb+') as target_file:

--- a/tools/scripts/make_shinzukan.py
+++ b/tools/scripts/make_shinzukan.py
@@ -3,6 +3,7 @@ import argparse
 import json
 import pathlib
 import subprocess
+import sys
 
 from generated.species import Species
 
@@ -37,10 +38,22 @@ NUM_SINNOH = 211
 
 pokedex = [0 for i in range(NUM_SINNOH)]
 
-with open(args.pokedex) as data_file:
-    dex_data = json.load(data_file)
-    for i, mon in enumerate(dex_data):
-        pokedex[i] = Species[mon].value
+try:
+    with open(args.pokedex) as data_file:
+        dex_data = json.load(data_file)
+        for i, mon in enumerate(dex_data):
+            pokedex[i] = Species[mon].value
+except json.decoder.JSONDecodeError as e:
+    docLines = e.doc.splitlines()
+    startLine = max(e.lineno-2, 0)
+    endLine = min(e.lineno+1, len(docLines))
+    
+    errorLines = [f"{lineNum:>4} {line}" for lineNum, line in zip(list(range(startLine+1, endLine+1)), docLines[startLine : endLine])][ : endLine - startLine]
+    errorLineIndex = e.lineno - startLine - 1
+    errorLines[errorLineIndex] = errorLines[errorLineIndex][ : 5] + f"\033[31m{errorLines[errorLineIndex][5 : ]}\033[0m"
+
+    print(f"{args.pokedex}:{e.lineno}:{e.colno}\033[31m error: \033[0m{e.msg}\n{'\n'.join(errorLines)}\n", file=sys.stderr)
+    sys.exit(1)
 
 target_fname = private_dir / 'shinzukan_0.bin'
 with open(target_fname, 'wb+') as target_file:


### PR DESCRIPTION
Added exception handling to most instances of `json.load()` to improve the signal-to-noise ratio of error messages for incorrectly formatted json files.

json formatting errors now look like this:
![Screenshot_20250427_143915](https://github.com/user-attachments/assets/ef2479ff-ffa0-4be5-b020-43191850cf30)
