### PR TITLE
fix typo in `SetMenuYOrigin` ID

### DIFF
--- a/asm/macros/scrcmd.inc
+++ b/asm/macros/scrcmd.inc
@@ -4846,7 +4846,7 @@
     .endm
 
     .macro SetMenuYOriginSide bottomSide
-    .short 826
+    .short 827
     .byte \bottomSide
     .endm
 


### PR DESCRIPTION
this lines up with the scrcmd.c and my testing. only reason this wasnt caught earlier is because `SetMenuYOrigin` isnt used in any scripts