### PR TITLE
save_data: adding explicit padding to PlayerSave

### DIFF
--- a/include/save_player.h
+++ b/include/save_player.h
@@ -7,7 +7,8 @@
 #include "trainer_info.h"
 
 typedef struct PlayerSave {
-    Options options;
+    Options options; // u16 bitfield
+    u8 padding_02[2];
     TrainerInfo info;
     u16 coins;
     PlayTime playTime;

--- a/include/save_player.h
+++ b/include/save_player.h
@@ -8,7 +8,7 @@
 
 typedef struct PlayerSave {
     Options options; // u16 bitfield
-    u8 padding_02[2];
+    // u8 padding_02[2]; // implicit padding in vanilla
     TrainerInfo info;
     u16 coins;
     PlayTime playTime;


### PR DESCRIPTION
via #562 : `Options` is a u16 so there's 2 bytes of padding after for alignment