### PR TITLE
Duplicate generator for field-scripts to force dependency on events

### DIFF
--- a/res/field/events/meson.build
+++ b/res/field/events/meson.build
@@ -564,7 +564,7 @@ events_narc = custom_target('zone_event.narc',
         'zone_event.naix.h',
     ],
     input: event_bin_gen.process(events_files, env: json2bin_env),
-    depends: [ py_consts_generators, events_headers],
+    depends: [ py_consts_generators, events_headers ],
     command: [
         narc_exe, 'create',
         '--naix',

--- a/res/field/scripts/meson.build
+++ b/res/field/scripts/meson.build
@@ -1,5 +1,33 @@
-relative_source_root = fs.relative_to(meson.project_source_root(), meson.project_build_root())
 relative_build_dir = fs.relative_to(meson.current_build_dir(), meson.project_build_root())
+
+# NOTE: This is a functional copy of script_bin_gen, which is separated from the
+# base generator due to an additional dependency on headers generated for
+# events IDs. Meson unfortunately does not have a clean way to copy an existing
+# object and tweak a single property.
+# WARN: If you update this generator, you should also consider updating its parent
+# in res/meson.build
+field_script_bin_gen = generator(make_script_bin_sh,
+    arguments: [
+        '-i', relative_source_root / 'include',
+        '-i', relative_source_root / 'asm',
+        '-i', '.' / 'res' / 'text',
+        '-i', '.' / 'res',
+        '-i', '.',
+        '--depfile',
+        '--assembler', arm_none_eabi_gcc_exe.full_path(),
+        '--objcopy', arm_none_eabi_objcopy_exe.full_path(),
+        '@EXTRA_ARGS@',
+        '@INPUT@',
+    ],
+    depends: [
+        text_banks,
+        c_consts_generators,
+        h_headers,
+        events_headers,
+    ],
+    output: '@BASENAME@',
+    depfile: '@BASENAME@.d',
+)
 
 scr_seq_target_name = 'scr_seq.narc'
 scr_seq_private_dir = relative_build_dir / scr_seq_target_name + '.p'
@@ -1138,7 +1166,7 @@ scr_seq_narc = custom_target('scr_seq.narc',
         'scr_seq.narc',
         'scr_seq.naix.h',
     ],
-    input: script_bin_gen.process(
+    input: field_script_bin_gen.process(
         scr_seq_files,
         extra_args: ['--depfile', '--out-dir', scr_seq_private_dir]
     ),

--- a/res/meson.build
+++ b/res/meson.build
@@ -89,6 +89,8 @@ relative_source_root = fs.relative_to(meson.project_source_root(), meson.project
 # *breaks* the dependency-chain if any of these files are edited. However, because
 # this generator produces a depfile, the build back-end will still see the correct
 # granular headers on which each input source file depends.
+# WARN: If you update this generator, you should also consider updating its child
+# in res/field/scripts/meson.build
 script_bin_gen = generator(make_script_bin_sh,
     arguments: [
         '-i', relative_source_root / 'include',


### PR DESCRIPTION
This kinda sucks, but it's the only solution that I can find for establishing this link. I'm working on a patch proposal for Meson 1.11 that aims to make it possible to specify extra dependencies in the `process` call.