### PR TITLE
Document most remaining message script commands

### DIFF
--- a/asm/macros/scrcmd.inc
+++ b/asm/macros/scrcmd.inc
@@ -298,14 +298,19 @@
     .short \messageVar
     .endm
 
-    .macro ScrCmd_02E arg0
+    .macro MessageNoSkip messageID
     .short 46
-    .short \arg0
+    .short \messageID
     .endm
 
-    .macro ScrCmd_02F arg0
+    /*
+     * Used in multi-player contexts to show a message such that it takes
+     * a predictable amount of time, to keep connected games in sync.
+     * In single-player, this behaves like the Message script command.
+     */
+    .macro MessageSynchronized messageID
     .short 47
-    .byte \arg0
+    .byte \messageID
     .endm
 
     .macro WaitABPress
@@ -2886,32 +2891,32 @@
     .short \dummy
     .endm
 
-    .macro ScrCmd_Unused_1FA arg0, arg1
+    .macro MessageFromBankInstant bankID, messageID
     .short 506
-    .short \arg0
-    .short \arg1
+    .short \bankID
+    .short \messageID
     .endm
 
-    .macro ExternalMessage bankID, messageID
+    .macro MessageFromBank bankID, messageID
     .short 507
     .short \bankID
     .short \messageID
     .endm
 
-    .macro ScrCmd_Unused_1FC arg0, arg1, arg2, arg3
+    .macro SentenceInstant sentenceType, sentenceID, word1, word2
     .short 508
-    .short \arg0
-    .short \arg1
-    .short \arg2
-    .short \arg3
+    .short \sentenceType
+    .short \sentenceID
+    .short \word1
+    .short \word2
     .endm
 
-    .macro ScrCmd_Unused_1FD arg0, arg1, arg2, arg3
+    .macro Sentence sentenceType, sentenceID, word1, word2
     .short 509
-    .short \arg0
-    .short \arg1
-    .short \arg2
-    .short \arg3
+    .short \sentenceType
+    .short \sentenceID
+    .short \word1
+    .short \word2
     .endm
 
     .macro ScrCmd_1FE arg0
@@ -2919,12 +2924,12 @@
     .byte \arg0
     .endm
 
-    .macro PrintBattleFrontierBanlist messageID, numRequiredEligiblePokemon, unused2, unused3
+    .macro MessageSeenBanlistSpecies banlistMsgStartIdx, numPokemonRequired
     .short 511
-    .byte \messageID
-    .short \numRequiredEligiblePokemon
-    .short \unused2
-    .byte \unused3
+    .byte \banlistMsgStartIdx
+    .short \numPokemonRequired
+    .short 0
+    .byte 0
     .endm
 
     .macro GetPreviousMapID destVarID
@@ -2995,7 +3000,7 @@
     .short 523
     .endm
 
-    .macro ScrCmd_20C
+    .macro MessageFromTrainerType
     .short 524
     .endm
 
@@ -3685,9 +3690,9 @@
     .short \destAccessoryID
     .endm
 
-    .macro ScrCmd_26D arg0
+    .macro MessageUnown messageID
     .short 621
-    .short \arg0
+    .short \messageID
     .endm
 
     .macro GetGBACartridgeVersion destVarID
@@ -4163,9 +4168,9 @@
     .short 703
     .endm
 
-    .macro ScrCmd_2C0 arg0
+    .macro MessageAutoScroll messageID
     .short 704
-    .short \arg0
+    .short \messageID
     .endm
 
     .macro OpenSaveInfo

--- a/include/overlay005/script_message.h
+++ b/include/overlay005/script_message.h
@@ -5,6 +5,8 @@
 #include "message.h"
 #include "string_template.h"
 
