### PR TITLE
Generate an NAIX for pl_poke_icon

### DIFF
--- a/res/pokemon/meson.build
+++ b/res/pokemon/meson.build
@@ -220,7 +220,10 @@ h_headers += datagen_species_out[12]
 
 # OLD NARCs
 pl_poke_icon_narc = custom_target('pl_poke_icon.narc',
-    output: 'pl_poke_icon.narc',
+    output: [
+        'pl_poke_icon.narc',
+        'pl_poke_icon.naix.h',
+    ],
     input: [
         icons_shared,
         poke_icon_files
@@ -230,12 +233,14 @@ pl_poke_icon_narc = custom_target('pl_poke_icon.narc',
         make_pl_poke_icon_py,
         '--nitrogfx', nitrogfx_exe,
         '--narc', narc_exe,
+        '--order-file', files('species_icons.order'),
         '--shared-dir', '@CURRENT_SOURCE_DIR@/.shared',
         '--private-dir', '@PRIVATE_DIR@',
         '--output-dir', '@OUTDIR@',
         poke_icon_files,
     ],
 )
+naix_headers += pl_poke_icon_narc[1]
 
 pl_pokegra_narc = custom_target('pl_pokegra.narc',
     output: 'pl_pokegra.narc',

--- a/res/pokemon/species_icons.order
+++ b/res/pokemon/species_icons.order
@@ -1,0 +1,7 @@
+shared_pals.NCLR
+shared_anim.NANR
+shared_cell.NCER
+shared_anim_32k.NANR
+shared_cell_32k.NCER
+shared_anim_64k.NANR
+shared_cell_64k.NCER

--- a/src/pokemon_icon.c
+++ b/src/pokemon_icon.c
@@ -8,23 +8,12 @@
 
 #include "pokemon.h"
 
+#include "res/pokemon/pl_poke_icon.naix.h"
 #include "res/pokemon/species_icon_palettes.h"
-
-enum PokeIconSharedResourceIndex {
-    POKEICON_SHARED_PALETTES = 0,
-    POKEICON_SHARED_ANIMATION,
-    POKEICON_SHARED_CELLS,
-    POKEICON_SHARED_32K_ANIMATION,
-    POKEICON_SHARED_32K_CELLS,
-    POKEICON_SHARED_64K_ANIMATION,
-    POKEICON_SHARED_64K_CELLS,
-
-    POKEICON_ICON_TILES_START,
-};
 
 static inline u32 IconTilesIndex(u32 icon)
 {
-    return icon + POKEICON_ICON_TILES_START;
+    return icon + icon_00000_NCGR;
 }
 
 u32 BoxPokemon_IconSpriteIndex(const BoxPokemon *boxMon)
@@ -178,35 +167,35 @@ const u8 Pokemon_IconPaletteIndex(Pokemon *mon)
 
 u32 PokeIconPalettesFileIndex(void)
 {
-    return POKEICON_SHARED_PALETTES;
+    return shared_pals_NCLR;
 }
 
 u32 PokeIconCellsFileIndex(void)
 {
-    return POKEICON_SHARED_CELLS;
+    return shared_cell_NCER;
 }
 
 u32 PokeIcon32KCellsFileIndex(void)
 {
-    return POKEICON_SHARED_32K_CELLS;
+    return shared_cell_32k_NCER;
 }
 
 u32 PokeIcon64KCellsFileIndex(void)
 {
-    return POKEICON_SHARED_64K_CELLS;
+    return shared_cell_64k_NCER;
 }
 
 u32 PokeIconAnimationFileIndex(void)
 {
-    return POKEICON_SHARED_ANIMATION;
+    return shared_anim_NANR;
 }
 
 u32 PokeIcon32KAnimationFileIndex(void)
 {
-    return POKEICON_SHARED_32K_ANIMATION;
+    return shared_anim_32k_NANR;
 }
 
 u32 PokeIcon64KAnimationFileIndex(void)
 {
-    return POKEICON_SHARED_64K_ANIMATION;
+    return shared_anim_64k_NANR;
 }

--- a/tools/scripts/make_pl_poke_icon.py
+++ b/tools/scripts/make_pl_poke_icon.py
@@ -5,43 +5,57 @@ import pathlib
 import subprocess
 
 argparser = argparse.ArgumentParser(
-    prog='pl_poke_icon.narc packer',
-    description='Packs the archive containing Pokemon icons'
+    prog="pl_poke_icon.narc packer",
+    description="Packs the archive containing Pokemon icons"
 )
-argparser.add_argument('-n', '--nitrogfx',
+argparser.add_argument("-n", "--nitrogfx",
                        required=True,
-                       help='Path to nitrogfx executable')
-argparser.add_argument('-k', '--narc',
+                       help="Path to nitrogfx executable")
+argparser.add_argument("-k", "--narc",
                        required=True,
-                       help='Path to narc executable')
-argparser.add_argument('-s', '--shared-dir',
+                       help="Path to narc executable")
+argparser.add_argument("-s", "--shared-dir",
                        required=True,
-                       help='Path to the .shared directory')
-argparser.add_argument('-p', '--private-dir',
+                       help="Path to the .shared directory")
+argparser.add_argument("-p", "--private-dir",
                        required=True,
-                       help='Path to the private directory (where binaries will be made)')
-argparser.add_argument('-o', '--output-dir',
+                       help="Path to the private directory (where binaries will be made)")
+argparser.add_argument("-o", "--output-dir",
                        required=True,
-                       help='Path to the output directory (where the NARC will be made)')
-argparser.add_argument('icon_files',
-                       nargs='+',
-                       help='Input icon files to pack into the NARC')
+                       help="Path to the output directory (where the NARC will be made)")
+argparser.add_argument("-f", "--order-file",
+                       required=True,
+                       help="Path to the order file for the output NARC")
+argparser.add_argument("icon_files",
+                       nargs="+",
+                       help="Input icon files to pack into the NARC")
 args = argparser.parse_args()
 
 shared_dir = pathlib.Path(args.shared_dir)
 private_dir = pathlib.Path(args.private_dir)
 output_dir = pathlib.Path(args.output_dir)
 
-bin_dest_dir = private_dir / 'pl_poke_icon_work'
+bin_dest_dir = private_dir / "pl_poke_icon_work"
 bin_dest_dir.mkdir(parents=True, exist_ok=True)
 
-subprocess.run([args.nitrogfx, shared_dir / 'pl_poke_icon.pal', bin_dest_dir / '0000.NCLR', '-bitdepth', '4'])
+subprocess.run([
+    args.nitrogfx,
+    shared_dir / "pl_poke_icon.pal",
+    bin_dest_dir / "shared_pals.NCLR",
+    "-bitdepth", "4",
+])
 
-for i in range(3):
-    anim_file_src = shared_dir / f'pl_poke_icon_anim_{i+1:02}.json'
-    cell_file_src = shared_dir / f'pl_poke_icon_cell_{i+1:02}.json'
-    anim_file_dst = bin_dest_dir / f'{(i*2+1):04}.NANR'
-    cell_file_dst = bin_dest_dir / f'{(i*2+2):04}.NCER'
+shared_anims_cells = [
+    ("shared_anim", "shared_cell"),
+    ("shared_anim_32k", "shared_cell_32k"),
+    ("shared_anim_64k", "shared_cell_64k"),
+]
+
+for i in range(len(shared_anims_cells)):
+    anim_file_src = shared_dir / f"pl_poke_icon_anim_{i+1:02}.json"
+    cell_file_src = shared_dir / f"pl_poke_icon_cell_{i+1:02}.json"
+    anim_file_dst = bin_dest_dir / f"{shared_anims_cells[i][0]}.NANR"
+    cell_file_dst = bin_dest_dir / f'{shared_anims_cells[i][1]}.NCER'
 
     subprocess.run([args.nitrogfx, anim_file_src, anim_file_dst])
     subprocess.run([args.nitrogfx, cell_file_src, cell_file_dst])
@@ -50,9 +64,15 @@ for i, input_fname in enumerate(args.icon_files):
     subprocess.run([
         args.nitrogfx,
         input_fname,
-        bin_dest_dir / f'{i+7:04}.NCGR',
-        '-clobbersize',
-        '-version101'
+        bin_dest_dir / f"icon_{i:05}.NCGR",
+        "-clobbersize",
+        "-version101"
     ])
 
-subprocess.run([args.narc, 'create', '--output', output_dir / 'pl_poke_icon.narc', bin_dest_dir])
+subprocess.run([
+    args.narc, "create",
+    "--naix",
+    "--order", args.order_file,
+    "--output", output_dir / "pl_poke_icon.narc",
+    bin_dest_dir,
+])


### PR DESCRIPTION
This is a bit of plumbing that I put together while working on `resdat` / `cldat` tooling today; while that tooling is not yet done, this can be put up separately.

We should probably also refactor this script to reference the environment variable typically used for species and take in additional icons as arguments, rather than the whole list.