### PR TITLE
nitrogfx: Output Converted Images with OAM Colors

### DIFF
--- a/res/fonts/pl_font.ignore
+++ b/res/fonts/pl_font.ignore
@@ -2,3 +2,4 @@ font_special_chars.NCGR
 *.narc
 *.naix
 *.h
+*.4bpp

--- a/tools/nitrogfx/gfx.c
+++ b/tools/nitrogfx/gfx.c
@@ -297,7 +297,7 @@ static void ConvertFromTiles8BppCell(unsigned char *src, unsigned char *dest, in
                 }
                 else
                 {
-                   *dest++ = src[idxComponentY * pitch + idxComponentX];
+                    *dest++ = src[idxComponentY * pitch + idxComponentX];
                 }
             }
         }

--- a/tools/nitrogfx/gfx.c
+++ b/tools/nitrogfx/gfx.c
@@ -292,19 +292,12 @@ static void ConvertFromTiles8BppCell(unsigned char *src, unsigned char *dest, in
                     dest[idxComponentY * pitch + idxComponentX] = *src++;
                     if (palette != -1)
                     {
-                        dest[idxComponentY * pitch + idxComponentX] = dest[idxComponentY * pitch + idxComponentX] % 16 + palette * 16;
+                        dest[idxComponentY * pitch + idxComponentX] += palette * 16;
                     }
                 }
                 else
                 {
-                    if (palette == -1)
-                    {
-                        *dest++ = src[idxComponentY * pitch + idxComponentX];
-                    }
-                    else
-                    {
-                        *dest++ = src[idxComponentY * pitch + idxComponentX] % 16;
-                    }
+                   *dest++ = src[idxComponentY * pitch + idxComponentX];
                 }
             }
         }

--- a/tools/nitrogfx/gfx.h
+++ b/tools/nitrogfx/gfx.h
@@ -52,7 +52,7 @@ struct Image {
 
 void ReadImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
 uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack, bool convertTo8Bpp, int palIndex);
-void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG, bool snap, bool noSkip);
+void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG, bool snap, bool noSkip, bool convertBpp);
 void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, const char *embedName, struct Image *image, bool invertColors);
 void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image,
                    bool invertColors, bool clobberSize, bool byteOrder, bool version101, bool sopc, bool vram, uint32_t scanMode,

--- a/tools/nitrogfx/main.c
+++ b/tools/nitrogfx/main.c
@@ -106,7 +106,7 @@ void ConvertNtrToPng(char *inputPath, char *outputPath, struct NtrToPngOptions *
 
     if (options->cellFilePath != NULL)
     {
-        ApplyCellsToImage(options->cellFilePath, &image, true, options->cellSnap, options->noSkip);
+        ApplyCellsToImage(options->cellFilePath, &image, true, options->cellSnap, options->noSkip, options->convertTo8Bpp);
     }
 
     WritePng(outputPath, &image);
@@ -155,6 +155,10 @@ void ConvertPngToNtr(char *inputPath, char *outputPath, struct PngToNtrOptions *
     struct Image image;
 
     image.bitDepth = options->bitDepth == 0 ? 4 : options->bitDepth;
+    if (options->convertTo4Bpp)
+    {
+        image.bitDepth = 8;
+    }
 
     ReadPng(inputPath, &image);
 
@@ -177,7 +181,7 @@ void ConvertPngToNtr(char *inputPath, char *outputPath, struct PngToNtrOptions *
 
     if (options->cellFilePath != NULL)
     {
-        ApplyCellsToImage(options->cellFilePath, &image, false, options->cellSnap, false);
+        ApplyCellsToImage(options->cellFilePath, &image, false, options->cellSnap, false, options->convertTo4Bpp);
     }
 
     WriteNtrImage(outputPath, options->numTiles, options->bitDepth, options->colsPerChunk, options->rowsPerChunk,

--- a/tools/nitrogfx/main.c
+++ b/tools/nitrogfx/main.c
@@ -181,7 +181,7 @@ void ConvertPngToNtr(char *inputPath, char *outputPath, struct PngToNtrOptions *
 
     if (options->cellFilePath != NULL)
     {
-        ApplyCellsToImage(options->cellFilePath, &image, false, options->cellSnap, false, options->convertTo4Bpp);
+        ApplyCellsToImage(options->cellFilePath, &image, false, options->cellSnap, false, false);
     }
 
     WriteNtrImage(outputPath, options->numTiles, options->bitDepth, options->colsPerChunk, options->rowsPerChunk,


### PR DESCRIPTION
Updates `NCGR` -> `png` conversion to output OAMs with the palette used in-game if both `-cell` and `-convertTo8Bpp` are passed

Ex:
<img width="160" height="337" alt="type_icons" src="https://github.com/user-attachments/assets/7c45ffda-00de-436d-b0e7-6f241aaa9bb2" />
versus
<img width="160" height="337" alt="type_icons" src="https://github.com/user-attachments/assets/7aca8ec2-0e37-4de2-90da-fb28158f4ad2" />

Also includes another bugfix with pl_font.narc's ignore file.