### PR TITLE
ci: Do not install recommendations from apt-get

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Software
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y bison flex g++ gcc-arm-none-eabi git make ninja-build pkg-config python3 wget xz-utils
+          sudo apt-get install -y --no-install-recommends bison flex g++ gcc-arm-none-eabi git make ninja-build pkg-config python3 wget xz-utils
 
       - name: Checkout Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
The goal here is to suppress installing recommendations that come from `gcc-arm-none-eabi`, since we effectively only use it as an assembler. Notably, this should skip installing `libstdc++-arm-none-eabi-newlib`, which is ~80% of the download size for a given CI run.