### PR TITLE
Rename `CalcDotProduct2D` -> `ApproximateArcLength`

### DIFF
--- a/include/math_util.h
+++ b/include/math_util.h
@@ -46,7 +46,13 @@ u32 MTRNG_Next(void);
 
 void CreateAffineTransformationMatrix(MtxFx22 *matrix, u16 degrees, fx32 xScale, fx32 yScale, u8 mode);
 
-s32 CalcDotProduct2D(s32 x0, s32 y0, s32 x1, s32 y1, u32 unused);
+/*
+ * Computes an approximation of the (signed) arc length spanned by the (signed)
+ * angle from (x0, y0) to (x1, y1) on a circle of radius length((x0, y0)). The
+ * last argument was most likely intended to be the radius, but went unused in
+ * the final version.
+ */
+s32 ApproximateArcLength(s32 x0, s32 y0, s32 x1, s32 y1, u32 unused_radius);
 s32 CalcRadialAngle(u16 radius, s32 distance);
 
 u32 SumBytes(const void *data, u32 size);

--- a/src/applications/pokedex/crysub.c
+++ b/src/applications/pokedex/crysub.c
@@ -1059,7 +1059,7 @@ static void UpdateDialPosition(PokedexCrySubPageData *pokedexCrySubPageData)
     int y0 = pokedexCrySubPageData->dialY - DIAL_Y;
     int x1 = gSystem.touchX - DIAL_X;
     int y1 = gSystem.touchY - DIAL_Y;
-    int magnitude = CalcDotProduct2D(x0, y0, x1, y1, 0);
+    int magnitude = ApproximateArcLength(x0, y0, x1, y1, 0);
 
     if (MATH_IAbs(magnitude) < 1) {
         return;

--- a/src/applications/pokedex/ov21_021D76B0.c
+++ b/src/applications/pokedex/ov21_021D76B0.c
@@ -828,7 +828,7 @@ static void ov21_021D8324(UnkStruct_ov21_021D7A64 *param0)
     v3 = gSystem.touchX - (128 + 120);
     v2 = gSystem.touchY - (104 + -0);
 
-    param0->unk_0C = CalcDotProduct2D(v1, v0, v3, v2, 524);
+    param0->unk_0C = ApproximateArcLength(v1, v0, v3, v2, 524);
     param0->unk_0C *= 10;
 }
 

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -169,7 +169,7 @@ static inline void CalcCrossProduct(const VecFx32 *a, const VecFx32 *b, VecFx32 
     outResult->z = FX_Mul(a->x, b->y) - FX_Mul(b->x, a->y);
 }
 
-s32 CalcDotProduct2D(s32 x0, s32 y0, s32 x1, s32 y1, u32 unused)
+s32 ApproximateArcLength(s32 x0, s32 y0, s32 x1, s32 y1, u32 unused)
 {
     VecFx32 vec0, vec1, vecResult, cross;
     fx32 crossMagnitude;

--- a/src/overlay083/ov83_0223F7F4.c
+++ b/src/overlay083/ov83_0223F7F4.c
@@ -35,7 +35,7 @@ s32 ov83_0223F7F4(int param0, int param1, int param2, int param3, int param4, in
     param2 -= param4;
     param3 -= param5;
 
-    v3 = CalcDotProduct2D(param2, param3, param0, param1, 0);
+    v3 = ApproximateArcLength(param2, param3, param0, param1, 0);
     v3 = ((v3) * 160);
 
     return v3;

--- a/src/overlay084/ov84_0223B5A0.c
+++ b/src/overlay084/ov84_0223B5A0.c
@@ -2958,7 +2958,7 @@ static BOOL ov84_0223EB84(UnkStruct_ov84_0223B5A0 *param0, u16 param1)
         if (ov84_0223EB6C() == 1) {
             s32 v0, v1;
 
-            v0 = CalcDotProduct2D(128 - param0->unk_49E, 80 - param0->unk_4A0, 128 - gSystem.touchX, 80 - gSystem.touchY, 80);
+            v0 = ApproximateArcLength(128 - param0->unk_49E, 80 - param0->unk_4A0, 128 - gSystem.touchX, 80 - gSystem.touchY, 80);
             v1 = CalcRadialAngle(80, v0 * 2);
             v1 = ((v1 << 8) / 182) >> 8;
             param0->unk_49A += v1;


### PR DESCRIPTION
This function was misnamed, it's actually an approximation of the arc length for the angle between the two vectors (x0, y0) and (x1, y1) on a circle of radius length((x0, y0)). It's typically use to calculate how much a player has moved their stylus along a circular shape, such as the pokeball dial in the bag or pokedex.