### PR TITLE
Synced `heap.c/h` structure with pokeheartgold and pokediamond

### DIFF
--- a/include/heap.h
+++ b/include/heap.h
@@ -6,7 +6,7 @@
 #include "constants/heap.h"
 
 typedef struct HeapParam {
-    u32 size;        // maximum size of the heap
+    u32 size; // maximum size of the heap
     OSArenaId arena; // where to allocate the heap from
 } HeapParam;
 

--- a/src/heap.c
+++ b/src/heap.c
@@ -47,7 +47,7 @@ void Heap_InitSystem(const HeapParam *templates, u32 nTemplates, u32 totalNumHea
     }
 
     sHeapInfo.heapHandles = OS_AllocFromMainArenaLo(
-    	(usableHeaps + 1) * sizeof(NNSFndHeapHandle)
+        (usableHeaps + 1) * sizeof(NNSFndHeapHandle)
             + usableHeaps * sizeof(NNSFndHeapHandle)
             + usableHeaps * sizeof(void *)
             + totalNumHeaps * sizeof(u16)


### PR DESCRIPTION
Previous PR synced names. This PR syncs the contents of the heap.c/heap.h files themselves.

Matching PRs:
- pokeheartgold: https://github.com/pret/pokeheartgold/pull/429
- Pokediamond: https://github.com/pret/pokediamond/pull/576