### PR TITLE
nitrogfx: various cell fixes

### DIFF
--- a/tools/nitrogfx/gfx.c
+++ b/tools/nitrogfx/gfx.c
@@ -10,8 +10,6 @@
 #include "json.h"
 #include "util.h"
 
-static int SnapToTile(int val);
-
 static unsigned int FindNitroDataBlock(const unsigned char *data, const char *ident, unsigned int fileSize, unsigned int *blockSize_out)
 {
     unsigned int offset = 0x10;

--- a/tools/nitrogfx/gfx.c
+++ b/tools/nitrogfx/gfx.c
@@ -10,6 +10,8 @@
 #include "json.h"
 #include "util.h"
 
+static int SnapToTile(int val);
+
 static unsigned int FindNitroDataBlock(const unsigned char *data, const char *ident, unsigned int fileSize, unsigned int *blockSize_out)
 {
     unsigned int offset = 0x10;
@@ -584,7 +586,22 @@ uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk,
     return key;
 }
 
-void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
+// accounts for OAMs overlapping by a few pixels
+static int SnapToTile(int val)
+{
+    int displacement = val % 8;
+    if (displacement < 4)
+    {
+        val -= displacement;
+    }
+    else
+    {
+        val += 8 - displacement;
+    }
+    return val;
+}
+
+void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG, bool snap)
 {
     char *cellFileExtension = GetFileExtension(cellFilePath);
     if (cellFileExtension == NULL)
@@ -610,7 +627,7 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
         }
     }
 
-    int outputHeight = 0;
+    int outputHeight = -1;
     int outputWidth = 0;
     int numTiles = 0;
 
@@ -624,34 +641,34 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
         int cellWidth = 0;
         if (options->cells[i]->attributes.boundingRect)
         {
-            cellHeight = options->cells[i]->maxY - options->cells[i]->minY + 1;
-            cellWidth = options->cells[i]->maxX - options->cells[i]->minX + 1;
+            cellHeight = options->cells[i]->maxY - options->cells[i]->minY;
+            cellWidth = options->cells[i]->maxX - options->cells[i]->minX;
+            if (snap)
+            {
+                cellHeight = SnapToTile(cellHeight);
+                cellWidth = SnapToTile(cellWidth);
+            }
         }
         else
         {
             FATAL_ERROR("No bounding rectangle. Incompatible NCER\n");
         }
 
-        outputHeight += cellHeight;
+        outputHeight += cellHeight + 1;
         if (outputWidth < cellWidth)
         {
             outputWidth = cellWidth;
         }
-        if (i)
-        {
-            outputHeight++;
-        }
     }
 
-    if (outputHeight == 0 || outputWidth == 0)
+    if (outputHeight < 1 || outputWidth == 0)
     {
         FATAL_ERROR("No cells. Incompatible NCER\n");
     }
     unsigned char *newPixels = malloc(outputHeight * outputWidth);
     memset(newPixels, 255, outputHeight * outputWidth);
 
-    int scanHeight = 0;
-    int maxTile = 0;
+    int scanHeight = -1;
     int tileMask[outputHeight * outputWidth]; // check for unused (starting) tiles
     memset(tileMask, 0, outputHeight * outputWidth * sizeof(int));
     for (int i = 0; i < options->cellCount; i++)
@@ -660,11 +677,12 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
         {
             continue;
         }
-        if (i)
+        scanHeight++;
+        int cellHeight = options->cells[i]->maxY - options->cells[i]->minY;
+        if (snap)
         {
-            scanHeight++;
+            cellHeight = SnapToTile(cellHeight);
         }
-        int cellHeight = options->cells[i]->maxY - options->cells[i]->minY + 1;
         int uniqueOAMs = options->cells[i]->oamCount;
 
         for (int j = 0; j < options->cells[i]->oamCount; j++)
@@ -735,42 +753,41 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
             x -= options->cells[i]->minX;
             y -= options->cells[i]->minY;
 
+            if (snap)
+            {
+                x = SnapToTile(x);
+                y = SnapToTile(y);
+            }
+
             int pixelOffset = 0;
             switch (options->mappingType)
             {
                 case 0:
                     pixelOffset = options->cells[i]->oam[j].attr2.CharName * 32;
-                    maxTile = options->cells[i]->oam[j].attr2.CharName + oamHeight * oamWidth;
-                    if (maxTile > numTiles)
-                    {
-                        numTiles = maxTile;
-                    }
-                    if (tileMask[options->cells[i]->oam[j].attr2.CharName])
-                    {
-                        uniqueOAMs--;
-                        continue;
-                    }
-                    tileMask[options->cells[i]->oam[j].attr2.CharName]++;
                     break;
                 case 1:
-                    pixelOffset = options->cells[i]->oam[j].attr2.CharName * 64 + (scanHeight - i) * outputWidth / 2;
-                    numTiles += oamHeight * oamWidth;
+                    pixelOffset = options->cells[i]->oam[j].attr2.CharName * 64;
                     break;
                 case 2:
                     pixelOffset = options->cells[i]->oam[j].attr2.CharName * 128;
-                    maxTile = options->cells[i]->oam[j].attr2.CharName * 4 + oamHeight * oamWidth;
-                    if (maxTile > numTiles)
-                    {
-                        numTiles = maxTile;
-                    }
-                    if (tileMask[options->cells[i]->oam[j].attr2.CharName])
-                    {
-                        uniqueOAMs--;
-                        continue;
-                    }
-                    tileMask[options->cells[i]->oam[j].attr2.CharName]++;
+                    break;
+                case 3:
+                    pixelOffset = options->cells[i]->oam[j].attr2.CharName * 256;
                     break;
             }
