### PR TITLE
Delete build resource folder to prevent artifacts from polluting builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ target: $(BUILD)/build.ninja
 
 clean: $(BUILD)/build.ninja
 	$(MESON) compile -C $(BUILD) --clean
+	rm -rf $(BUILD)/res
 
 distclean:
 	rm -rf $(BUILD)


### PR DESCRIPTION
Suggested by @Gudf and @lhearachel 