### PR TITLE
copy generated text banks instead of moving

### DIFF
--- a/res/text/meson.build
+++ b/res/text/meson.build
@@ -114,7 +114,7 @@ text_bank_files += species_text_banks
 trainer_text_banks = custom_target('trainer_text_banks',
     output: trainer_text_bank_names,
     command: [
-        'mv',
+        'cp',
         '@OUTDIR@/../trainers/npc_trainer_messages.json',
         '@OUTDIR@/../trainers/npc_trainer_names.json',
         '@OUTDIR@',
@@ -128,7 +128,7 @@ text_bank_files += trainer_text_banks
 frontier_text_banks = custom_target('frontier_text_banks',
     output: frontier_text_bank_names,
     command: [
-        'mv',
+        'cp',
         '@OUTDIR@/../trainers/frontier/frontier_trainer_messages.json',
         '@OUTDIR@/../trainers/frontier/frontier_trainer_names.json',
         '@OUTDIR@',


### PR DESCRIPTION
there are situations where the text narc gets rebuilt without these being generated again (for example, editing a trainer file doesn't make the frontier datagen run again), so they need to stay in place