+#define FIELD_MESSAGE_SENTENCE_INSTANT 0xFF
+
 typedef struct ScriptMessageOptions {
     u8 renderDelay;
     u8 autoScroll;

--- a/include/unk_0204AEE8.h
+++ b/include/unk_0204AEE8.h
@@ -10,7 +10,7 @@
 #include "savedata.h"
 #include "string_template.h"
 
-StringTemplate *BattleFrontier_GetStringWithSeenBannedSpecies(SaveData *saveData, u16 param1, u16 param2, u8 param3, u8 *param4);
+StringTemplate *BattleFrontier_MakeSeenBanlistSpeciesMsg(SaveData *saveData, u16 numPokemonRequired, u16 unused2, u8 unused3, u8 *outNumBannedSeen);
 u16 sub_0204AF9C(u8 param0);
 u16 sub_0204AFC4(FieldSystem *fieldSystem, const u16 *param1);
 u16 sub_0204B020(FieldSystem *fieldSystem, const u16 *param1);

--- a/res/field/scripts/scripts_battle_arcade.s
+++ b/res/field/scripts/scripts_battle_arcade.s
@@ -116,13 +116,13 @@ _01B8:
 
 _01E5:
     Message 8
-    PrintBattleFrontierBanlist 9, 3, 0, 0
+    MessageSeenBanlistSpecies 9, 3
     GoTo _0145
     End
 
 _01F8:
     Message 8
-    PrintBattleFrontierBanlist 9, 2, 0, 0
+    MessageSeenBanlistSpecies 9, 2
     GoTo _0145
     End
 
@@ -320,7 +320,7 @@ _0564:
     Return
 
 _057F:
-    ScrCmd_02E 32
+    MessageNoSkip 32
     WaitTime 10, VAR_RESULT
     ClearReceivedTempDataAllPlayers
     ScrCmd_135 155

--- a/res/field/scripts/scripts_battle_castle.s
+++ b/res/field/scripts/scripts_battle_castle.s
@@ -113,13 +113,13 @@ _01AC:
 
 _01D9:
     Message 8
-    PrintBattleFrontierBanlist 9, 3, 0, 0
+    MessageSeenBanlistSpecies 9, 3
     GoTo _0139
     End
 
 _01EC:
     Message 8
-    PrintBattleFrontierBanlist 9, 2, 0, 0
+    MessageSeenBanlistSpecies 9, 2
     GoTo _0139
     End
 
@@ -317,7 +317,7 @@ _0558:
     Return
 
 _0573:
-    ScrCmd_02E 32
+    MessageNoSkip 32
     WaitTime 10, VAR_RESULT
     ClearReceivedTempDataAllPlayers
     ScrCmd_135 137

--- a/res/field/scripts/scripts_battle_factory.s
+++ b/res/field/scripts/scripts_battle_factory.s
@@ -269,7 +269,7 @@ _0449:
     Return
 
 _0464:
-    ScrCmd_02E 9
+    MessageNoSkip 9
     WaitTime 15, VAR_RESULT
     ClearReceivedTempDataAllPlayers
     ScrCmd_135 169

--- a/res/field/scripts/scripts_battle_hall.s
+++ b/res/field/scripts/scripts_battle_hall.s
@@ -239,13 +239,13 @@ _03AC:
 
 _03CF:
     Message 35
-    PrintBattleFrontierBanlist 37, 1, 0, 0
+    MessageSeenBanlistSpecies 37, 1
     GoTo _034D
     End
 
 _03E2:
     Message 36
-    PrintBattleFrontierBanlist 37, 2, 0, 0
+    MessageSeenBanlistSpecies 37, 2
     GoTo _034D
     End
 
@@ -436,7 +436,7 @@ _074B:
     Return
 
 _0766:
-    ScrCmd_02E 9
+    MessageNoSkip 9
     WaitTime 10, VAR_RESULT
     ClearReceivedTempDataAllPlayers
     ScrCmd_135 109

--- a/res/field/scripts/scripts_battle_tower.s
+++ b/res/field/scripts/scripts_battle_tower.s
@@ -226,7 +226,7 @@ BattleTower_InitSingleBattleRoomChallenge:
 _0360:
     CallBattleTowerFunction BATTLE_TOWER_FUNCTION_CHECK_ENOUGH_VALID_POKEMON, 0, VAR_RESULT
     GoToIfEq VAR_RESULT, 1, BattleTower_SelectAndValidatePokemon
-    PrintBattleFrontierBanlist BattleTower_Text_NotEnoughEligiblePokemon, 3, 0, 0
+    MessageSeenBanlistSpecies BattleTower_Text_NotEnoughEligiblePokemon, 3
     GoTo BattleTower_WaitABXPadPress
     End
 
@@ -234,7 +234,7 @@ BattleTower_InitDoubleBattleRoomChallenge:
     InitBattleTower 0, BATTLE_TOWER_MODE_DOUBLE
     CallBattleTowerFunction BATTLE_TOWER_FUNCTION_CHECK_ENOUGH_VALID_POKEMON, 0, VAR_RESULT
     GoToIfEq VAR_RESULT, 1, BattleTower_SelectAndValidatePokemon
-    PrintBattleFrontierBanlist BattleTower_Text_NotEnoughEligiblePokemon, 4, 0, 0
+    MessageSeenBanlistSpecies BattleTower_Text_NotEnoughEligiblePokemon, 4
     GoTo BattleTower_WaitABXPadPress
     End
 
@@ -679,7 +679,7 @@ BattleTower_ExplainMultiBattleRoom:
 BattleTower_StartMultiBattleRoomChallenge:
     CallBattleTowerFunction BATTLE_TOWER_FUNCTION_CHECK_ENOUGH_VALID_POKEMON, 2, VAR_RESULT
     GoToIfEq VAR_RESULT, 1, BattleTower_AskCommunicateWithFriend
-    PrintBattleFrontierBanlist BattleTower_Text_NotEnoughEligiblePokemon, 2, 0, 0
+    MessageSeenBanlistSpecies BattleTower_Text_NotEnoughEligiblePokemon, 2
     GoTo BattleTower_WaitABXPadPress
     End
 

--- a/res/field/scripts/scripts_common.s
+++ b/res/field/scripts/scripts_common.s
@@ -1358,7 +1358,7 @@ _12A8:
     PlayFanfare SEQ_SE_CONFIRM
     LockAll
     FacePlayer
-    ScrCmd_20C
+    MessageFromTrainerType
     WaitABXPadPress
     CloseMessage
     ReleaseAll

--- a/res/field/scripts/scripts_solaceon_ruins_maniac_tunnel_room.s
+++ b/res/field/scripts/scripts_solaceon_ruins_maniac_tunnel_room.s
@@ -8,7 +8,7 @@
 _0006:
     PlayFanfare SEQ_SE_CONFIRM
     LockAll
-    ScrCmd_26D 0
+    MessageUnown 0
     WaitABXPadPress
     CloseMessage
     ReleaseAll

--- a/res/field/scripts/scripts_solaceon_ruins_room_1.s
+++ b/res/field/scripts/scripts_solaceon_ruins_room_1.s
@@ -13,7 +13,7 @@ _000A:
 _0010:
     PlayFanfare SEQ_SE_CONFIRM
     LockAll
-    ScrCmd_26D 0
+    MessageUnown 0
     WaitABXPadPress
     CloseMessage
     ReleaseAll

--- a/res/field/scripts/scripts_solaceon_ruins_room_7.s
+++ b/res/field/scripts/scripts_solaceon_ruins_room_7.s
@@ -8,7 +8,7 @@
 _0006:
     PlayFanfare SEQ_SE_CONFIRM
     LockAll
-    ScrCmd_26D 0
+    MessageUnown 0
     WaitABXPadPress
     CloseMessage
     ReleaseAll

--- a/res/field/scripts/scripts_tv_broadcast.s
+++ b/res/field/scripts/scripts_tv_broadcast.s
@@ -21,14 +21,14 @@ TVBroadcast_Interact:
 
 TVBroadcast_PlayCommercial:
     LoadTVCommercial VAR_0x8004, VAR_0x8005
-    ExternalMessage VAR_0x8004, VAR_0x8005
+    MessageFromBank VAR_0x8004, VAR_0x8005
     WaitABXPadPress
     GoTo TVBroadcast_End
     End
 
 TVBroadcast_FinishProgram:
     LoadTVFarewell VAR_0x8004, VAR_0x8005
-    ExternalMessage VAR_0x8004, VAR_0x8005
+    MessageFromBank VAR_0x8004, VAR_0x8005
     WaitABXPadPress
     FinishTVProgram
     GoTo TVBroadcast_End
@@ -36,7 +36,7 @@ TVBroadcast_FinishProgram:
 
 TVBroadcast_BeginProgram:
     LoadTVGreeting VAR_0x8004, VAR_0x8005
-    ExternalMessage VAR_0x8004, VAR_0x8005
+    MessageFromBank VAR_0x8004, VAR_0x8005
     GoTo TVBroadcast_ContinueProgram
     End
 
@@ -49,7 +49,7 @@ TVBroadcast_ContinueProgram:
 TVBroadcast_FinishProgram_Early:
     LoadTVFarewellExtended VAR_0x8004, VAR_0x8005
     TVBroadcastDummy VAR_0x8004, VAR_0x8005
-    ExternalMessage VAR_0x8004, VAR_0x8005
+    MessageFromBank VAR_0x8004, VAR_0x8005
     FinishTVProgram
     WaitABXPadPress
     GoTo TVBroadcast_End
@@ -58,10 +58,10 @@ TVBroadcast_FinishProgram_Early:
 TVBroadcast_PlaySegment:
     LoadTVSegmentIntro VAR_0x8004, VAR_0x8005
     TVBroadcastDummy VAR_0x8004, VAR_0x8005
-    ExternalMessage VAR_0x8004, VAR_0x8005
+    MessageFromBank VAR_0x8004, VAR_0x8005
     LoadTVSegment VAR_0x8006, VAR_0x8004, VAR_0x8005
     TVBroadcastDummy VAR_0x8006, VAR_0x8004, VAR_0x8005
-    ExternalMessage VAR_0x8004, VAR_0x8005
+    MessageFromBank VAR_0x8004, VAR_0x8005
     WaitABXPadPress
     GoTo TVBroadcast_End
     End

--- a/res/field/scripts/scripts_tv_reporter_interviews.s
+++ b/res/field/scripts/scripts_tv_reporter_interviews.s
@@ -116,7 +116,7 @@ _0159:
 
 _0190:
     LoadTVInterviewMessage VAR_0x8000, VAR_0x8004, VAR_0x8005
-    ExternalMessage VAR_0x8004, VAR_0x8005
+    MessageFromBank VAR_0x8004, VAR_0x8005
     GoToIfEq VAR_0x8000, 10, _01F0
     FadeScreenOut
     WaitFadeScreen

--- a/res/field/scripts/scripts_union_room.s
+++ b/res/field/scripts/scripts_union_room.s
@@ -47,7 +47,7 @@ _002A:
 _00BA:
     ScrCmd_135 100
     ScrCmd_13F 2, VAR_RESULT
-    ScrCmd_2C0 VAR_RESULT
+    MessageAutoScroll VAR_RESULT
     GoTo _00EA
     End
 
@@ -477,7 +477,7 @@ _07BA:
     LockAll
     PlayFanfare SEQ_SE_DP_BUTTON9
     ScrCmd_13C 1
-    ScrCmd_2C0 7
+    MessageAutoScroll 7
     WaitABPressTime 30
     GoTo _07D4
     End

--- a/res/field/scripts/scripts_unk_0212.s
+++ b/res/field/scripts/scripts_unk_0212.s
@@ -505,11 +505,11 @@ _070D:
     ScrCmd_109 VAR_RESULT
     AddVar VAR_RESULT, 1
     ScrCmd_0FF VAR_RESULT, 0
-    ScrCmd_02F 22
+    MessageSynchronized 22
     ScrCmd_109 VAR_RESULT
     ScrCmd_0FD VAR_RESULT, 0
     ScrCmd_0FE VAR_RESULT, 1
-    ScrCmd_02F 64
+    MessageSynchronized 64
     ScrCmd_0F8 25
     ScrCmd_0F9 25
     CloseMessage
@@ -570,7 +570,7 @@ _0830:
     WaitMovement
     Call _0115
     WaitMovement
-    ScrCmd_02F 211
+    MessageSynchronized 211
     CloseMessage
     GoTo _086A
     End
@@ -585,20 +585,20 @@ _086A:
 
 _0892:
     BufferPlayerName 0
-    ScrCmd_02F 66
+    MessageSynchronized 66
     GoTo _08AE
     End
 
 _08A0:
     BufferPlayerName 0
-    ScrCmd_02F 67
+    MessageSynchronized 67
     GoTo _08AE
     End
 
 _08AE:
     ApplyMovement LOCALID_PLAYER, _0E00
     WaitMovement
-    ScrCmd_02F 68
+    MessageSynchronized 68
     ScrCmd_0F8 26
     ScrCmd_0F9 26
     CloseMessage
@@ -655,13 +655,13 @@ _0947:
     WaitMovement
     ScrCmd_102 0
     ScrCmd_103 1
-    ScrCmd_02F 69
+    MessageSynchronized 69
     ScrCmd_0F8 19
     ScrCmd_0F9 19
     ApplyMovement 0, _0E54
     WaitMovement
     ScrCmd_0FD 0, 0
-    ScrCmd_02F 70
+    MessageSynchronized 70
     ScrCmd_10B 0, VAR_RESULT
     ScrCmd_111 0
     Call _0C47
@@ -671,7 +671,7 @@ _0947:
     ApplyMovement 0, _0E5C
     WaitMovement
     ScrCmd_0FD 1, 0
-    ScrCmd_02F 71
+    MessageSynchronized 71
     ScrCmd_10B 1, VAR_RESULT
     ScrCmd_111 1
     Call _0C47
@@ -680,7 +680,7 @@ _0947:
     ScrCmd_0F9 21
     WaitTime 8, VAR_RESULT
     ScrCmd_0FD 2, 0
-    ScrCmd_02F 72
+    MessageSynchronized 72
     ScrCmd_10B 2, VAR_RESULT
     ScrCmd_111 2
     Call _0C47
@@ -690,7 +690,7 @@ _0947:
     ApplyMovement 0, _0E64
     WaitMovement
     ScrCmd_0FD 3, 0
-    ScrCmd_02F 73
+    MessageSynchronized 73
     ScrCmd_10B 3, VAR_RESULT
     ScrCmd_111 3
     Call _0C47
@@ -699,7 +699,7 @@ _0947:
     ScrCmd_0F9 23
     ApplyMovement 0, _0E6C
     WaitMovement
-    ScrCmd_02F 74
+    MessageSynchronized 74
     CloseMessage
     ScrCmd_0F8 4
     ScrCmd_0F9 4
@@ -723,7 +723,7 @@ _0947:
     ScrCmd_10B VAR_RESULT, VAR_RESULT
     Call _0C47
     ScrCmd_112
-    ScrCmd_02F 76
+    MessageSynchronized 76
     ScrCmd_115 VAR_RESULT
     GoToIfEq VAR_RESULT, 1, _0B50
     ScrCmd_104 0
@@ -731,11 +731,11 @@ _0947:
     ScrCmd_10E 2
     ScrCmd_10D VAR_RESULT
     GoToIfEq VAR_RESULT, 0, _0B1B
-    ScrCmd_02F 79
+    MessageSynchronized 79
     GoTo _0B50
 
 _0B1B:
-    ScrCmd_02F 77
+    MessageSynchronized 77
     CloseMessage
     ApplyMovement 0, _0E64
     ApplyMovement 5, _0E54
@@ -747,7 +747,7 @@ _0B1B:
     ApplyMovement 5, _0E6C
     WaitMovement
 _0B50:
-    ScrCmd_02F 78
+    MessageSynchronized 78
     CloseMessage
     PlayFanfare SEQ_SE_DP_CON_F007
     ScrCmd_108 VAR_RESULT

--- a/res/field/scripts/scripts_unk_0213.s
+++ b/res/field/scripts/scripts_unk_0213.s
@@ -309,7 +309,7 @@ _045D:
 _046A:
     SetVar VAR_UNK_0x40D5, 1
     SetFlag FLAG_COMMUNICATION_CLUB_ACCESSIBLE
-    ScrCmd_02E 52
+    MessageNoSkip 52
     WaitABPressTime 45
     ScrCmd_135 96
     CloseMessage

--- a/res/field/scripts/scripts_unk_0407.s
+++ b/res/field/scripts/scripts_unk_0407.s
@@ -52,7 +52,7 @@ _00A2:
     GoToIfEq VAR_RESULT, 0, _00D8
     PlaySound SEQ_FANFA4
     PrepareMysteryGiftReceivedMsg VAR_0x8005, VAR_0x8006
-    ExternalMessage VAR_0x8005, VAR_0x8006
+    MessageFromBank VAR_0x8005, VAR_0x8006
     WaitSound
     Message 18
     WaitABXPadPress
@@ -61,7 +61,7 @@ _00A2:
 
 _00D8:
     PrepareMysterGiftCantReceiveMsg VAR_0x8005, VAR_0x8006
-    ExternalMessage VAR_0x8005, VAR_0x8006
+    MessageFromBank VAR_0x8005, VAR_0x8006
     WaitABXPadPress
     GoTo _00F9
 

--- a/src/overlay005/script_message.c
+++ b/src/overlay005/script_message.c
@@ -85,7 +85,7 @@ void ScriptMessage_ShowSentence(ScriptContext *ctx, u16 sentenceType, u16 senten
     OpenMessageBox(ctx->fieldSystem, &msgData);
     GetStrBufFromSentence(&msgData, sentenceType, sentenceID, word1, word2);
 
-    if (canSkipDelay != 0xFF) {
+    if (canSkipDelay != FIELD_MESSAGE_SENTENCE_INSTANT) {
         PrintFieldMessage(&msgData, FONT_MESSAGE, GetTextFrameDelay(ctx), canSkipDelay, FALSE);
     } else {
         PrintTextMessage(&msgData, FONT_MESSAGE);

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -5024,7 +5024,7 @@ static const u16 sBattleFrontierBanlist[BATTLE_FRONTIER_BANLIST_SIZE] = {
 
 BOOL Pokemon_IsOnBattleFrontierBanlist(u16 species)
 {
-    for (u32 i = 0; i < NELEMS(sBattleFrontierBanlist); i++) {
+    for (u32 i = 0; i < BATTLE_FRONTIER_BANLIST_SIZE; i++) {
         if (species == sBattleFrontierBanlist[i]) {
             return TRUE;
         }
@@ -5035,7 +5035,7 @@ BOOL Pokemon_IsOnBattleFrontierBanlist(u16 species)
 
 u16 Pokemon_GetBattleFrontierBanlistEntry(u8 index)
 {
-    if (index >= NELEMS(sBattleFrontierBanlist)) {
+    if (index >= BATTLE_FRONTIER_BANLIST_SIZE) {
         index = 0;
     }
 

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -286,18 +286,18 @@ static BOOL ScrCmd_SetVarFromValue(ScriptContext *ctx);
 static BOOL ScrCmd_SetVarFromVar(ScriptContext *ctx);
 static BOOL ScrCmd_Unused_02A(ScriptContext *ctx);
 static BOOL ScrCmd_MessageInstant(ScriptContext *ctx);
-static BOOL ScrCmd_Unused_1FA(ScriptContext *ctx);
-static BOOL ScrCmd_ExternalMessage(ScriptContext *ctx);
-static BOOL ScrCmd_Unused_1FC(ScriptContext *ctx);
-static BOOL ScrCmd_Unused_1FD(ScriptContext *ctx);
+static BOOL ScrCmd_MessageFromBankInstant(ScriptContext *ctx);
+static BOOL ScrCmd_MessageFromBank(ScriptContext *ctx);
+static BOOL ScrCmd_SentenceInstant(ScriptContext *ctx);
+static BOOL ScrCmd_Sentence(ScriptContext *ctx);
 static BOOL ScrCmd_1FE(ScriptContext *ctx);
-static BOOL ScrCmd_PrintBattleFrontierBanlist(ScriptContext *ctx);
-static BOOL ScrCmd_26D(ScriptContext *ctx);
+static BOOL ScrCmd_MessageSeenBanlistSpecies(ScriptContext *ctx);
+static BOOL ScrCmd_MessageUnown(ScriptContext *ctx);
 static BOOL ScrCmd_Message(ScriptContext *ctx);
 static BOOL ScrCmd_MessageVar(ScriptContext *ctx);
-static BOOL ScrCmd_2C0(ScriptContext *ctx);
-static BOOL ScrCmd_02E(ScriptContext *ctx);
-static BOOL ScrCmd_02F(ScriptContext *ctx);
+static BOOL ScrCmd_MessageAutoScroll(ScriptContext *ctx);
+static BOOL ScrCmd_MessageNoSkip(ScriptContext *ctx);
+static BOOL ScrCmd_MessageSynchronized(ScriptContext *ctx);
 static BOOL ScriptContext_WaitForFinishedPrinting(ScriptContext *ctx);
 static BOOL ScrCmd_WaitABPress(ScriptContext *ctx);
 static BOOL ScriptContext_CheckABPress(ScriptContext *ctx);
@@ -594,7 +594,7 @@ static BOOL ScrCmd_204(ScriptContext *ctx);
 static BOOL ScrCmd_205(ScriptContext *ctx);
 static BOOL ScrCmd_310(ScriptContext *ctx);
 static BOOL ScrCmd_StartGreatMarshLookout(ScriptContext *ctx);
-static BOOL ScrCmd_20C(ScriptContext *ctx);
+static BOOL ScrCmd_MessageFromTrainerType(ScriptContext *ctx);
 static BOOL ScrCmd_20D(ScriptContext *ctx);
 static BOOL ScrCmd_InitGreatMarshTram(ScriptContext *ctx);
 static BOOL ScrCmd_MoveGreatMarshTram(ScriptContext *ctx);
@@ -815,8 +815,8 @@ const ScrCmdFunc Unk_020EAC58[] = {
     ScrCmd_MessageInstant,
     ScrCmd_Message,
     ScrCmd_MessageVar,
-    ScrCmd_02E,
-    ScrCmd_02F,
+    ScrCmd_MessageNoSkip,
+    ScrCmd_MessageSynchronized,
     ScrCmd_WaitABPress,
     ScrCmd_WaitABXPadPress,
     ScrCmd_WaitABPadPress,
@@ -1275,12 +1275,12 @@ const ScrCmdFunc Unk_020EAC58[] = {
     ScrCmd_SurvivePoison,
     ScrCmd_1F8,
     ScrCmd_Dummy1F9,
-    ScrCmd_Unused_1FA,
-    ScrCmd_ExternalMessage,
-    ScrCmd_Unused_1FC,
-    ScrCmd_Unused_1FD,
+    ScrCmd_MessageFromBankInstant,
+    ScrCmd_MessageFromBank,
+    ScrCmd_SentenceInstant,
+    ScrCmd_Sentence,
     ScrCmd_1FE,
-    ScrCmd_PrintBattleFrontierBanlist,
+    ScrCmd_MessageSeenBanlistSpecies,
     ScrCmd_GetPreviousMapID,
     ScrCmd_GetCurrentMapID,
     ScrCmd_StartEndSafariGame,
@@ -1293,7 +1293,7 @@ const ScrCmdFunc Unk_020EAC58[] = {
     ScrCmd_209,
     ScrCmd_20A,
     ScrCmd_20B,
-    ScrCmd_20C,
+    ScrCmd_MessageFromTrainerType,
     ScrCmd_20D,
     ScrCmd_InitGreatMarshTram,
     ScrCmd_MoveGreatMarshTram,
@@ -1390,7 +1390,7 @@ const ScrCmdFunc Unk_020EAC58[] = {
     ScrCmd_26A,
     ScrCmd_CheckHasAllLegendaryTitansInParty,
     ScrCmd_TryGetRandomMassageGirlAccessory,
-    ScrCmd_26D,
+    ScrCmd_MessageUnown,
     ScrCmd_GetGBACartridgeVersion,
     ScrCmd_ClearSpiritombCounter,
     ScrCmd_SetHiddenLocation,
@@ -1473,7 +1473,7 @@ const ScrCmdFunc Unk_020EAC58[] = {
     ScrCmd_StartLegendaryBattle,
     ScrCmd_GetTrainerCardLevel,
     ScrCmd_2BF,
-    ScrCmd_2C0,
+    ScrCmd_MessageAutoScroll,
     ScrCmd_OpenSaveInfo,
     ScrCmd_CloseSaveInfo,
     ScrCmd_Unused_2C3,
@@ -2039,20 +2039,20 @@ static BOOL ScrCmd_MessageInstant(ScriptContext *ctx)
     return FALSE;
 }
 
-static BOOL ScrCmd_Unused_1FA(ScriptContext *ctx)
+static BOOL ScrCmd_MessageFromBankInstant(ScriptContext *ctx)
 {
-    u16 v1 = ScriptContext_GetVar(ctx);
-    u16 v2 = ScriptContext_GetVar(ctx);
+    u16 bankID = ScriptContext_GetVar(ctx);
+    u16 messageID = ScriptContext_GetVar(ctx);
 
-    MessageLoader *msgLoader = MessageLoader_Init(MESSAGE_LOADER_NARC_HANDLE, NARC_INDEX_MSGDATA__PL_MSG, v1, HEAP_ID_FIELD3);
+    MessageLoader *msgLoader = MessageLoader_Init(MESSAGE_LOADER_NARC_HANDLE, NARC_INDEX_MSGDATA__PL_MSG, bankID, HEAP_ID_FIELD3);
 
-    ScriptMessage_ShowInstant(ctx, msgLoader, v2);
+    ScriptMessage_ShowInstant(ctx, msgLoader, messageID);
     MessageLoader_Free(msgLoader);
 
     return FALSE;
 }
 
-static BOOL ScrCmd_ExternalMessage(ScriptContext *ctx)
+static BOOL ScrCmd_MessageFromBank(ScriptContext *ctx)
 {
     u16 bankID = ScriptContext_GetVar(ctx);
     u16 messageID = ScriptContext_GetVar(ctx);
@@ -2066,25 +2066,25 @@ static BOOL ScrCmd_ExternalMessage(ScriptContext *ctx)
     return TRUE;
 }
 
-static BOOL ScrCmd_Unused_1FC(ScriptContext *ctx)
+static BOOL ScrCmd_SentenceInstant(ScriptContext *ctx)
 {
-    u16 v0 = ScriptContext_ReadHalfWord(ctx);
-    u16 v1 = ScriptContext_ReadHalfWord(ctx);
-    u16 v2 = ScriptContext_ReadHalfWord(ctx);
-    u16 v3 = ScriptContext_ReadHalfWord(ctx);
+    u16 sentenceType = ScriptContext_ReadHalfWord(ctx);
+    u16 sentenceID = ScriptContext_ReadHalfWord(ctx);
+    u16 word1 = ScriptContext_ReadHalfWord(ctx);
+    u16 word2 = ScriptContext_ReadHalfWord(ctx);
 
-    ScriptMessage_ShowSentence(ctx, v0, v1, v2, v3, 0xFF);
+    ScriptMessage_ShowSentence(ctx, sentenceType, sentenceID, word1, word2, FIELD_MESSAGE_SENTENCE_INSTANT);
     return FALSE;
 }
 
-static BOOL ScrCmd_Unused_1FD(ScriptContext *ctx)
+static BOOL ScrCmd_Sentence(ScriptContext *ctx)
 {
-    u16 v0 = ScriptContext_ReadHalfWord(ctx);
-    u16 v1 = ScriptContext_ReadHalfWord(ctx);
-    u16 v2 = ScriptContext_ReadHalfWord(ctx);
-    u16 v3 = ScriptContext_ReadHalfWord(ctx);
+    u16 sentenceType = ScriptContext_ReadHalfWord(ctx);
+    u16 sentenceID = ScriptContext_ReadHalfWord(ctx);
+    u16 word1 = ScriptContext_ReadHalfWord(ctx);
+    u16 word2 = ScriptContext_ReadHalfWord(ctx);
 
-    ScriptMessage_ShowSentence(ctx, v0, v1, v2, v3, 1);
+    ScriptMessage_ShowSentence(ctx, sentenceType, sentenceID, word1, word2, TRUE);
     ScriptContext_Pause(ctx, ScriptContext_WaitForFinishedPrinting);
 
     return TRUE;
@@ -2114,33 +2114,33 @@ static BOOL ScrCmd_1FE(ScriptContext *ctx)
     return TRUE;
 }
 
-static BOOL ScrCmd_PrintBattleFrontierBanlist(ScriptContext *ctx)
+static BOOL ScrCmd_MessageSeenBanlistSpecies(ScriptContext *ctx)
 {
     FieldSystem *fieldSystem = ctx->fieldSystem;
-    u8 messageID = ScriptContext_ReadByte(ctx);
-    u16 numRequiredEligiblePokemon = ScriptContext_GetVar(ctx);
+    u8 banlistMsgStartIdx = ScriptContext_ReadByte(ctx);
+    u16 numPokemonRequired = ScriptContext_GetVar(ctx);
     u16 unused3 = ScriptContext_ReadHalfWord(ctx);
     u8 unused4 = ScriptContext_ReadByte(ctx);
     u8 numBannedSpeciesSeen = 0;
 
-    StringTemplate *strTemplate = BattleFrontier_GetStringWithSeenBannedSpecies(fieldSystem->saveData, numRequiredEligiblePokemon, unused3, unused4, &numBannedSpeciesSeen);
+    StringTemplate *seenBannedSpeciesList = BattleFrontier_MakeSeenBanlistSpeciesMsg(fieldSystem->saveData, numPokemonRequired, unused3, unused4, &numBannedSpeciesSeen);
 
-    ScriptMessage_ShowTemplate(ctx, strTemplate, messageID + numBannedSpeciesSeen, TRUE);
-    StringTemplate_Free(strTemplate);
+    ScriptMessage_ShowTemplate(ctx, seenBannedSpeciesList, banlistMsgStartIdx + numBannedSpeciesSeen, TRUE);
+    StringTemplate_Free(seenBannedSpeciesList);
     ScriptContext_Pause(ctx, ScriptContext_WaitForFinishedPrinting);
 
     return TRUE;
 }
 
-static BOOL ScrCmd_26D(ScriptContext *ctx)
+static BOOL ScrCmd_MessageUnown(ScriptContext *ctx)
 {
-    ScriptMessageOptions v0;
-    u16 v1 = ScriptContext_ReadHalfWord(ctx);
+    u16 messageID = ScriptContext_ReadHalfWord(ctx);
 
-    ScriptMessageOptions_Init(&v0, ctx);
-    v0.fontID = 3;
+    ScriptMessageOptions msgOptions;
+    ScriptMessageOptions_Init(&msgOptions, ctx);
+    msgOptions.fontID = FONT_UNOWN;
 
-    ScriptMessage_Show(ctx, ctx->loader, v1, FALSE, &v0);
+    ScriptMessage_Show(ctx, ctx->loader, messageID, FALSE, &msgOptions);
     ScriptContext_Pause(ctx, ScriptContext_WaitForFinishedPrinting);
 
     return TRUE;
@@ -2174,43 +2174,43 @@ static BOOL ScrCmd_MessageVar(ScriptContext *ctx)
     return TRUE;
 }
 
-static BOOL ScrCmd_2C0(ScriptContext *ctx)
+static BOOL ScrCmd_MessageAutoScroll(ScriptContext *ctx)
 {
-    u16 v0 = ScriptContext_GetVar(ctx);
-    ScriptMessageOptions v1;
+    u16 messageID = ScriptContext_GetVar(ctx);
+    ScriptMessageOptions msgOptions;
 
-    ScriptMessageOptions_Init(&v1, ctx);
+    ScriptMessageOptions_Init(&msgOptions, ctx);
 
-    v1.autoScroll = 1;
+    msgOptions.autoScroll = TRUE;
 
-    ScriptMessage_Show(ctx, ctx->loader, (u8)v0, TRUE, &v1);
+    ScriptMessage_Show(ctx, ctx->loader, (u8)messageID, TRUE, &msgOptions);
     ScriptContext_Pause(ctx, ScriptContext_WaitForFinishedPrinting);
 
     return TRUE;
 }
 
-static BOOL ScrCmd_02E(ScriptContext *ctx)
+static BOOL ScrCmd_MessageNoSkip(ScriptContext *ctx)
 {
-    u16 v0 = ScriptContext_GetVar(ctx);
+    u16 messageID = ScriptContext_GetVar(ctx);
 
-    ScriptMessage_Show(ctx, ctx->loader, (u8)v0, FALSE, NULL);
+    ScriptMessage_Show(ctx, ctx->loader, (u8)messageID, FALSE, NULL);
     ScriptContext_Pause(ctx, ScriptContext_WaitForFinishedPrinting);
 
     return TRUE;
 }
 
-static BOOL ScrCmd_20C(ScriptContext *ctx)
+static BOOL ScrCmd_MessageFromTrainerType(ScriptContext *ctx)
 {
     MapObject **mapObj = FieldSystem_GetScriptMemberPtr(ctx->fieldSystem, SCRIPT_MANAGER_TARGET_OBJECT);
-    u8 v1 = MapObject_GetTrainerType(*mapObj);
+    u8 trainerType = MapObject_GetTrainerType(*mapObj);
 
-    ScriptMessage_Show(ctx, ctx->loader, v1, TRUE, NULL);
+    ScriptMessage_Show(ctx, ctx->loader, trainerType, TRUE, NULL);
     ScriptContext_Pause(ctx, ScriptContext_WaitForFinishedPrinting);
 
     return TRUE;
 }
 
-static BOOL ScrCmd_02F(ScriptContext *ctx)
+static BOOL ScrCmd_MessageSynchronized(ScriptContext *ctx)
 {
     u8 messageID = ScriptContext_ReadByte(ctx);
 


### PR DESCRIPTION
Documents remaining script commands using `ScriptMessage`, except for one.
The remaining `ScrCmd_1FE` is used in the battle tower and seems to be for pre/post-battle messages, from what I can see in text bank 613? But it looks like it would require looking into battle frontier stuff more in-depth so I chose to left it undocumented for now.