### PR TITLE
Document script_manager

### DIFF
--- a/include/map_header_data.h
+++ b/include/map_header_data.h
@@ -86,7 +86,7 @@ BOOL MapHeaderData_SetWarpEventDestWarpID(FieldSystem *fieldSystem, u16 index, u
 BOOL MapHeaderData_SetBgEventPos(FieldSystem *fieldSystem, u16 index, u16 x, u16 z);
 void MapHeaderData_LoadWildEncounters(WildEncounters *encounterData, int headerID);
 const WildEncounters *MapHeaderData_GetWildEncounters(const FieldSystem *fieldSystem);
-const u8 *MapHeaderData_GetInitScripts(const FieldSystem *fieldSystem);
+const u8 *MapHeaderData_GetInitScriptBytes(const FieldSystem *fieldSystem);
 BOOL MapHeaderData_IsAnyObjectEventAtPos(const FieldSystem *fieldSystem, u16 x, u16 z);
 
 #endif // POKEPLATINUM_MAP_HEADER_DATA_H

--- a/include/script_manager.h
+++ b/include/script_manager.h
@@ -100,6 +100,11 @@ enum ScriptContextType {
 
 #define SCRIPT_MANAGER_MAGIC_NUMBER 0x3643F
 
+#define INIT_SCRIPT_TYPE_FIRST_MATCH 1
+#define INIT_SCRIPT_TYPE_FIXED_UNK_2 2
+#define INIT_SCRIPT_TYPE_FIXED_UNK_3 3
+#define INIT_SCRIPT_TYPE_FIXED_UNK_4 4
+
 typedef void (*FieldSysFunc)(FieldSystem *);
 
 typedef struct ApproachingTrainer {
@@ -153,10 +158,10 @@ void ScriptManager_Change(FieldTask *taskManager, u16 scriptID, MapObject *objec
 ScriptContext *ScriptContext_CreateAndStart(FieldSystem *fieldSystem, u16 scriptID);
 void *ScriptManager_GetMemberPtr(ScriptManager *scriptManager, u32 member);
 void *FieldSystem_GetScriptMemberPtr(FieldSystem *fieldSystem, u32 member);
-void sub_0203F0C0(FieldSystem *fieldSystem);
+void FieldSystem_ShowStartMenu(FieldSystem *fieldSystem);
 u16 *FieldSystem_GetVarPointer(FieldSystem *fieldSystem, u16 varID);
 u16 FieldSystem_TryGetVar(FieldSystem *fieldSystem, u16 varID);
-u16 sub_0203F164(FieldSystem *fieldSystem, u16 param1);
+u16 FieldSystem_GetGraphicsID(FieldSystem *fieldSystem, u16 param1);
 BOOL FieldSystem_CheckFlag(FieldSystem *fieldSystem, u16 flagID);
 void FieldSystem_SetFlag(FieldSystem *fieldSystem, u16 flagID);
 void FieldSystem_ClearFlag(FieldSystem *fieldSystem, u16 flagID);
@@ -176,6 +181,6 @@ u8 Script_GetHiddenItemRange(u16 scriptID);
 UnkStruct_0203F478 *sub_0203F478(FieldSystem *fieldSystem, int heapID);
 void FieldSystem_InitNewGameState(FieldSystem *fieldSystem);
 void FieldSystem_RunScript(FieldSystem *fieldSystem, u16 scriptID);
-BOOL sub_0203F5C0(FieldSystem *fieldSystem, u8 param1);
+BOOL FieldSystem_RunInitScript(FieldSystem *fieldSystem, u8 param1);
 
 #endif // POKEPLATINUM_SCRIPT_MANAGER_H

--- a/include/start_menu.h
+++ b/include/start_menu.h
@@ -11,7 +11,7 @@ BOOL sub_0203A9C8(FieldSystem *fieldSystem);
 void StartMenu_Init(struct FieldSystem_t *fieldSystem);
 void sub_0203AA78(struct FieldSystem_t *fieldSystem);
 void sub_0203AABC(FieldSystem *fieldSystem);
-void sub_0203AB00(FieldSystem *fieldSystem);
+void StartMenu_Open(FieldSystem *fieldSystem);
 void sub_0203B674(StartMenu *param0, void *param1);
 BOOL sub_0203B7C0(FieldTask *param0);
 BOOL sub_0203C3F4(FieldTask *param0);

--- a/src/field_map_change.c
+++ b/src/field_map_change.c
@@ -285,7 +285,7 @@ void FieldMapChange_UpdateGameData(FieldSystem *fieldSystem, BOOL noWarp)
         }
     }
 
-    sub_0203F5C0(fieldSystem, 2);
+    FieldSystem_RunInitScript(fieldSystem, INIT_SCRIPT_TYPE_FIXED_UNK_2);
 
     fieldSystem->wildBattleMetadata.encounterAttempts = 0;
     fieldSystem->wildBattleMetadata.wildMonDefeated = 0;
@@ -1362,7 +1362,7 @@ static BOOL sub_02054494(FieldTask *task)
         break;
     case 1:
         FieldMapChange_SetNewLocation(fieldSystem, &mapChangeSub->nextLocation);
-        sub_0203F5C0(fieldSystem, 2);
+        FieldSystem_RunInitScript(fieldSystem, INIT_SCRIPT_TYPE_FIXED_UNK_2);
         mapChangeSub->state++;
         break;
     case 2:

--- a/src/map_header_data.c
+++ b/src/map_header_data.c
@@ -239,7 +239,7 @@ static void MapHeaderData_LoadInitScripts(MapHeaderData *data, int headerID)
     NARC_ReadWholeMemberByIndexPair(data->initScripts, NARC_INDEX_FIELDDATA__SCRIPT__SCR_SEQ, initScriptsID);
 }
 
-const u8 *MapHeaderData_GetInitScripts(const FieldSystem *fieldSystem)
+const u8 *MapHeaderData_GetInitScriptBytes(const FieldSystem *fieldSystem)
 {
     GF_ASSERT(fieldSystem->mapHeaderData != NULL);
     return (const u8 *)&fieldSystem->mapHeaderData->initScripts;

--- a/src/map_object.c
+++ b/src/map_object.c
@@ -130,7 +130,7 @@ static MapObject *sub_020624CC(const MapObjectManager *mapObjMan, int localID, i
 static void sub_02062604(MapObject *mapObj);
 static void sub_02062618(MapObject *mapObj);
 static void sub_02062628(MapObject *mapObj);
-static int sub_0206262C(FieldSystem *fieldSystem, int param1);
+static int MapObject_GetFieldSystemGraphicsID(FieldSystem *fieldSystem, int param1);
 static void sub_02062648(MapObject *mapObj);
 static void sub_02062660(MapObject *mapObj);
 static void sub_02062670(MapObject *mapObj);
@@ -692,7 +692,7 @@ static void MapObjectMan_AddMoveTask(const MapObjectManager *mapObjMan, MapObjec
 static void sub_020621E8(MapObject *mapObj, const ObjectEvent *objectEvent, FieldSystem *fieldSystem)
 {
     MapObject_SetLocalID(mapObj, ObjectEvent_GetLocalID(objectEvent));
-    MapObject_SetGraphicsID(mapObj, sub_0206262C(fieldSystem, ObjectEvent_GetGraphicsID(objectEvent)));
+    MapObject_SetGraphicsID(mapObj, MapObject_GetFieldSystemGraphicsID(fieldSystem, ObjectEvent_GetGraphicsID(objectEvent)));
     MapObject_SetMovementType(mapObj, ObjectEvent_GetMovementType(objectEvent));
     MapObject_SetTrainerType(mapObj, ObjectEvent_GetTrainerType(objectEvent));
     MapObject_SetFlag(mapObj, ObjectEvent_GetFlag(objectEvent));
@@ -907,11 +907,11 @@ static void sub_02062628(MapObject *mapObj)
     (void)0;
 }
 
-static int sub_0206262C(FieldSystem *fieldSystem, int graphicsID)
+static int MapObject_GetFieldSystemGraphicsID(FieldSystem *fieldSystem, int graphicsID)
 {
     if (graphicsID >= 0x65 && graphicsID <= 0x74) {
         graphicsID -= 0x65;
-        graphicsID = sub_0203F164(fieldSystem, graphicsID);
+        graphicsID = FieldSystem_GetGraphicsID(fieldSystem, graphicsID);
     }
 
     return graphicsID;

--- a/src/overlay005/field_control.c
+++ b/src/overlay005/field_control.c
@@ -174,7 +174,7 @@ void FieldInput_Update(FieldInput *input, FieldSystem *fieldSystem, u16 pressedK
 
 BOOL FieldInput_Process(const FieldInput *input, FieldSystem *fieldSystem)
 {
-    if (input->dummy5 == FALSE && sub_0203F5C0(fieldSystem, 1) == TRUE) {
+    if (input->dummy5 == FALSE && FieldSystem_RunInitScript(fieldSystem, INIT_SCRIPT_TYPE_FIRST_MATCH) == TRUE) {
         return TRUE;
     }
 
@@ -359,7 +359,7 @@ static BOOL Field_CheckSign(FieldSystem *fieldSystem)
 
 BOOL FieldInput_Process_Underground(FieldInput *input, FieldSystem *fieldSystem)
 {
-    if (input->dummy5 == FALSE && sub_0203F5C0(fieldSystem, 1) == TRUE) {
+    if (input->dummy5 == FALSE && FieldSystem_RunInitScript(fieldSystem, INIT_SCRIPT_TYPE_FIRST_MATCH) == TRUE) {
         return TRUE;
     }
 
@@ -488,7 +488,7 @@ BOOL FieldInput_Process_UnionRoom(const FieldInput *input, FieldSystem *fieldSys
 
 int FieldInput_Process_BattleTower(const FieldInput *input, FieldSystem *fieldSystem)
 {
-    if (input->dummy5 == FALSE && sub_0203F5C0(fieldSystem, 1) == TRUE) {
+    if (input->dummy5 == FALSE && FieldSystem_RunInitScript(fieldSystem, INIT_SCRIPT_TYPE_FIRST_MATCH) == TRUE) {
         return TRUE;
     }
 

--- a/src/overlay005/fieldmap.c
+++ b/src/overlay005/fieldmap.c
@@ -200,7 +200,7 @@ static BOOL FieldMap_Init(ApplicationManager *appMan, int *param1)
         fieldSystem->bgConfig = BgConfig_New(HEAP_ID_FIELD);
         ov5_021D1444(fieldSystem->bgConfig);
         FieldMessage_LoadTextPalettes(PAL_LOAD_MAIN_BG, TRUE);
-        sub_0203F5C0(fieldSystem, 4);
+        FieldSystem_RunInitScript(fieldSystem, INIT_SCRIPT_TYPE_FIXED_UNK_4);
         break;
     case 1:
         ov5_021D1790(fieldSystem);
@@ -219,7 +219,7 @@ static BOOL FieldMap_Init(ApplicationManager *appMan, int *param1)
         }
 
         sub_020556A0(fieldSystem, fieldSystem->location->mapId);
-        sub_0203F5C0(fieldSystem, 3);
+        FieldSystem_RunInitScript(fieldSystem, INIT_SCRIPT_TYPE_FIXED_UNK_3);
 
         fieldSystem->unk_04->hBlankSystem = HBlankSystem_New(HEAP_ID_FIELD);
         HBlankSystem_Start(fieldSystem->unk_04->hBlankSystem);

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -2281,7 +2281,7 @@ static BOOL ScriptContext_CheckABXPadPress(ScriptContext *ctx)
     } else if (gSystem.pressedKeys & PAD_KEY_RIGHT) {
         Player_SetDir(ctx->fieldSystem->playerAvatar, DIR_EAST);
     } else if (gSystem.pressedKeys & PAD_BUTTON_X) {
-        sub_0203F0C0(ctx->fieldSystem);
+        FieldSystem_ShowStartMenu(ctx->fieldSystem);
     } else {
         return FALSE;
     }
@@ -2588,7 +2588,7 @@ static BOOL ScrCmd_ShowStartMenu(ScriptContext *ctx)
 {
     FieldSystem *fieldSystem = ctx->fieldSystem;
 
-    sub_0203F0C0(fieldSystem);
+    FieldSystem_ShowStartMenu(fieldSystem);
     return FALSE;
 }
 

--- a/src/script_manager.c
+++ b/src/script_manager.c
@@ -39,8 +39,8 @@ static void ScriptContext_JumpToOffsetID(ScriptContext *ctx, u16 param1);
 static void *ScriptContext_LoadScripts(int headerID);
 static u32 MapHeaderToMsgArchive(int headerID);
 static BOOL ScriptManager_SetHiddenItem(ScriptManager *scriptManager, u16 scriptID);
-static u16 FieldSystem_GetStaticInitScriptID(const u8 *param0, u8 param1);
-static u16 FieldSystem_GetDynamicInitScriptID(FieldSystem *fieldSystem, const u8 *param1, u8 param2);
+static u16 FieldSystem_GetFixedInitScriptID(const u8 *param0, u8 param1);
+static u16 FieldSystem_GetFirstMatchInitScriptID(FieldSystem *fieldSystem, const u8 *param1, u8 param2);
 
 void ScriptManager_Set(FieldSystem *fieldSystem, u16 scriptID, MapObject *object)
 {
@@ -754,9 +754,9 @@ BOOL FieldSystem_RunInitScript(FieldSystem *fieldSystem, u8 initScriptType)
 
     u16 scriptID;
     if (initScriptType == INIT_SCRIPT_TYPE_FIRST_MATCH) {
-        scriptID = FieldSystem_GetDynamicInitScriptID(fieldSystem, initScripts, initScriptType);
+        scriptID = FieldSystem_GetFirstMatchInitScriptID(fieldSystem, initScriptBytes, initScriptType);
     } else {
-        scriptID = FieldSystem_GetStaticInitScriptID(initScripts, initScriptType);
+        scriptID = FieldSystem_GetFixedInitScriptID(initScriptBytes, initScriptType);
     }
 
     if (scriptID == 0xffff) {
@@ -772,7 +772,7 @@ BOOL FieldSystem_RunInitScript(FieldSystem *fieldSystem, u8 initScriptType)
     return TRUE;
 }
 
-static u16 FieldSystem_GetStaticInitScriptID(const u8 *initScripts, u8 initScriptType)
+static u16 FieldSystem_GetFixedInitScriptID(const u8 *initScriptBytes, u8 initScriptType)
 {
     while (TRUE) {
         if (*initScripts == 0) {
@@ -790,7 +790,7 @@ static u16 FieldSystem_GetStaticInitScriptID(const u8 *initScripts, u8 initScrip
     return 0xffff;
 }
 
-static u16 FieldSystem_GetDynamicInitScriptID(FieldSystem *fieldSystem, const u8 *initScripts, u8 initScriptType)
+static u16 FieldSystem_GetFirstMatchInitScriptID(FieldSystem *fieldSystem, const u8 *initScriptBytes, u8 initScriptType)
 {
     u16 currentVar, compareVar;
     u32 offset = 0;

--- a/src/script_manager.c
+++ b/src/script_manager.c
@@ -30,23 +30,23 @@
 static BOOL FieldTask_RunScript(FieldTask *taskManager);
 static ScriptManager *ScriptManager_New();
 static void ScriptContext_Free(ScriptContext *ctx);
-static void sub_0203EA68(FieldSystem *fieldSystem, ScriptManager *scriptManager, u16 scriptID, MapObject *object, void *saveType);
-static void sub_0203EAF4(FieldSystem *fieldSystem, ScriptContext *ctx, u16 scriptID, u8 dummy);
+static void ScriptManager_Init(FieldSystem *fieldSystem, ScriptManager *scriptManager, u16 scriptID, MapObject *object, void *saveType);
+static void ScriptContext_LoadAndStart(FieldSystem *fieldSystem, ScriptContext *ctx, u16 scriptID, u8 dummy);
 static u16 ScriptContext_LoadAndOffsetID(FieldSystem *fieldSystem, ScriptContext *ctx, u16 scriptID);
 static void ScriptContext_Load(FieldSystem *fieldSystem, ScriptContext *ctx, int scriptFile, u32 textBank);
 static void ScriptContext_LoadFromCurrentMap(FieldSystem *fieldSystem, ScriptContext *ctx);
-static void sub_0203F0E4(ScriptContext *ctx, u16 param1);
+static void ScriptContext_JumpToOffsetID(ScriptContext *ctx, u16 param1);
 static void *ScriptContext_LoadScripts(int headerID);
 static u32 MapHeaderToMsgArchive(int headerID);
 static BOOL ScriptManager_SetHiddenItem(ScriptManager *scriptManager, u16 scriptID);
-static u16 sub_0203F610(const u8 *param0, u8 param1);
-static u16 sub_0203F638(FieldSystem *fieldSystem, const u8 *param1, u8 param2);
+static u16 FieldSystem_GetStaticInitScriptID(const u8 *param0, u8 param1);
+static u16 FieldSystem_GetDynamicInitScriptID(FieldSystem *fieldSystem, const u8 *param1, u8 param2);
 
 void ScriptManager_Set(FieldSystem *fieldSystem, u16 scriptID, MapObject *object)
 {
     ScriptManager *scriptManager = ScriptManager_New();
 
-    sub_0203EA68(fieldSystem, scriptManager, scriptID, object, NULL);
+    ScriptManager_Init(fieldSystem, scriptManager, scriptID, object, NULL);
     FieldSystem_CreateTask(fieldSystem, FieldTask_RunScript, scriptManager);
 }
 
@@ -68,7 +68,7 @@ void ScriptManager_Start(FieldTask *taskManager, u16 scriptID, MapObject *object
     FieldSystem *fieldSystem = FieldTask_GetFieldSystem(taskManager);
     ScriptManager *scriptManager = ScriptManager_New();
 
-    sub_0203EA68(fieldSystem, scriptManager, scriptID, object, saveType);
+    ScriptManager_Init(fieldSystem, scriptManager, scriptID, object, saveType);
     FieldTask_InitCall(taskManager, FieldTask_RunScript, scriptManager);
 }
 
@@ -77,7 +77,7 @@ void ScriptManager_Change(FieldTask *taskManager, u16 scriptID, MapObject *objec
     FieldSystem *fieldSystem = FieldTask_GetFieldSystem(taskManager);
     ScriptManager *scriptManager = ScriptManager_New();
 
-    sub_0203EA68(fieldSystem, scriptManager, scriptID, object, NULL);
+    ScriptManager_Init(fieldSystem, scriptManager, scriptID, object, NULL);
     FieldTask_InitJump(taskManager, FieldTask_RunScript, scriptManager);
 }
 
@@ -150,7 +150,7 @@ static void ScriptContext_Free(ScriptContext *ctx)
     Heap_Free(ctx);
 }
 
-static void sub_0203EA68(FieldSystem *fieldSystem, ScriptManager *scriptManager, u16 scriptID, MapObject *object, void *saveType)
+static void ScriptManager_Init(FieldSystem *fieldSystem, ScriptManager *scriptManager, u16 scriptID, MapObject *object, void *saveType)
 {
     u16 *targetID = ScriptManager_GetMemberPtr(scriptManager, SCRIPT_DATA_TARGET_OBJECT_ID);
 
@@ -175,18 +175,18 @@ ScriptContext *ScriptContext_CreateAndStart(FieldSystem *fieldSystem, u16 script
     GF_ASSERT(ctx != NULL);
 
     ScriptContext_Init(ctx, Unk_020EAC58, Unk_020EAB80);
-    sub_0203EAF4(fieldSystem, ctx, scriptID, 0);
+    ScriptContext_LoadAndStart(fieldSystem, ctx, scriptID, 0);
 
     return ctx;
 }
 
-static void sub_0203EAF4(FieldSystem *fieldSystem, ScriptContext *ctx, u16 scriptID, u8 dummy)
+static void ScriptContext_LoadAndStart(FieldSystem *fieldSystem, ScriptContext *ctx, u16 scriptID, u8 dummy)
 {
     ctx->fieldSystem = fieldSystem;
     u16 offsetID = ScriptContext_LoadAndOffsetID(fieldSystem, ctx, scriptID);
 
     ScriptContext_Start(ctx, ctx->scripts);
-    sub_0203F0E4(ctx, offsetID);
+    ScriptContext_JumpToOffsetID(ctx, offsetID);
     ScriptContext_SetTask(ctx, fieldSystem->task);
 }
 
@@ -441,18 +441,18 @@ void *FieldSystem_GetScriptMemberPtr(FieldSystem *fieldSystem, u32 member)
     return ScriptManager_GetMemberPtr(script, member);
 }
 
-void sub_0203F0C0(FieldSystem *fieldSystem)
+void FieldSystem_ShowStartMenu(FieldSystem *fieldSystem)
 {
     ScriptManager *scriptManager = FieldTask_GetEnv(fieldSystem->task);
 
     if (sub_0203A9C8(fieldSystem) == TRUE) {
-        scriptManager->function = sub_0203AB00;
+        scriptManager->function = StartMenu_Open;
     }
 }
 
-static void sub_0203F0E4(ScriptContext *ctx, u16 param1)
+static void ScriptContext_JumpToOffsetID(ScriptContext *ctx, u16 offsetID)
 {
-    ctx->scriptPtr += (param1 * 4);
+    ctx->scriptPtr += (offsetID * 4);
     ctx->scriptPtr += ScriptContext_ReadWord(ctx);
 }
 
@@ -492,10 +492,10 @@ u16 FieldSystem_TryGetVar(FieldSystem *fieldSystem, u16 varID)
     return *var;
 }
 
-u16 sub_0203F164(FieldSystem *fieldSystem, u16 varID)
+u16 FieldSystem_GetGraphicsID(FieldSystem *fieldSystem, u16 graphicsVarID)
 {
-    GF_ASSERT(varID < 16);
-    return FieldSystem_TryGetVar(fieldSystem, (((0 + VARS_START) + 32) + varID));
+    GF_ASSERT(graphicsVarID < 16);
+    return FieldSystem_TryGetVar(fieldSystem, (((0 + VARS_START) + 32) + graphicsVarID));
 }
 
 BOOL FieldSystem_CheckFlag(FieldSystem *fieldSystem, u16 flagID)
@@ -744,7 +744,7 @@ void FieldSystem_RunScript(FieldSystem *fieldSystem, u16 scriptID)
     ScriptContext_Free(ctx);
 }
 
-BOOL sub_0203F5C0(FieldSystem *fieldSystem, u8 param1)
+BOOL FieldSystem_RunInitScript(FieldSystem *fieldSystem, u8 initScriptType)
 {
     const u8 *initScripts = MapHeaderData_GetInitScripts(fieldSystem);
 
@@ -753,17 +753,17 @@ BOOL sub_0203F5C0(FieldSystem *fieldSystem, u8 param1)
     }
 
     u16 scriptID;
-    if (param1 == 1) {
-        scriptID = sub_0203F638(fieldSystem, initScripts, param1);
+    if (initScriptType == INIT_SCRIPT_TYPE_FIRST_MATCH) {
+        scriptID = FieldSystem_GetDynamicInitScriptID(fieldSystem, initScripts, initScriptType);
     } else {
-        scriptID = sub_0203F610(initScripts, param1);
+        scriptID = FieldSystem_GetStaticInitScriptID(initScripts, initScriptType);
     }
 
     if (scriptID == 0xffff) {
         return FALSE;
     }
 
-    if (param1 == 1) {
+    if (initScriptType == INIT_SCRIPT_TYPE_FIRST_MATCH) {
         ScriptManager_Set(fieldSystem, scriptID, NULL);
     } else {
         FieldSystem_RunScript(fieldSystem, scriptID);
@@ -772,70 +772,70 @@ BOOL sub_0203F5C0(FieldSystem *fieldSystem, u8 param1)
     return TRUE;
 }
 
-static u16 sub_0203F610(const u8 *param0, u8 param1)
+static u16 FieldSystem_GetStaticInitScriptID(const u8 *initScripts, u8 initScriptType)
 {
     while (TRUE) {
-        if (*param0 == 0) {
+        if (*initScripts == 0) {
             return 0xffff;
         }
 
-        if (*param0 == param1) {
-            param0++;
-            return *param0 + (*(param0 + 1) << 8);
+        if (*initScripts == initScriptType) {
+            initScripts++;
+            return *initScripts + (*(initScripts + 1) << 8);
         }
 
-        param0 += (1 + 2 + 2);
+        initScripts += (1 + 2 + 2);
     }
 
     return 0xffff;
 }
 
-static u16 sub_0203F638(FieldSystem *fieldSystem, const u8 *param1, u8 param2)
+static u16 FieldSystem_GetDynamicInitScriptID(FieldSystem *fieldSystem, const u8 *initScripts, u8 initScriptType)
 {
-    u16 v0, v1;
-    u32 v2 = 0;
+    u16 currentVar, compareVar;
+    u32 offset = 0;
 
     while (TRUE) {
-        if (*param1 == 0) {
+        if (*initScripts == 0) {
             return 0xffff;
         }
 
-        if ((*param1) == param2) {
-            param1++;
-            v2 = (*param1 + (*(param1 + 1) << 8) + (*(param1 + 2) << 16) + (*(param1 + 3) << 24));
-            param1 += 4;
+        if ((*initScripts) == initScriptType) {
+            initScripts++;
+            offset = (*initScripts + (*(initScripts + 1) << 8) + (*(initScripts + 2) << 16) + (*(initScripts + 3) << 24));
+            initScripts += 4;
             break;
         }
 
-        param1 += (1 + 4);
+        initScripts += (1 + 4);
     }
 
-    if (v2 == 0) {
+    if (offset == 0) {
         return 0xffff;
     }
 
-    param1 = (param1 + v2);
+    initScripts = (initScripts + offset);
 
     while (TRUE) {
-        if (*param1 == 0) {
+        if (*initScripts == 0) {
             return 0xffff;
         }
 
-        v0 = (*param1 + (*(param1 + 1) << 8));
+        currentVar = (*initScripts + (*(initScripts + 1) << 8));
 
-        if (v0 == 0) {
+        if (currentVar == 0) {
             return 0xffff;
         }
 
-        param1 += 2;
-        v1 = (*param1 + (*(param1 + 1) << 8));
-        param1 += 2;
+        initScripts += 2;
+        compareVar = (*initScripts + (*(initScripts + 1) << 8));
+        initScripts += 2;
 
-        if (FieldSystem_TryGetVar(fieldSystem, v0) == FieldSystem_TryGetVar(fieldSystem, v1)) {
-            return *param1 + (*(param1 + 1) << 8);
+        if (FieldSystem_TryGetVar(fieldSystem, currentVar) == FieldSystem_TryGetVar(fieldSystem, compareVar)) {
+            return *initScripts + (*(initScripts + 1) << 8);
         }
 
-        param1 += 2;
+        initScripts += 2;
     }
 
     return 0xffff;

--- a/src/start_menu.c
+++ b/src/start_menu.c
@@ -336,7 +336,7 @@ void sub_0203AABC(FieldSystem *fieldSystem)
     FieldSystem_CreateTask(fieldSystem, sub_0203AC44, menu);
 }
 
-void sub_0203AB00(FieldSystem *fieldSystem)
+void StartMenu_Open(FieldSystem *fieldSystem)
 {
     StartMenu *menu;
 


### PR DESCRIPTION
Documented nearly all the remaining auto-named functions and variables in `script_manager.c`, also going into portions of `overlay034`, which as best I can guess deals solely with the Dowsing Machine app for the Poketch. Analyzing `FieldSystem_GetNearbyHiddenItems` (`sub_0203F478`) naturally brought with it understanding of several functions higher up in the callstack, so it made sense to include them here too. The distinction between `HiddenItemOffsets` and `HiddenItemScreenPosition` (relative number of tiles away from the player vs. absolute pixel coordinates on screen) might need some clearer naming, but I wasn't quite sure what might work best there.

Otherwise, the main thing left on the table here is identifying the exact ways the different types of init scripts are called, to give them more descriptive labels. Nearly all maps use solely `INIT_SCRIPT_MODE_DYNAMIC` and `INIT_SCRIPT_UNK_STATIC_MODE_2`, with `3` and `4` appearing only a handful of times in all. Though `scripts_valley_windworks_outside.s` is notable for being the only script to use every type of "static" init script (as well as a "dynamic" script).

I don't know if anyone else has already looked into how init scripts are declared, but here's the understanding I came to:

```bash
#include "macros/scrcmd.inc"


    .byte 4 # When init script mode = 4
    .short 2, 0 # The second map script (1-based index, not 0-based)
    .byte 2 # When init script mode = 2
    .short 1, 0 # The first map script
    .byte 3 # When init script mode = 3
    .short 7, 0 # The seventh map script
    .byte 1 # When init script mode = 1 (dynamic)
    ScriptEntry _0015 # Start of dynamic scripts (always last, with a single ScriptEntry)
    .byte 0 # No more init script modes covered (though this example is exhaustive)

_0015:
    .short 0x411E, 1, 8 # The eighth map script, when TryGetVar(0x411E) = TryGetVar(1), though the latter is just 1.
    .short 0 # No more dynamic init scripts 

    .balign 4, 0
```