### PR TITLE
(nitrogfx) Correctly calculate max possible NCER label length

### DIFF
--- a/tools/nitrogfx/gfx.c
+++ b/tools/nitrogfx/gfx.c
@@ -1675,7 +1675,7 @@ void ReadNtrCell_LABL(unsigned char * restrict data, unsigned int blockOffset, u
         {
             FATAL_ERROR("corrupted LABL block\n");
         }
-        unsigned long slen = strnlen((char *)data + offset, blockSize - offset);
+        unsigned long slen = strnlen((char *)data + offset, (blockOffset + blockSize) - offset);
         options->labels[i] = malloc(slen + 1);
         strncpy(options->labels[i], (char *)data + offset, slen + 1);
     }


### PR DESCRIPTION
Found this while trying to unpack `poketch.narc`.

When calculating the length of a NCER label `slen`, a max size argument is passed to `strnlen()`. I think this max size is meant to be the number of bytes between the start of the specific label and the end of the entire LABL block.

The problem is, while `blockSize` is the size of just the LABL block, `offset` is an offset from the beginning of the **entire** NCER. This results in `blockSize - offset` being much smaller than intended. I think it often underflows and becomes a non-problem, but I was experiencing a situation where `slen` was being set to 1, resulting in garbage data being generated into the cell.json.

My solution is to modify the max size calculation to be `(blockOffset + blockSize) - offset`. `blockOffset + blockSize` is the end point of the LABL block, and subtracting `offset` then gives the remaining space in the block after the start of the label, as I believe was originally intended.

Since this change only affects NCER -> cell.json, it doesn't affect the project build. But I did test it on the poketch NCER files I'm working on, and have confirmed nitrogfx now is building matching cell.jsons where it was not previously.