### PR TITLE
Update pokeradar.c for "unk_BC"

### DIFF
--- a/src/pokeradar.c
+++ b/src/pokeradar.c
@@ -49,7 +49,7 @@ typedef struct RadarChain {
     BOOL unk_14;
     BOOL unk_18;
     GrassPatch patch[NUM_GRASS_PATCHES];
-    GFXTestBox unk_BC;
+    GFXTestBox grassView;
     u8 unk_D0;
 } RadarChain;
 
@@ -64,7 +64,7 @@ static void IncWithCap(int *param0);
 RadarChain *RadarChain_Init(const int heapID)
 {
     RadarChain *chain = Heap_AllocFromHeap(heapID, sizeof(RadarChain));
-    GFXBoxTest_MakeBox(FX32_ONE * 16, FX32_ONE * 8, FX32_ONE * 16, &chain->unk_BC);
+    GFXBoxTest_MakeBox(FX32_ONE * 16, FX32_ONE * 8, FX32_ONE * 16, &chain->grassView);
     return chain;
 }
 
@@ -274,7 +274,7 @@ void sub_0206979C(FieldSystem *fieldSystem)
 
     for (patchRing = 0; patchRing < NUM_GRASS_PATCHES; patchRing++) {
         patch = &(fieldSystem->chain->patch[patchRing]);
-        v0 = GFXBoxTest_IsBoxAtPositionInView(&(patch->position), &(fieldSystem->chain->unk_BC));
+        v0 = GFXBoxTest_IsBoxAtPositionInView(&(patch->position), &(fieldSystem->chain->grassView));
         if (patch->active && !v0) {
             patch->active = FALSE;
         }


### PR DESCRIPTION
Replaced GFXTestBox name "unk_BC" with "grassView"; suggested due to the GFXTestBox being used to determine if a patch is in the given GFXTestBox; it seems as though any patch that isn't within the bounds that is selected to be active is rendered inactive. Hence the name. (Apologies if this is inaccurate in any way; I do not wish to make more work. I am trying VERY HARD to suggest a thing that, if it would be an issue, won't BREAK THE BUILD. If my analysis is wrong feel free to let me know! I just want to help a little.)