+            
+            if (options->vramTransferEnabled)
+            {
+                pixelOffset += options->transferData[i]->sourceDataOffset;
+            }
+            if (tileMask[pixelOffset])
+            {
+                uniqueOAMs--;
+                continue;
+            }
+            tileMask[pixelOffset] = 1;
+            numTiles += oamHeight * oamWidth;
+
             bool rotationScaling = options->cells[i]->oam[j].attr1.RotationScaling;
             bool hFlip = options->cells[i]->attributes.hFlip && rotationScaling;
             bool vFlip = options->cells[i]->attributes.vFlip && rotationScaling;
@@ -804,12 +821,8 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
 
         if (uniqueOAMs == 0)
         {
-            outputHeight -= cellHeight;
-            if (i)
-            {
-                scanHeight--;
-                outputHeight--;
-            }
+            outputHeight -= cellHeight + 1;
+            scanHeight--;
         }
         else
         {

--- a/tools/nitrogfx/gfx.c
+++ b/tools/nitrogfx/gfx.c
@@ -601,7 +601,7 @@ static int SnapToTile(int val)
     return val;
 }
 
-void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG, bool snap)
+void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG, bool snap, bool noSkip)
 {
     char *cellFileExtension = GetFileExtension(cellFilePath);
     if (cellFileExtension == NULL)
@@ -780,7 +780,7 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG, bool
             {
                 pixelOffset += options->transferData[i]->sourceDataOffset;
             }
-            if (tileMask[pixelOffset])
+            if (tileMask[pixelOffset] && !noSkip)
             {
                 uniqueOAMs--;
                 continue;

--- a/tools/nitrogfx/gfx.h
+++ b/tools/nitrogfx/gfx.h
@@ -52,7 +52,7 @@ struct Image {
 
 void ReadImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
 uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack);
-void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG);
+void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG, bool snap);
 void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
 void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image,
                    bool invertColors, bool clobberSize, bool byteOrder, bool version101, bool sopc, bool vram, uint32_t scanMode,

--- a/tools/nitrogfx/gfx.h
+++ b/tools/nitrogfx/gfx.h
@@ -52,7 +52,7 @@ struct Image {
 
 void ReadImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
 uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack);
-void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG, bool snap);
+void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG, bool snap, bool noSkip);
 void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
 void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image,
                    bool invertColors, bool clobberSize, bool byteOrder, bool version101, bool sopc, bool vram, uint32_t scanMode,

