### PR TITLE
Switch to a relative path for the text bank headers directory

### DIFF
--- a/res/text/meson.build
+++ b/res/text/meson.build
@@ -75,7 +75,7 @@ text_banks_order = custom_target('text_banks.order',
 )
 
 # 4. Generate individual text bank binaries from JSON files.
-bank_header_target = meson.current_build_dir() / 'bank'
+bank_header_target = fs.relative_to(meson.current_build_dir() / 'bank', meson.project_build_root())
 bank_header_dir = custom_target('bank_header_dir',
     capture: true,
     output: 'bank_header_dir',


### PR DESCRIPTION
This fixes build on systems where the absolute path to the repository contains spaces or other characters that are not allowed in C identifiers.

Invalid characters caused an issue because msgenc didn't replace them when creating the header guard constant, creating invalid preprocessor directives. In addition to that, the path wasn't properly enclosed in quotes when passed to `mkdir`, which means the directory wasn't created.