### PR TITLE
msgenc: Fix OOB entry ID read when dumping to JSON

### DIFF
--- a/tools/msgenc/Json.cpp
+++ b/tools/msgenc/Json.cpp
@@ -215,6 +215,7 @@ void Json::ToFile(MessagesConverter &converter) {
         rapidjson::Value entry_name(rapidjson::kStringType);
         if (it != id_strings.cend()) {
             entry_name.SetString(it->c_str(), doc.GetAllocator());
+            it++;
         } else {
             sprintf(keybuf, "%s_%s", prefix.c_str(), row_no_buf);
             entry_name.SetString(keybuf, doc.GetAllocator());
@@ -246,7 +247,6 @@ void Json::ToFile(MessagesConverter &converter) {
 
         messages.PushBack(entry, doc.GetAllocator());
         IncRowNoBuf();
-        it++;
     }
 
     doc.AddMember("messages", messages, doc.GetAllocator());

--- a/tools/msgenc/msgenc.cpp
+++ b/tools/msgenc/msgenc.cpp
@@ -11,7 +11,7 @@
 #include "Options.h"
 
 static const char* progname = "msgenc";
-static const char* version = "2025.08.12";
+static const char* version = "2025.11.24";
 
 static inline void usage() {
     cout << progname << " v" << version << endl;


### PR DESCRIPTION
Entry ID strings iterator was incremented unconditionally, so it ended up past the iterator's end when the text bank binary has more than however many entries the passed header file has + 1 (or more than 1 if no header file is passed), failing the check and resulting in an OOB read.