### PR TITLE
docs(install): on debian/ubuntu, install nasm

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -208,7 +208,7 @@ the repository](#2-downloading-the-repository).
 2. Install the following packages via `apt`:
 
     ```bash
-    sudo apt install bison flex g++ gcc-arm-none-eabi git make ninja-build pkg-config wget python3 xz-utils libc6:i386
+    sudo apt install bison flex g++ gcc-arm-none-eabi git make ninja-build pkg-config wget python3 xz-utils nasm libc6:i386
     ```
 
 #### Arch Linux (and derivatives, e.g., Manjaro, Endeavour)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -211,6 +211,12 @@ the repository](#2-downloading-the-repository).
     sudo apt install bison flex g++ gcc-arm-none-eabi git make ninja-build pkg-config wget python3 xz-utils nasm libc6:i386
     ```
 
+3. Install `meson` via `pip3`:
+
+    ```bash
+    pip3 install --user meson --break-system-packages
+    ```
+
 #### Arch Linux (and derivatives, e.g., Manjaro, Endeavour)
 
 1. Enable the [multilib repository](https://wiki.archlinux.org/title/Multilib).


### PR DESCRIPTION
i needed to install `nasm` on pop!_os 24.04 (based off ubuntu 24.04) in order to be able to run `make`.

in addition, add a note to install meson via pip3 (pop has an outdated version of meson)