### PR TITLE
Change param type to `enum PaletteLoadLocation` where appropriate

### DIFF
--- a/include/field_message.h
+++ b/include/field_message.h
@@ -3,9 +3,10 @@
 
 #include "bg_window.h"
 #include "game_options.h"
+#include "graphics.h"
 #include "strbuf.h"
 
-void FieldMessage_LoadTextPalettes(u32 palLocation, u32 resetPrinters);
+void FieldMessage_LoadTextPalettes(enum PaletteLoadLocation palLocation, u32 resetPrinters);
 void FieldMessage_AddWindow(BgConfig *bgConfig, Window *window, u32 bgLayer);
 void FieldMessage_DrawWindow(Window *window, const Options *options);
 void FieldMessage_ClearWindow(Window *window);

--- a/include/font.h
+++ b/include/font.h
@@ -2,6 +2,7 @@
 #define POKEPLATINUM_FONT_H
 
 #include "charcode.h"
+#include "graphics.h"
 #include "render_text.h"
 #include "strbuf.h"
 
@@ -55,8 +56,8 @@ u32 Font_CalcStringWidth(enum Font font, const charcode_t *str, u32 letterSpacin
 u32 Font_CalcStrbufWidth(enum Font font, const Strbuf *strbuf, u32 letterSpacing);
 u32 Font_AreAllCharsValid(enum Font font, Strbuf *strbuf, Strbuf *tmpbuf);
 u8 Font_GetAttribute(u8 font, u8 attribute);
-void Font_LoadTextPalette(int palLocation, u32 palSlotOffset, u32 heapID);
-void Font_LoadScreenIndicatorsPalette(int palLocation, u32 palSlotOffset, u32 heapID);
+void Font_LoadTextPalette(enum PaletteLoadLocation palLocation, u32 palSlotOffset, u32 heapID);
+void Font_LoadScreenIndicatorsPalette(enum PaletteLoadLocation palLocation, u32 palSlotOffset, u32 heapID);
 u32 Font_CalcMaxLineWidth(enum Font font, const Strbuf *strbuf, u32 letterSpacing);
 u32 Font_CalcCenterAlignment(enum Font font, const Strbuf *strbuf, u32 letterSpacing, u32 windowWidth);
 u32 Font_CalcStringWidthWithCursorControl(enum Font font, const Strbuf *strbuf);

--- a/src/applications/journal_display/journal_controller.c
+++ b/src/applications/journal_display/journal_controller.c
@@ -298,7 +298,7 @@ static void JournalController_LoadGraphics(JournalManager *journalManager)
     MI_CpuCopy16(tilemapBuffer, journalManager->tilemapBuffer_5C, 0x800);
     Bg_LoadTilemapBuffer(journalManager->bgConfig, 3, journalManager->tilemapBuffer_5C, 0x800);
 
-    Font_LoadTextPalette(0, 15 * 32, HEAP_ID_JOURNAL);
+    Font_LoadTextPalette(PAL_LOAD_MAIN_BG, 15 * 32, HEAP_ID_JOURNAL);
     Bg_MaskPalette(4, 0);
 }
 

--- a/src/applications/pokemon_summary_screen/main.c
+++ b/src/applications/pokemon_summary_screen/main.c
@@ -986,7 +986,7 @@ static int SetupPoffinFeedConditionPage(PokemonSummaryScreen *summaryScreen)
             Heap_FreeToHeap(mon);
         }
 