--- a/tools/nitrogfx/main.c
+++ b/tools/nitrogfx/main.c
@@ -105,7 +105,7 @@ void ConvertNtrToPng(char *inputPath, char *outputPath, struct NtrToPngOptions *
 
     if (options->cellFilePath != NULL)
     {
-        ApplyCellsToImage(options->cellFilePath, &image, true);
+        ApplyCellsToImage(options->cellFilePath, &image, true, options->cellSnap);
     }
 
     WritePng(outputPath, &image);
@@ -176,7 +176,7 @@ void ConvertPngToNtr(char *inputPath, char *outputPath, struct PngToNtrOptions *
 
     if (options->cellFilePath != NULL)
     {
-        ApplyCellsToImage(options->cellFilePath, &image, false);
+        ApplyCellsToImage(options->cellFilePath, &image, false, options->cellSnap);
     }
 
     WriteNtrImage(outputPath, options->numTiles, options->bitDepth, options->colsPerChunk, options->rowsPerChunk,
@@ -273,6 +273,7 @@ void HandleNtrToPngCommand(char *inputPath, char *outputPath, int argc, char **a
     struct NtrToPngOptions options;
     options.paletteFilePath = NULL;
     options.cellFilePath = NULL;
+    options.cellSnap = true;
     options.hasTransparency = false;
     options.width = 0;
     options.colsPerChunk = 1;
@@ -302,6 +303,15 @@ void HandleNtrToPngCommand(char *inputPath, char *outputPath, int argc, char **a
             i++;
 
             options.cellFilePath = argv[i];
+
+            if (i + 1 < argc)
+            {
+                if (strcmp(argv[i+1], "-nosnap") == 0)
+                {
+                    options.cellSnap = false;
+                    i++;
+                }
+            }
         }
         else if (strcmp(option, "-object") == 0)
         {
@@ -456,6 +466,7 @@ void HandlePngToNtrCommand(char *inputPath, char *outputPath, int argc, char **a
 {
     struct PngToNtrOptions options;
     options.cellFilePath = NULL;
+    options.cellSnap = true;
     options.numTiles = 0;
     options.bitDepth = 0;
     options.colsPerChunk = 1;
@@ -495,6 +506,15 @@ void HandlePngToNtrCommand(char *inputPath, char *outputPath, int argc, char **a
             i++;
 
             options.cellFilePath = argv[i];
+
+            if (i + 1 < argc)
+            {
+                if (strcmp(argv[i+1], "-nosnap") == 0)
+                {
+                    options.cellSnap = false;
+                    i++;
+                }
+            }
         }
         else if (strcmp(option, "-mwidth") == 0 || strcmp(option, "-cpc") == 0)
         {
@@ -1064,7 +1084,7 @@ static int CountLzCompressArgs(int argc, char **argv)
 
             i++;
 
-            count++;
+            count += 2;
         }
         else if (strcmp(option, "-search") == 0)
         {
@@ -1073,7 +1093,7 @@ static int CountLzCompressArgs(int argc, char **argv)
 
             i++;
 
-            count++;
+            count += 2;
         }
         else if (strcmp(option, "-reverse") == 0)
         {

--- a/tools/nitrogfx/main.c
+++ b/tools/nitrogfx/main.c
@@ -105,7 +105,7 @@ void ConvertNtrToPng(char *inputPath, char *outputPath, struct NtrToPngOptions *
 
     if (options->cellFilePath != NULL)
     {
-        ApplyCellsToImage(options->cellFilePath, &image, true, options->cellSnap);
+        ApplyCellsToImage(options->cellFilePath, &image, true, options->cellSnap, options->noSkip);
     }
 
     WritePng(outputPath, &image);
@@ -176,7 +176,7 @@ void ConvertPngToNtr(char *inputPath, char *outputPath, struct PngToNtrOptions *
 
     if (options->cellFilePath != NULL)
     {
-        ApplyCellsToImage(options->cellFilePath, &image, false, options->cellSnap);
+        ApplyCellsToImage(options->cellFilePath, &image, false, options->cellSnap, false);
     }
 
     WriteNtrImage(outputPath, options->numTiles, options->bitDepth, options->colsPerChunk, options->rowsPerChunk,
@@ -281,6 +281,7 @@ void HandleNtrToPngCommand(char *inputPath, char *outputPath, int argc, char **a
     options.palIndex = 1;
     options.scanFrontToBack = false;
     options.handleEmpty = false;
+    options.noSkip = false;
 
     for (int i = 3; i < argc; i++)
     {
@@ -304,12 +305,24 @@ void HandleNtrToPngCommand(char *inputPath, char *outputPath, int argc, char **a
 
             options.cellFilePath = argv[i];
 
-            if (i + 1 < argc)
+            for (int j = 0; j < 2; j++)
             {
-                if (strcmp(argv[i+1], "-nosnap") == 0)
+                if (i + 1 < argc)
                 {
-                    options.cellSnap = false;
-                    i++;
+                    if (strcmp(argv[i + 1], "-nosnap") == 0)
+                    {
+                        options.cellSnap = false;
+                        i++;
+                    }
+                    else if (strcmp(argv[i + 1], "-noskip") == 0)
+                    {
+                        options.noSkip = true;
+                        i++;
+                    }
+                }
+                else
+                {
+                    break;
                 }
             }
         }
@@ -509,7 +522,7 @@ void HandlePngToNtrCommand(char *inputPath, char *outputPath, int argc, char **a
 
             if (i + 1 < argc)
             {
-                if (strcmp(argv[i+1], "-nosnap") == 0)
+                if (strcmp(argv[i + 1], "-nosnap") == 0)
                 {
                     options.cellSnap = false;
                     i++;

--- a/tools/nitrogfx/options.h
+++ b/tools/nitrogfx/options.h
@@ -45,6 +45,7 @@ struct NtrToPngOptions {
     char *paletteFilePath;
     char *cellFilePath;
     bool cellSnap;
+    bool noSkip;
     int bitDepth;
     bool hasTransparency;
     int width;

--- a/tools/nitrogfx/options.h
+++ b/tools/nitrogfx/options.h
@@ -25,6 +25,7 @@ struct PngToGbaOptions {
 
 struct PngToNtrOptions {
     char *cellFilePath;
+    bool cellSnap;
     int numTiles;
     int bitDepth;
     int colsPerChunk;
@@ -43,6 +44,7 @@ struct PngToNtrOptions {
 struct NtrToPngOptions {
     char *paletteFilePath;
     char *cellFilePath;
+    bool cellSnap;
     int bitDepth;
     bool hasTransparency;
     int width;


### PR DESCRIPTION
- fixes the calculation of pixelOffset and cleans up the various mappingTypes
credit goes to @h2o-DS for the following:
- handles overlapping oams by rounding to the nearest multiple of 8
- fixes height calculations to prevent extra separator rows
