### PR TITLE
Fix msgenc compilation error on macOS

### DIFF
--- a/tools/msgenc/Json.cpp
+++ b/tools/msgenc/Json.cpp
@@ -224,7 +224,9 @@ void Json::ToFile(MessagesConverter &converter) {
         entry.AddMember("id", entry_name, doc.GetAllocator());
 
         if (message.find_first_not_of(' ') == string::npos) {
-            entry.AddMember("garbage", message.size(), doc.GetAllocator());
+            rapidjson::Value garbage(rapidjson::kNumberType);
+            garbage.SetInt(message.size());
+            entry.AddMember("garbage", garbage, doc.GetAllocator());
         } else {
             vector<string> message_lines = SplitMessage(message, true);
             if (message_lines.size() == 1) {


### PR DESCRIPTION
Fixes the following compilation error on macOS:

```
../tools/msgenc/Json.cpp:227:28:   required from here
  227 |             entry.AddMember("garbage", message.size(), doc.GetAllocator());
      |             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../subprojects/rapidjson-1.1.0/include/rapidjson/document.h:1265:22: error: call of overloaded 'GenericValue(long unsigned int&)' is ambiguous
 1265 |         GenericValue v(value);
      |                      ^
```