-        Font_LoadScreenIndicatorsPalette(0, PLTT_OFFSET(14), HEAP_ID_POKEMON_SUMMARY_SCREEN);
+        Font_LoadScreenIndicatorsPalette(PAL_LOAD_MAIN_BG, PLTT_OFFSET(14), HEAP_ID_POKEMON_SUMMARY_SCREEN);
         LoadMessageBoxGraphics(summaryScreen->bgConfig, BG_LAYER_MAIN_1, (1024 - (18 + 12)), 13, Options_Frame(summaryScreen->data->options), HEAP_ID_POKEMON_SUMMARY_SCREEN);
 
         if (summaryScreen->pageState == STAT_INCREASE_NONE) {
@@ -2171,7 +2171,7 @@ u8 PokemonSummaryScreen_RibbonIDAt(PokemonSummaryScreen *summaryScreen, u8 col)
 static int TryFeedPoffin(PokemonSummaryScreen *summaryScreen)
 {
     if (summaryScreen->monData.sheen == MAX_POKEMON_SHEEN) {
-        Font_LoadScreenIndicatorsPalette(0, PLTT_OFFSET(14), HEAP_ID_POKEMON_SUMMARY_SCREEN);
+        Font_LoadScreenIndicatorsPalette(PAL_LOAD_MAIN_BG, PLTT_OFFSET(14), HEAP_ID_POKEMON_SUMMARY_SCREEN);
         LoadMessageBoxGraphics(summaryScreen->bgConfig, BG_LAYER_MAIN_1, (1024 - (18 + 12)), 13, Options_Frame(summaryScreen->data->options), HEAP_ID_POKEMON_SUMMARY_SCREEN);
         PokemonSummaryScreen_PrintPoffinFeedMsg(summaryScreen, SUMMARY_MSG_MON_WONT_EAT_MORE);
         summaryScreen->data->returnMode = SUMMARY_RETURN_CANCEL;

--- a/src/error_message_reset.c
+++ b/src/error_message_reset.c
@@ -11,6 +11,7 @@
 #include "brightness_controller.h"
 #include "communication_system.h"
 #include "font.h"
+#include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
 #include "main.h"
@@ -133,7 +134,7 @@ void ErrorMessageReset_PrintErrorAndReset(void)
     Bg_InitFromTemplate(bgConfig, 0, &sErrorMessageBgTemplate, 0);
     Bg_ClearTilemap(bgConfig, 0);
     LoadStandardWindowGraphics(bgConfig, 0, (512 - 9), 2, 0, heapID);
-    Font_LoadTextPalette(0, 1 * (2 * 16), heapID);
+    Font_LoadTextPalette(PAL_LOAD_MAIN_BG, 1 * (2 * 16), heapID);
     Bg_ClearTilesRange(0, 32, 0, heapID);
     Bg_MaskPalette(0, 0x6c21);
     Bg_MaskPalette(4, 0x6c21);

--- a/src/field_message.c
+++ b/src/field_message.c
@@ -14,7 +14,7 @@
 #include "strbuf.h"
 #include "text.h"
 
-void FieldMessage_LoadTextPalettes(u32 palLocation, u32 resetPrinters)
+void FieldMessage_LoadTextPalettes(enum PaletteLoadLocation palLocation, u32 resetPrinters)
 {
     if (resetPrinters == TRUE) {
         Text_ResetAllPrinters();

--- a/src/font.c
+++ b/src/font.c
@@ -231,7 +231,7 @@ u8 Font_GetAttribute(u8 font, u8 attribute)
     return result;
 }
 
-void Font_LoadTextPalette(int palLocation, u32 palSlotOffset, u32 heapID)
+void Font_LoadTextPalette(enum PaletteLoadLocation palLocation, u32 palSlotOffset, u32 heapID)
 {
     Graphics_LoadPalette(NARC_INDEX_GRAPHIC__PL_FONT,
         font_NCLR,
@@ -241,7 +241,7 @@ void Font_LoadTextPalette(int palLocation, u32 palSlotOffset, u32 heapID)
         heapID);
 }
 
-void Font_LoadScreenIndicatorsPalette(int palLocation, u32 palSlotOffset, u32 heapID)
+void Font_LoadScreenIndicatorsPalette(enum PaletteLoadLocation palLocation, u32 palSlotOffset, u32 heapID)
 {
     Graphics_LoadPalette(NARC_INDEX_GRAPHIC__PL_FONT,
         screen_indicators_NCLR,

--- a/src/library_tv/library_tv.c
+++ b/src/library_tv/library_tv.c
@@ -223,7 +223,7 @@ static void LibraryTV_SetVramBank(LibraryTV *ltv)
     Graphics_LoadTilemapToBgLayer(NARC_INDEX_GRAPHIC__LIBRARY_TV, screenID, ltv->bgl, frame, 0, 0, 0, ltv->heapID);
 
     Graphics_LoadPalette(NARC_INDEX_GRAPHIC__LIBRARY_TV, 3, 0, 0, 0, ltv->heapID);
-    Font_LoadTextPalette(0, 1 * (2 * 16), ltv->heapID);
+    Font_LoadTextPalette(PAL_LOAD_MAIN_BG, 1 * (2 * 16), ltv->heapID);
     Bg_MaskPalette(0, 0x0);
     Bg_MaskPalette(4, 0x0);
 

--- a/src/overlay005/fieldmap.c
+++ b/src/overlay005/fieldmap.c
@@ -60,6 +60,7 @@
 #include "field_system.h"
 #include "field_task.h"
 #include "game_overlay.h"
+#include "graphics.h"
 #include "gx_layers.h"
 #include "heap.h"
 #include "inlines.h"
@@ -199,7 +200,7 @@ static BOOL FieldMap_Init(OverlayManager *overlayMan, int *param1)
         GXLayers_SwapDisplay();
         fieldSystem->bgConfig = BgConfig_New(HEAP_ID_FIELD);
         ov5_021D1444(fieldSystem->bgConfig);
-        FieldMessage_LoadTextPalettes(0, TRUE);
+        FieldMessage_LoadTextPalettes(PAL_LOAD_MAIN_BG, TRUE);
         sub_0203F5C0(fieldSystem, 4);
         break;
     case 1:


### PR DESCRIPTION
Changes the type of parameter `palLocation` of `Font_LoadTextPalette`, `Font_LoadScreenIndicatorsPalette` and `FieldMessage_LoadTextPalettes` to `enum PaletteLoadLocation`. Afaict, these were the only remaining functions passing their argument to one of the `Graphics_LoadPalette...` without it being properly typed.

Also replaces instances of literals passed to these with the appropriate enum variant in already "fully" documented functions. Lmk if you'd like them to be replaced everywhere instead, I really only stuck to the already documented stuff to avoid merge conflicts, and it should be trivially automatable so it wouldn't be a lot of extra work.