### PR TITLE
Update Debug Macros to Allow a Single Argument

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -15,8 +15,8 @@ __attribute__((format(printf, 1, 2))) void EmulatorLog(const char *text, ...);
 
 #else
 
-#define EmulatorPrintf(text, ...)
-#define EmulatorLog(text, ...)
+#define EmulatorPrintf(...)
+#define EmulatorLog(...)
 
 #endif
 


### PR DESCRIPTION
With
```c
#define EmulatorPrintf(text, ...)
```
calls of `EmulatorPrintf` with a single parameter fail. e.g., `EmulatorPrintf("text\n");`. To remedy this, replace it with
```c
#define EmulatorPrintf(...)
```