### PR TITLE
nitrogfx: Fix UB during NANR encoding

### DIFF
--- a/tools/nitrogfx/json.c
+++ b/tools/nitrogfx/json.c
@@ -479,6 +479,7 @@ struct JsonToAnimationOptions *ParseNANRJson(char *path)
 
         cJSON *resultType = cJSON_GetObjectItemCaseSensitive(animationResult, "resultType");
         options->animationResults[i]->resultType = GetInt(resultType);
+        options->animationResults[i]->padded = false;
         switch (options->animationResults[i]->resultType) {
             case 0: { //index
                 cJSON *index = cJSON_GetObjectItemCaseSensitive(animationResult, "index");


### PR DESCRIPTION
The program stores an additional `padded` flag for each animation result, but didn't initialize it properly, such that is was never set to `false` when the result shouldn't have padding, causing undefined behaviour that sometimes resulted in wrongly encoded NANR files.