### PR TITLE
(nitrogfx) Call SnapToTile for cells without boundingRect

### DIFF
--- a/tools/nitrogfx/gfx.c
+++ b/tools/nitrogfx/gfx.c
@@ -800,11 +800,6 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG, bool
         {
             cellHeight = options->cells[i]->maxY - options->cells[i]->minY;
             cellWidth = options->cells[i]->maxX - options->cells[i]->minX;
-            if (snap)
-            {
-                cellHeight = SnapToTile(cellHeight);
-                cellWidth = SnapToTile(cellWidth);
-            }
             minXs[i] = options->cells[i]->minX;
             minYs[i] = options->cells[i]->minY;
         }
@@ -848,6 +843,11 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG, bool
             cellHeight = maxY - minY;
             minXs[i] = minX;
             minYs[i] = minY;
+        }
+        if (snap)
+        {
+            cellHeight = SnapToTile(cellHeight);
+            cellWidth = SnapToTile(cellWidth);
         }
 
         outputHeight += cellHeight + 1;


### PR DESCRIPTION
This is another change I found while unpacking poketch.narc.

The offending NCGR was for the friendship checker sprites. When applying the cell file to convert to PNG I was getting this result 
<img width="69" height="83" alt="friendship_checker_old" src="https://github.com/user-attachments/assets/ac4f0cda-83df-49db-8741-c327bff937b8" />
After doing some digging, I found that I could get a valid result by moving the x coordinate of one of the OAMs by one. I then managed to find the relevant section in the nitrogfx source, and saw that while `x` and `y` were being "snapped", `outputWidth` was not.

To fix this, I would like to simply move the block that snaps `cellHeight` and `cellWidth` to outside the `boundingRect` conditional, so that it is called regardless of how the height and width are calculated.

Here is what the PNG becomes with this change:
<img width="72" height="83" alt="friendship_checker" src="https://github.com/user-attachments/assets/cf1e3943-5528-4b2f-808c-e6c11273e8e2" />