### PR TITLE
Fix Incorrect Names in Rowan Intro

### DIFF
--- a/platinum.us/main.lsf
+++ b/platinum.us/main.lsf
@@ -1263,7 +1263,7 @@ Overlay rowan_intro
 {
 	After main
 	Object main.nef.p/src_applications_rowan_intro_rowan_intro_app.c.o
-	Object main.nef.p/src_applications_rowan_intro_keyboard_app.c.o
+	Object main.nef.p/src_applications_rowan_intro_tv_app.c.o
 }
 
 Overlay options_menu

--- a/src/applications/rowan_intro/rowan_intro_app.c
+++ b/src/applications/rowan_intro/rowan_intro_app.c
@@ -292,10 +292,9 @@ static void RowanIntro_LoadTilemap(RowanIntro *manager);
 static void RowanIntro_LoadSubLayer3Tilemap(RowanIntro *manager);
 static BOOL RowanIntro_Run(RowanIntro *manager);
 
-// Keyboard application Init,Main,Exit
-int ov73_021D3250(ApplicationManager *appMan, int *state);
-int ov73_021D3280(ApplicationManager *appMan, int *state);
-int ov73_021D3404(ApplicationManager *appMan, int *state);
+int RowanIntroTv_Init(ApplicationManager *appMan, int *state);
+int RowanIntroTv_Main(ApplicationManager *appMan, int *state);
+int RowanIntroTv_Exit(ApplicationManager *appMan, int *state);
 
 const ApplicationManagerTemplate sDummyApplicationManagerTemplate = {
     RowanIntro_Init,
@@ -304,10 +303,10 @@ const ApplicationManagerTemplate sDummyApplicationManagerTemplate = {
     FS_OVERLAY_ID_NONE,
 };
 
-static const ApplicationManagerTemplate sKeyboardApplicationTemplate = {
-    ov73_021D3250,
-    ov73_021D3280,
-    ov73_021D3404,
+static const ApplicationManagerTemplate sTvApplicationTemplate = {
+    RowanIntroTv_Init,
+    RowanIntroTv_Main,
+    RowanIntroTv_Exit,
     FS_OVERLAY_ID_NONE,
 };
 
@@ -2991,7 +2990,7 @@ static BOOL RowanIntro_Run(RowanIntro *manager)
         break;
     case RI_STATE_END:
         manager->appMan = ApplicationManager_New(
-            &sKeyboardApplicationTemplate,
+            &sTvApplicationTemplate,
             NULL,
             manager->heapID);
         manager->state = RI_STATE_EXIT;

--- a/src/applications/rowan_intro/tv_app.c
+++ b/src/applications/rowan_intro/tv_app.c
@@ -29,9 +29,9 @@ typedef struct {
 } UnkStruct_ov73_021D342C;
 
 void EnqueueApplication(FSOverlayID param0, const ApplicationManagerTemplate *param1);
-int ov73_021D3250(ApplicationManager *appMan, int *param1);
-int ov73_021D3280(ApplicationManager *appMan, int *param1);
-int ov73_021D3404(ApplicationManager *appMan, int *param1);
+int RowanIntroTv_Init(ApplicationManager *appMan, int *param1);
+int RowanIntroTv_Main(ApplicationManager *appMan, int *param1);
+int RowanIntroTv_Exit(ApplicationManager *appMan, int *param1);
 static void ov73_021D3420(void *param0);
 static void ov73_021D342C(UnkStruct_ov73_021D342C *param0);
 static void ov73_021D35F4(UnkStruct_ov73_021D342C *param0);
@@ -40,7 +40,7 @@ static void ov73_021D368C(UnkStruct_ov73_021D342C *param0);
 static BOOL ov73_021D3698(UnkStruct_ov73_021D342C *param0, int param1, int param2, int param3);
 static void ov73_021D37AC(UnkStruct_ov73_021D342C *param0);
 
-int ov73_021D3250(ApplicationManager *appMan, int *param1)
+int RowanIntroTv_Init(ApplicationManager *appMan, int *param1)
 {
     UnkStruct_ov73_021D342C *v0;
     int heapID = HEAP_ID_83;
@@ -56,7 +56,7 @@ int ov73_021D3250(ApplicationManager *appMan, int *param1)
     return 1;
 }
 
-int ov73_021D3280(ApplicationManager *appMan, int *param1)
+int RowanIntroTv_Main(ApplicationManager *appMan, int *param1)
 {
     UnkStruct_ov73_021D342C *v0 = ApplicationManager_Data(appMan);
     int v1 = 0;
@@ -142,7 +142,7 @@ int ov73_021D3280(ApplicationManager *appMan, int *param1)
     return v1;
 }
 
-int ov73_021D3404(ApplicationManager *appMan, int *param1)
+int RowanIntroTv_Exit(ApplicationManager *appMan, int *param1)
 {
     UnkStruct_ov73_021D342C *v0 = ApplicationManager_Data(appMan);
     int heapID = v0->heapID;

--- a/src/meson.build
+++ b/src/meson.build
@@ -803,7 +803,7 @@ pokeplatinum_c = files(
     'overlay071/ov71_0223D324.c',
     'overlay072/ov72_0223D7A0.c',
     'applications/rowan_intro/rowan_intro_app.c',
-    'applications/rowan_intro/keyboard_app.c',
+    'applications/rowan_intro/tv_app.c',
     'applications/options_menu.c',
     'overlay075/ov75_021D0D80.c',
     'overlay076/ov76_0223B140.c',


### PR DESCRIPTION
I mistook which application template was being used where, and thought that the other file in overlay 73 was the keyboard app, but it is the TV that is shown at the end of the intro. This fixes the incorrect naming where it exists.

PR documenting the TV app will follow later (in a day or two or a week).