### PR TITLE
rom: build the trainer AI script with arm-none-eabi-gcc

### DIFF
--- a/asm/macros/aicmd.inc
+++ b/asm/macros/aicmd.inc
@@ -1,185 +1,185 @@
     .equ FALSE, 0
     .equ TRUE, 1
 
-    .macro IfRandomLessThan i, jump
+    .macro IfRandomLessThan i:req, jump:req
     .long 0
     .long \i
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfRandomGreaterThan i, jump
+    .macro IfRandomGreaterThan i:req, jump:req
     .long 1
     .long \i
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfRandomEqualTo i, jump
+    .macro IfRandomEqualTo i:req, jump:req
     .long 2
     .long \i
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfRandomNotEqualTo i, jump
+    .macro IfRandomNotEqualTo i:req, jump:req
     .long 3
     .long \i
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro AddToMoveScore i
+    .macro AddToMoveScore i:req
     .long 4
     .long \i
     .endm
 
-    .macro IfHPPercentLessThan battler, i, jump
+    .macro IfHPPercentLessThan battler:req, i:req, jump:req
     .long 5
     .long \battler
     .long \i
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfHPPercentGreaterThan battler, i, jump
+    .macro IfHPPercentGreaterThan battler:req, i:req, jump:req
     .long 6
     .long \battler
     .long \i
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfHPPercentEqualTo battler, i, jump
+    .macro IfHPPercentEqualTo battler:req, i:req, jump:req
     .long 7
     .long \battler
     .long \i
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfHPPercentNotEqualTo battler, i, jump
+    .macro IfHPPercentNotEqualTo battler:req, i:req, jump:req
     .long 8
     .long \battler
     .long \i
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfStatus battler, status, jump
+    .macro IfStatus battler:req, status:req, jump:req
     .long 9
     .long \battler
     .long \status
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfNotStatus battler, status, jump
+    .macro IfNotStatus battler:req, status:req, jump:req
     .long 10
     .long \battler
     .long \status
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfVolatileStatus battler, volatile_status, jump
+    .macro IfVolatileStatus battler:req, volatile_status:req, jump:req
     .long 11
     .long \battler
     .long \volatile_status
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfNotVolatileStatus battler, volatile_status, jump
+    .macro IfNotVolatileStatus battler:req, volatile_status:req, jump:req
     .long 12
     .long \battler
     .long \volatile_status
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfMoveEffect battler, move_effects, jump
+    .macro IfMoveEffect battler:req, move_effects:req, jump:req
     .long 13
     .long \battler
     .long \move_effects
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfNotMoveEffect battler, move_effects, jump
+    .macro IfNotMoveEffect battler:req, move_effects:req, jump:req
     .long 14
     .long \battler
     .long \move_effects
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfSideCondition battler, side_conditions, jump
+    .macro IfSideCondition battler:req, side_conditions:req, jump:req
     .long 15
     .long \battler
     .long \side_conditions
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfNotSideCondition battler, side_conditions, jump
+    .macro IfNotSideCondition battler:req, side_conditions:req, jump:req
     .long 16
     .long \battler
     .long \side_conditions
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfLoadedLessThan loaded_val, jump
+    .macro IfLoadedLessThan loaded_val:req, jump:req
     .long 17
     .long \loaded_val
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfLoadedGreaterThan loaded_val, jump
+    .macro IfLoadedGreaterThan loaded_val:req, jump:req
     .long 18
     .long \loaded_val
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfLoadedEqualTo loaded_val, jump
+    .macro IfLoadedEqualTo loaded_val:req, jump:req
     .long 19
     .long \loaded_val
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfLoadedNotEqualTo loaded_val, jump
+    .macro IfLoadedNotEqualTo loaded_val:req, jump:req
     .long 20
     .long \loaded_val
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfLoadedMask loaded_val, jump
+    .macro IfLoadedMask loaded_val:req, jump:req
     .long 21
     .long \loaded_val
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfLoadedNotMask loaded_val, jump
+    .macro IfLoadedNotMask loaded_val:req, jump:req
     .long 22
     .long \loaded_val
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfMoveEqualTo move, jump
+    .macro IfMoveEqualTo move:req, jump:req
     .long 23
     .long \move
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfMoveNotEqualTo move, jump
+    .macro IfMoveNotEqualTo move:req, jump:req
     .long 24
     .long \move
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfLoadedinTable table, jump
+    .macro IfLoadedinTable table:req, jump:req
     .long 25
     .long (\table-.) / 4 - 2
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfLoadedNotinTable table, jump
+    .macro IfLoadedNotinTable table:req, jump:req
     .long 26
     .long (\table-.) / 4 - 2
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfAttackerHasDamagingMoves jump
+    .macro IfAttackerHasDamagingMoves jump:req
     .long 27
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfAttackerHasNoDamagingMoves jump
+    .macro IfAttackerHasNoDamagingMoves jump:req
     .long 28
     .long (\jump-.) / 4 - 1
     .endm
@@ -188,7 +188,7 @@
     .long 29
     .endm
 
-    .macro LoadTypeFrom load_type_target
+    .macro LoadTypeFrom load_type_target:req
     .long 30
     .long \load_type_target
     .endm
@@ -197,41 +197,41 @@
     .long 31
     .endm
 
-    .macro FlagMoveDamageScore bool
+    .macro FlagMoveDamageScore bool:req
     .long 32
     .long \bool
     .endm
 
-    .macro LoadBattlerPreviousMove battler
+    .macro LoadBattlerPreviousMove battler:req
     .long 33
     .long \battler
     .endm
 
-    .macro IfTempEqualTo loaded_val, jump
+    .macro IfTempEqualTo loaded_val:req, jump:req
     .long 34
     .long \loaded_val
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfTempNotEqualTo loaded_val, jump
+    .macro IfTempNotEqualTo loaded_val:req, jump:req
     .long 35
     .long \loaded_val
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfSpeedCompareEqualTo cmp, jump
+    .macro IfSpeedCompareEqualTo cmp:req, jump:req
     .long 36
     .long \cmp
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfSpeedCompareNotEqualTo cmp, jump
+    .macro IfSpeedCompareNotEqualTo cmp:req, jump:req
     .long 37
     .long \cmp
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro CountAlivePartyBattlers battler
+    .macro CountAlivePartyBattlers battler:req
     .long 38
     .long \battler
     .endm
@@ -244,7 +244,7 @@
     .long 40
     .endm
 
-    .macro LoadBattlerAbility battler
+    .macro LoadBattlerAbility battler:req
     .long 41
     .long \battler
     .endm
@@ -253,20 +253,20 @@
     .long 42
     .endm
 
-    .macro IfMoveEffectivenessEquals modifier, jump
+    .macro IfMoveEffectivenessEquals modifier:req, jump:req
     .long 43
     .long \modifier
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfPartyMemberStatus battler, pokemon_status, jump
+    .macro IfPartyMemberStatus battler:req, pokemon_status:req, jump:req
     .long 44
     .long \battler
     .long \pokemon_status
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfPartyMemberNotStatus battler, pokemon_status, jump
+    .macro IfPartyMemberNotStatus battler:req, pokemon_status:req, jump:req
     .long 45
     .long \battler
     .long \pokemon_status
@@ -277,19 +277,19 @@
     .long 46
     .endm
 
-    .macro IfCurrentMoveEffectEqualTo battle_effect, jump
+    .macro IfCurrentMoveEffectEqualTo battle_effect:req, jump:req
     .long 47
     .long \battle_effect
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfCurrentMoveEffectNotEqualTo battle_effect, jump
+    .macro IfCurrentMoveEffectNotEqualTo battle_effect:req, jump:req
     .long 48
     .long \battle_effect
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfStatStageLessThan battler, stat, i, jump
+    .macro IfStatStageLessThan battler:req, stat:req, i:req, jump:req
     .long 49
     .long \battler
     .long \stat
@@ -297,7 +297,7 @@
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfStatStageGreaterThan battler, stat, i, jump
+    .macro IfStatStageGreaterThan battler:req, stat:req, i:req, jump:req
     .long 50
     .long \battler
     .long \stat
@@ -305,7 +305,7 @@
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfStatStageEqualTo battler, stat, i, jump
+    .macro IfStatStageEqualTo battler:req, stat:req, i:req, jump:req
     .long 51
     .long \battler
     .long \stat
@@ -313,7 +313,7 @@
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfStatStageNotEqualTo battler, stat, i, jump
+    .macro IfStatStageNotEqualTo battler:req, stat:req, i:req, jump:req
     .long 52
     .long \battler
     .long \stat
@@ -321,54 +321,54 @@
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfCurrentMoveKills roll_damage, jump
+    .macro IfCurrentMoveKills roll_damage:req, jump:req
     .long 53
     .long \roll_damage
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfCurrentMoveDoesNotKill roll_damage, jump
+    .macro IfCurrentMoveDoesNotKill roll_damage:req, jump:req
     .long 54
     .long \roll_damage
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfMoveKnown battler, move, jump
+    .macro IfMoveKnown battler:req, move:req, jump:req
     .long 55
     .long \battler
     .long \move
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfMoveNotKnown battler, move, jump
+    .macro IfMoveNotKnown battler:req, move:req, jump:req
     .long 56
     .long \battler
     .long \move
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfMoveEffectKnown battler, battle_effect, jump
+    .macro IfMoveEffectKnown battler:req, battle_effect:req, jump:req
     .long 57
     .long \battler
     .long \battle_effect
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfMoveEffectNotKnown battler, battle_effect, jump
+    .macro IfMoveEffectNotKnown battler:req, battle_effect:req, jump:req
     .long 58
     .long \battler
     .long \battle_effect
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfBattlerUnderEffect battler, check_effect, jump
+    .macro IfBattlerUnderEffect battler:req, check_effect:req, jump:req
     .long 59
     .long \battler
     .long \check_effect
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfCurrentMoveMatchesEffect check_effect, jump
+    .macro IfCurrentMoveMatchesEffect check_effect:req, jump:req
     .long 60
     .long \check_effect
     .long (\jump-.) / 4 - 1
@@ -378,7 +378,7 @@
     .long 61
     .endm
 
-    .macro Dummy3E i
+    .macro Dummy3E i:req
     .long 62
     .long \i
     .endm
@@ -387,27 +387,27 @@
     .long 63
     .endm
 
-    .macro LoadHeldItem battler
+    .macro LoadHeldItem battler:req
     .long 64
     .long \battler
     .endm
 
-    .macro LoadHeldItemEffect battler
+    .macro LoadHeldItemEffect battler:req
     .long 65
     .long \battler
     .endm
 
-    .macro LoadGender battler
+    .macro LoadGender battler:req
     .long 66
     .long \battler
     .endm
 
-    .macro LoadIsFirstTurnInBattle battler
+    .macro LoadIsFirstTurnInBattle battler:req
     .long 67
     .long \battler
     .endm
 
-    .macro LoadStockpileCount battler
+    .macro LoadStockpileCount battler:req
     .long 68
     .long \battler
     .endm
@@ -416,7 +416,7 @@
     .long 69
     .endm
 
-    .macro LoadRecycleItem battler
+    .macro LoadRecycleItem battler:req
     .long 70
     .long \battler
     .endm
@@ -433,17 +433,17 @@
     .long 73
     .endm
 
-    .macro LoadProtectChain battler
+    .macro LoadProtectChain battler:req
     .long 74
     .long \battler
     .endm
 
-    .macro PushAndGoTo jump
+    .macro PushAndGoTo jump:req
     .long 75
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro GoTo jump
+    .macro GoTo jump:req
     .long 76
     .long (\jump-.) / 4 - 1
     .endm
@@ -452,77 +452,77 @@
     .long 77
     .endm
 
-    .macro IfLevel check_level, jump
+    .macro IfLevel check_level:req, jump:req
     .long 78
     .long \check_level
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfTargetIsTaunted jump
+    .macro IfTargetIsTaunted jump:req
     .long 79
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfTargetIsNotTaunted jump
+    .macro IfTargetIsNotTaunted jump:req
     .long 80
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfTargetIsPartner jump
+    .macro IfTargetIsPartner jump:req
     .long 81
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro FlagBattlerIsType battler, type
+    .macro FlagBattlerIsType battler:req, type:req
     .long 82
     .long \battler
     .long \type
     .endm
 
-    .macro CheckBattlerAbility battler, ability
+    .macro CheckBattlerAbility battler:req, ability:req
     .long 83
     .long \battler
     .long \ability
     .endm
 
-    .macro IfActivatedFlashFire battler, jump
+    .macro IfActivatedFlashFire battler:req, jump:req
     .long 84
     .long \battler
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfHeldItemEqualTo battler, item, jump
+    .macro IfHeldItemEqualTo battler:req, item:req, jump:req
     .long 85
     .long \battler
     .long \item
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfFieldConditionsMask field_conditions, jump
+    .macro IfFieldConditionsMask field_conditions:req, jump:req
     .long 86
     .long \field_conditions
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro LoadSpikesLayers battler, side_conditions
+    .macro LoadSpikesLayers battler:req, side_conditions:req
     .long 87
     .long \battler
     .long \side_conditions
     .endm
 
-    .macro IfAnyPartyMemberIsWounded battler, jump
+    .macro IfAnyPartyMemberIsWounded battler:req, jump:req
     .long 88
     .long \battler
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfAnyPartyMemberUsedPP battler, jump
+    .macro IfAnyPartyMemberUsedPP battler:req, jump:req
     .long 89
     .long \battler
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro LoadFlingPower battler
+    .macro LoadFlingPower battler:req
     .long 90
     .long \battler
     .endm
@@ -531,7 +531,7 @@
     .long 91
     .endm
 
-    .macro IfCanUseLastResort battler, jump
+    .macro IfCanUseLastResort battler:req, jump:req
     .long 92
     .long \battler
     .long (\jump-.) / 4 - 1
@@ -545,94 +545,94 @@
     .long 94
     .endm
 
-    .macro LoadBattlerSpeedRank battler
+    .macro LoadBattlerSpeedRank battler:req
     .long 95
     .long \battler
     .endm
 
-    .macro LoadBattlerTurnCount battler
+    .macro LoadBattlerTurnCount battler:req
     .long 96
     .long \battler
     .endm
 
-    .macro IfPartyMemberDealsMoreDamage roll_damage, jump
+    .macro IfPartyMemberDealsMoreDamage roll_damage:req, jump:req
     .long 97
     .long \roll_damage
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfHasSuperEffectiveMove jump
+    .macro IfHasSuperEffectiveMove jump:req
     .long 98
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfBattlerDealsMoreDamage battler, roll_damage, jump
+    .macro IfBattlerDealsMoreDamage battler:req, roll_damage:req, jump:req
     .long 99
     .long \battler
     .long \roll_damage
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro SumPositiveStatStages battler
+    .macro SumPositiveStatStages battler:req
     .long 100
     .long \battler
     .endm
 
-    .macro DiffStatStages battler, battle_stat
+    .macro DiffStatStages battler:req, battle_stat:req
     .long 101
     .long \battler
     .long \battle_stat
     .endm
 
-    .macro IfBattlerHasHigherStat battler, battle_stat, jump
+    .macro IfBattlerHasHigherStat battler:req, battle_stat:req, jump:req
     .long 102
     .long \battler
     .long \battle_stat
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfBattlerHasLowerStat battler, battle_stat, jump
+    .macro IfBattlerHasLowerStat battler:req, battle_stat:req, jump:req
     .long 103
     .long \battler
     .long \battle_stat
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfBattlerHasEqualStat battler, battle_stat, jump
+    .macro IfBattlerHasEqualStat battler:req, battle_stat:req, jump:req
     .long 104
     .long \battler
     .long \battle_stat
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro CheckIfHighestDamageWithPartner roll_damage
+    .macro CheckIfHighestDamageWithPartner roll_damage:req
     .long 105
     .long \roll_damage
     .endm
 
-    .macro IfBattlerFainted battler, jump
+    .macro IfBattlerFainted battler:req, jump:req
     .long 106
     .long \battler
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro IfBattlerNotFainted battler, jump
+    .macro IfBattlerNotFainted battler:req, jump:req
     .long 107
     .long \battler
     .long (\jump-.) / 4 - 1
     .endm
 
-    .macro LoadAbility battler
+    .macro LoadAbility battler:req
     .long 108
     .long \battler
     .endm
 
     .equ TABLE_END, 0xFFFFFFFF
 
-    .macro TableEntry entry
+    .macro TableEntry entry:req
     .long \entry
     .endm
 
-    .macro LabelDistance dst, src
+    .macro LabelDistance dst:req, src:req
     .long (\dst-\src) / 4
     .endm

--- a/asm/meson.build
+++ b/asm/meson.build
@@ -1,3 +1,0 @@
-pokeplatinum_asm = files(
-    'trainer_ai/trainer_ai_script.s'
-)

--- a/meson.build
+++ b/meson.build
@@ -167,22 +167,37 @@ alias_target('data', nitrofs_files)
 ###                     ARM9 BINARY                      ###
 ############################################################
 subdir('src')
-subdir('asm')
+
+trainer_ai_o = custom_target(
+    'trainer_ai_script.o',
+    output: 'trainer_ai_script.o',
+    input: files('src/battle/trainer_ai/script.s'),
+    command: [
+        arm_none_eabi_gcc_exe,
+        '-I', meson.global_source_root() / 'include',
+        '-I', meson.global_source_root() / 'asm',
+        '-I', meson.global_build_root(),
+        '-x', 'assembler-with-cpp',
+        '-MD', '-MF', '@DEPFILE@',
+        '-c', '-o', '@OUTPUT@',
+        '@INPUT@',
+    ],
+    depfile: '@BASENAME@.d',
+)
 
 main = executable('main',
     sources: [
         pokeplatinum_c,
-        pokeplatinum_asm,
         c_consts_generators,
         naix_headers,
         h_headers,
         embed_headers,
     ],
+    objects: trainer_ai_o,
     c_args: [
         pokeplatinum_args,
         '-thumb'
     ],
-    nasm_args: asm_args,
     c_pch: 'include/pch/global_pch.h',
     include_directories: [
         public_includes,

--- a/platinum.us/main.lsf
+++ b/platinum.us/main.lsf
@@ -673,7 +673,7 @@ Overlay trainer_ai
 {
 	After overlay11
 	Object main.nef.p/src_battle_trainer_ai_trainer_ai.c.o
-	Object main.nef.p/asm_trainer_ai_trainer_ai_script.s.o
+	Object trainer_ai_script.o
 }
 
 Overlay dummy4

--- a/src/battle/trainer_ai/script.s
+++ b/src/battle/trainer_ai/script.s
@@ -16,55 +16,55 @@
 gTrainerAITable:
 
 FlagTable:
-    LabelDistance Basic_Main,          FlagTable ; AI_FLAG_BASIC
-    LabelDistance EvalAttack_Main,     FlagTable ; AI_FLAG_EVAL_ATTACK
-    LabelDistance Expert_Main,         FlagTable ; AI_FLAG_EXPERT
-    LabelDistance SetupFirstTurn_Main, FlagTable ; AI_FLAG_SETUP_FIRST_TURN
-    LabelDistance Risky_Main,          FlagTable ; AI_FLAG_RISKY
-    LabelDistance DamagePriority_Main, FlagTable ; AI_FLAG_DAMAGE_PRIORITY
-    LabelDistance BatonPass_Main,      FlagTable ; AI_FLAG_BATON_PASS
-    LabelDistance TagStrategy_Main,    FlagTable ; AI_FLAG_TAG_STRATEGY
-    LabelDistance CheckHP_Main,        FlagTable ; AI_FLAG_CHECK_HP
-    LabelDistance Weather_Main,        FlagTable ; AI_FLAG_WEATHER
-    LabelDistance Harrassment_Main,    FlagTable ; AI_FLAG_HARRASSMENT
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_11
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_12
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_13
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_14
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_15
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_16
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_17
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_18
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_19
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_20
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_21
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_22
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_23
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_24
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_25
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_26
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_27
-    LabelDistance Terminate,           FlagTable ; AI_FLAG_UNUSED_28
-    LabelDistance RoamingPokemon_Main, FlagTable ; AI_FLAG_ROAMING_POKEMON
-    LabelDistance Safari_Main,         FlagTable ; AI_FLAG_SAFARI
-    LabelDistance CatchTutorial_Main,  FlagTable ; AI_FLAG_CATCH_TUTORIAL
+    LabelDistance Basic_Main,          FlagTable // AI_FLAG_BASIC
+    LabelDistance EvalAttack_Main,     FlagTable // AI_FLAG_EVAL_ATTACK
+    LabelDistance Expert_Main,         FlagTable // AI_FLAG_EXPERT
+    LabelDistance SetupFirstTurn_Main, FlagTable // AI_FLAG_SETUP_FIRST_TURN
+    LabelDistance Risky_Main,          FlagTable // AI_FLAG_RISKY
+    LabelDistance DamagePriority_Main, FlagTable // AI_FLAG_DAMAGE_PRIORITY
+    LabelDistance BatonPass_Main,      FlagTable // AI_FLAG_BATON_PASS
+    LabelDistance TagStrategy_Main,    FlagTable // AI_FLAG_TAG_STRATEGY
+    LabelDistance CheckHP_Main,        FlagTable // AI_FLAG_CHECK_HP
+    LabelDistance Weather_Main,        FlagTable // AI_FLAG_WEATHER
+    LabelDistance Harrassment_Main,    FlagTable // AI_FLAG_HARRASSMENT
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_11
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_12
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_13
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_14
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_15
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_16
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_17
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_18
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_19
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_20
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_21
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_22
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_23
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_24
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_25
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_26
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_27
+    LabelDistance Terminate,           FlagTable // AI_FLAG_UNUSED_28
+    LabelDistance RoamingPokemon_Main, FlagTable // AI_FLAG_ROAMING_POKEMON
+    LabelDistance Safari_Main,         FlagTable // AI_FLAG_SAFARI
+    LabelDistance CatchTutorial_Main,  FlagTable // AI_FLAG_CATCH_TUTORIAL
 
 Basic_Main:
-    ; Ignore this flag on partner battlers.
+    // Ignore this flag on partner battlers.
     IfTargetIsPartner Terminate
 
-    ; Skip damage scoring for OHKO moves (only Fissure and Horn Drill)
+    // Skip damage scoring for OHKO moves (only Fissure and Horn Drill)
     IfMoveEqualTo MOVE_FISSURE, Basic_CheckForImmunity
     IfMoveEqualTo MOVE_HORN_DRILL, Basic_CheckForImmunity
 
-    ; Score the move according to its damage. If the AI does not know any
-    ; moves which are eligible for scoring, skip ahead.
+    // Score the move according to its damage. If the AI does not know any
+    // moves which are eligible for scoring, skip ahead.
     FlagMoveDamageScore FALSE
     IfLoadedEqualTo AI_NO_COMPARISON_MADE, Basic_CheckSoundproof
 
 Basic_CheckForImmunity:
-    ; Check for any immunity to the current move based on move type and what
-    ; we know the battler's ability to be (if we do at all).
+    // Check for any immunity to the current move based on move type and what
+    // we know the battler's ability to be (if we do at all).
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, ScoreMinus10
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_MOLD_BREAKER, Basic_NoImmunityAbility
@@ -75,7 +75,7 @@ Basic_CheckForImmunity:
     IfLoadedEqualTo ABILITY_FLASH_FIRE, Basic_CheckFireAbsorption
     IfLoadedEqualTo ABILITY_WONDER_GUARD, Basic_CheckWonderGuard
     IfLoadedEqualTo ABILITY_LEVITATE, Basic_CheckGroundAbsorption
-    IfLoadedEqualTo ABILITY_LEVITATE, Basic_CheckWaterAbsorption2 ; BUG: This line should branch on Dry Skin rather than Levitate
+    IfLoadedEqualTo ABILITY_LEVITATE, Basic_CheckWaterAbsorption2 // BUG: This line should branch on Dry Skin rather than Levitate
     GoTo Basic_NoImmunityAbility
 
 Basic_CheckElectricAbsorption:
@@ -113,7 +113,7 @@ Basic_NoImmunityAbility:
     IfLoadedEqualTo AI_NO_COMPARISON_MADE, Basic_CheckSoundproof
 
 Basic_CheckSoundproof:
-    ; Check for immunity to sound-based moves
+    // Check for immunity to sound-based moves
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedNotEqualTo ABILITY_SOUNDPROOF, Basic_ScoreMoveEffect
     LoadBattlerAbility AI_BATTLER_ATTACKER
@@ -286,7 +286,7 @@ Basic_ScoreMoveEffect:
     PopOrEnd 
 
 Basic_CheckCannotSleep:
-    ; If the target cannot be put to sleep for any reason, score -10.
+    // If the target cannot be put to sleep for any reason, score -10.
     IfStatus AI_BATTLER_DEFENDER, MON_CONDITION_ANY, ScoreMinus10
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_SAFEGUARD, ScoreMinus10
     LoadBattlerAbility AI_BATTLER_DEFENDER
@@ -295,31 +295,31 @@ Basic_CheckCannotSleep:
     PopOrEnd 
 
 Basic_CheckCannotExplode:
-    ; If the target is immune, score -10.
+    // If the target is immune, score -10.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, ScoreMinus10
 
-    ; If the target has Damp and we do not have Mold Breaker, score -10.
+    // If the target has Damp and we do not have Mold Breaker, score -10.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_MOLD_BREAKER, Basic_CheckLastMon
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_DAMP, ScoreMinus10
 
 Basic_CheckLastMon:
-    ; If we are on our last Pokemon and the target is not also on their last Pokemon,
-    ; score -10.
+    // If we are on our last Pokemon and the target is not also on their last Pokemon,
+    // score -10.
     CountAlivePartyBattlers AI_BATTLER_ATTACKER
     IfLoadedNotEqualTo 0, Basic_Explode_Terminate
     CountAlivePartyBattlers AI_BATTLER_DEFENDER
     IfLoadedNotEqualTo 0, ScoreMinus10
 
-    ; If the target is also on their last Pokemon, score -1 instead of -10.
+    // If the target is also on their last Pokemon, score -1 instead of -10.
     GoTo ScoreMinus1
 
 Basic_Explode_Terminate:
     PopOrEnd 
 
 Basic_CheckNightmare:
-    ; If the target is immune to the effect of Nightmare for any reason, score -8/-10.
+    // If the target is immune to the effect of Nightmare for any reason, score -8/-10.
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_NIGHTMARE, ScoreMinus10
     IfNotStatus AI_BATTLER_DEFENDER, MON_CONDITION_SLEEP, ScoreMinus8
     LoadBattlerAbility AI_BATTLER_DEFENDER
@@ -327,19 +327,19 @@ Basic_CheckNightmare:
     PopOrEnd 
 
 Basic_CheckDreamEater:
-    ; If the target is immune to Dream Eater for any reason, score -8/-10.
+    // If the target is immune to Dream Eater for any reason, score -8/-10.
     IfNotStatus AI_BATTLER_DEFENDER, MON_CONDITION_SLEEP, ScoreMinus8
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckBellyDrum:
-    ; If the attacker is at half HP or less, score -10.
+    // If the attacker is at half HP or less, score -10.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 51, ScoreMinus10
 
-    ; General comments on stat-boosting Status moves below:
-    ;   - If the attacker has Simple and is already at +2, score -10.
-    ;   - If the attacker is already at +6, score -10.
-    ;   - Special cases for Speed (Trick Room active -> -10) and Accuracy/Evasion (attacker has No Guard -> -10)
+    // General comments on stat-boosting Status moves below:
+    //   - If the attacker has Simple and is already at +2, score -10.
+    //   - If the attacker is already at +6, score -10.
+    //   - Special cases for Speed (Trick Room active -> -10) and Accuracy/Evasion (attacker has No Guard -> -10)
 Basic_CheckHighStatStage_Attack:
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedNotEqualTo ABILITY_SIMPLE, Basic_CheckHighStatStage_Attack_NoSimple
@@ -417,14 +417,14 @@ Basic_CheckHighStatStage_Evasion_NoSimple:
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_EVASION, 12, ScoreMinus10
     PopOrEnd 
 
-    ; General comments on stat-reducing Status moves below:
-    ;   - If the target is already at -6, score -10.
-    ;   - If the target has White Smoke or Clear Body, score -10.
-    ;   - If reducing Attack -> -10 if the target has Hyper Cutter
-    ;   - If reducing Speed -> -10 if Trick Room is currently active
-    ;   - If reducing Speed -> -10 if the target has Speed Boost
-    ;   - If reducing Accuracy or Evasion -> -10 if either battler has No Guard
-    ;   - If reducing Accuracy -> -10 if the target has Keen Eye
+    // General comments on stat-reducing Status moves below:
+    //   - If the target is already at -6, score -10.
+    //   - If the target has White Smoke or Clear Body, score -10.
+    //   - If reducing Attack -> -10 if the target has Hyper Cutter
+    //   - If reducing Speed -> -10 if Trick Room is currently active
+    //   - If reducing Speed -> -10 if the target has Speed Boost
+    //   - If reducing Accuracy or Evasion -> -10 if either battler has No Guard
+    //   - If reducing Accuracy -> -10 if the target has Keen Eye
 Basic_CheckLowStatStage_Attack:
     IfStatStageEqualTo AI_BATTLER_DEFENDER, BATTLE_STAT_ATTACK, 0, ScoreMinus10
     LoadBattlerAbility AI_BATTLER_DEFENDER
@@ -473,10 +473,10 @@ Basic_CheckClearBodyEffect:
     PopOrEnd 
 
 Basic_CheckStatStageImbalance:
-    ; The name is a little esoteric; an "imbalance" is regarded as the attacker
-    ; having any reduced stat stage or the target having any increased stat stage.
-    ;
-    ; If neither of those are true, score -10.
+    // The name is a little esoteric; an "imbalance" is regarded as the attacker
+    // having any reduced stat stage or the target having any increased stat stage.
+    //
+    // If neither of those are true, score -10.
     IfStatStageLessThan AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 6, Basic_CheckStatStageImbalance_Terminate
     IfStatStageLessThan AI_BATTLER_ATTACKER, BATTLE_STAT_DEFENSE, 6, Basic_CheckStatStageImbalance_Terminate
     IfStatStageLessThan AI_BATTLER_ATTACKER, BATTLE_STAT_SPEED, 6, Basic_CheckStatStageImbalance_Terminate
@@ -497,7 +497,7 @@ Basic_CheckStatStageImbalance_Terminate:
     PopOrEnd 
 
 Basic_CheckCanForceSwitch:
-    ; If the target cannot be forced out for any reason, score -10.
+    // If the target cannot be forced out for any reason, score -10.
     CountAlivePartyBattlers AI_BATTLER_DEFENDER
     IfLoadedEqualTo 0, ScoreMinus10
     LoadBattlerAbility AI_BATTLER_ATTACKER
@@ -509,7 +509,7 @@ Basic_CheckCanForceSwitch_Terminate:
     PopOrEnd 
 
 Basic_CheckCanRecoverHP:
-    ; If at 100% HP, score -8.
+    // If at 100% HP, score -8.
     IfHPPercentNotEqualTo AI_BATTLER_ATTACKER, 100, Basic_CheckCanRecoverHP_Terminate
     AddToMoveScore -8
 
@@ -517,7 +517,7 @@ Basic_CheckCanRecoverHP_Terminate:
     PopOrEnd 
 
 Basic_CheckCannotPoison:
-    ; If the target is immune to the usual effects of Poison for any reason, score -10.
+    // If the target is immune to the usual effects of Poison for any reason, score -10.
     LoadTypeFrom LOAD_DEFENDER_TYPE_1
     IfLoadedEqualTo TYPE_STEEL, ScoreMinus10
     IfLoadedEqualTo TYPE_POISON, ScoreMinus10
@@ -525,7 +525,7 @@ Basic_CheckCannotPoison:
     IfLoadedEqualTo TYPE_STEEL, ScoreMinus10
     IfLoadedEqualTo TYPE_POISON, ScoreMinus10
 
-    ; Check for immunity by ability
+    // Check for immunity by ability
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_IMMUNITY, ScoreMinus10
     IfLoadedEqualTo ABILITY_MAGIC_GUARD, ScoreMinus10
@@ -547,12 +547,12 @@ Basic_CheckCannotPoison_StatusOrSafeguard:
     PopOrEnd 
 
 Basic_CheckAlreadyUnderLightScreen:
-    ; If already under the effect of Light Screen, score -8.
+    // If already under the effect of Light Screen, score -8.
     IfSideCondition AI_BATTLER_ATTACKER, SIDE_CONDITION_LIGHT_SCREEN, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckOHKOWouldFail:
-    ; If the OHKO move would always fail for any reason, score -10.
+    // If the OHKO move would always fail for any reason, score -10.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, ScoreMinus10
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_MOLD_BREAKER, Basic_CheckOHKOWouldFail_Levels
@@ -564,14 +564,14 @@ Basic_CheckOHKOWouldFail_Levels:
     PopOrEnd 
 
 Basic_CheckMagnitude:
-    ; If the target's ability is Levitate and the attacker's ability is not Mold Breaker, score -10.
+    // If the target's ability is Levitate and the attacker's ability is not Mold Breaker, score -10.
     IfLoadedEqualTo ABILITY_MOLD_BREAKER, Basic_CheckNonStandardDamageOrChargeTurn
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_LEVITATE, ScoreMinus10
 
 Basic_CheckNonStandardDamageOrChargeTurn:
-    ; If the target is immune to this move by its typing or due to the target's ability being
-    ; Wonder Guard, score -10.
+    // If the target is immune to this move by its typing or due to the target's ability being
+    // Wonder Guard, score -10.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, ScoreMinus10
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedNotEqualTo ABILITY_WONDER_GUARD, Basic_CheckNonStandardDamageOrChargeTurn_Terminate
@@ -585,32 +585,32 @@ Basic_CheckNonStandardDamageOrChargeTurn_Terminate:
     PopOrEnd 
 
 Basic_CheckAlreadyUnderMist:
-    ; If already under the effect of Mist, score -8.
+    // If already under the effect of Mist, score -8.
     IfSideCondition AI_BATTLER_ATTACKER, SIDE_CONDITION_MIST, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckAlreadyPumpedUp:
-    ; If already under the effect of Focus Energy, score -10.
+    // If already under the effect of Focus Energy, score -10.
     IfVolatileStatus AI_BATTLER_ATTACKER, VOLATILE_CONDITION_FOCUS_ENERGY, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckCannotConfuse:
-    ; If the target is already confused, score -5.
+    // If the target is already confused, score -5.
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_CONFUSION, ScoreMinus5
 
-    ; If the target otherwise cannot be confused, score -10.
+    // If the target otherwise cannot be confused, score -10.
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_OWN_TEMPO, ScoreMinus10
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_SAFEGUARD, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckAlreadyUnderReflect:
-    ; If already under the effect of Reflect, score -8.
+    // If already under the effect of Reflect, score -8.
     IfSideCondition AI_BATTLER_ATTACKER, SIDE_CONDITION_REFLECT, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckCannotParalyze:
-    ; If the target cannot be paralyzed for any reason, score -10.
+    // If the target cannot be paralyzed for any reason, score -10.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, ScoreMinus10
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_LIMBER, ScoreMinus10
@@ -631,13 +631,13 @@ Basic_CheckCannotParalyze_ImmuneToStatus:
     PopOrEnd 
 
 Basic_CheckCannotSubstitute:
-    ; If the attacker's Substitute would fail, score -8/-10.
+    // If the attacker's Substitute would fail, score -8/-10.
     IfVolatileStatus AI_BATTLER_ATTACKER, VOLATILE_CONDITION_SUBSTITUTE, ScoreMinus8
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 26, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckCannotLeechSeed:
-    ; If the target is already Seeded or immune to the effects of Leech Seed, score -10.
+    // If the target is already Seeded or immune to the effects of Leech Seed, score -10.
     IfMoveEffect AI_BATTLER_DEFENDER, MOVE_EFFECT_LEECH_SEED, ScoreMinus10
     LoadTypeFrom LOAD_DEFENDER_TYPE_1
     IfLoadedEqualTo TYPE_GRASS, ScoreMinus10
@@ -648,22 +648,22 @@ Basic_CheckCannotLeechSeed:
     PopOrEnd 
 
 Basic_CheckCannotDisable:
-    ; If the target is already Disabled, score -8.
+    // If the target is already Disabled, score -8.
     IfBattlerUnderEffect AI_BATTLER_DEFENDER, CHECK_DISABLE, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckCannotEncore:
-    ; If the target is already Encored, score -8.
+    // If the target is already Encored, score -8.
     IfBattlerUnderEffect AI_BATTLER_DEFENDER, CHECK_ENCORE, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckAttackerAsleep:
-    ; If the attacker is not currently asleep, score -8.
+    // If the attacker is not currently asleep, score -8.
     IfNotStatus AI_BATTLER_ATTACKER, MON_CONDITION_SLEEP, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckLockOn:
-    ; If the target is already Locked On, or either battler has No Guard, score -10.
+    // If the target is already Locked On, or either battler has No Guard, score -10.
     IfMoveEffect AI_BATTLER_DEFENDER, MOVE_EFFECT_LOCK_ON, ScoreMinus10
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_NO_GUARD, ScoreMinus10
@@ -672,19 +672,19 @@ Basic_CheckLockOn:
     PopOrEnd 
 
 Basic_CheckMeanLook:
-    ; If the target is already under the effect of Mean Look, score -10.
+    // If the target is already under the effect of Mean Look, score -10.
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_MEAN_LOOK, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckCurse:
-    ; Branch for a Ghost-type using Curse
+    // Branch for a Ghost-type using Curse
     LoadTypeFrom LOAD_ATTACKER_TYPE_1
     IfLoadedEqualTo TYPE_GHOST, Basic_CheckCurse_GhostType
     LoadTypeFrom LOAD_ATTACKER_TYPE_2
     IfLoadedEqualTo TYPE_GHOST, Basic_CheckCurse_GhostType
 
-    ; If the attacker has Simple, treat it like a boosting move for both Attack and Defense.
-    ; That is, if either Attack or Defense are already +2, score -10.
+    // If the attacker has Simple, treat it like a boosting move for both Attack and Defense.
+    // That is, if either Attack or Defense are already +2, score -10.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedNotEqualTo ABILITY_SIMPLE, Basic_CheckCurse_NoSimple
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 8, ScoreMinus10
@@ -692,20 +692,20 @@ Basic_CheckCurse:
     PopOrEnd 
 
 Basic_CheckCurse_NoSimple:
-    ; If the attacker does not have Simple and either Attack or Defense are already +6, score -10.
+    // If the attacker does not have Simple and either Attack or Defense are already +6, score -10.
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 12, ScoreMinus10
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_DEFENSE, 12, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckCurse_GhostType:
-    ; If the target is immune to the effect, score -10.
+    // If the target is immune to the effect, score -10.
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_CURSE, ScoreMinus10
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_MAGIC_GUARD, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckSpikes:
-    ; If the target already has 3 layers of Spikes or is on their last Pokemon, score -10.
+    // If the target already has 3 layers of Spikes or is on their last Pokemon, score -10.
     LoadSpikesLayers AI_BATTLER_DEFENDER, SIDE_CONDITION_SPIKES
     IfLoadedEqualTo 3, ScoreMinus10
     CountAlivePartyBattlers AI_BATTLER_DEFENDER
@@ -713,23 +713,23 @@ Basic_CheckSpikes:
     PopOrEnd 
 
 Basic_CheckForesight:
-    ; If the target is already under the effect, score -10.
+    // If the target is already under the effect, score -10.
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_FORESIGHT, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckPerishSong:
-    ; If the target is already under the effect, score -10.
+    // If the target is already under the effect, score -10.
     IfMoveEffect AI_BATTLER_DEFENDER, MOVE_EFFECT_PERISH_SONG, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckSandstorm:
-    ; If the current weather is Sand, score -8.
+    // If the current weather is Sand, score -8.
     LoadCurrentWeather 
     IfLoadedEqualTo AI_WEATHER_SANDSTORM, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckCannotAttract:
-    ; If the target cannot be Infatuated for any reason, score -10.
+    // If the target cannot be Infatuated for any reason, score -10.
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_ATTRACT, ScoreMinus10
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_OBLIVIOUS, ScoreMinus10
@@ -752,13 +752,13 @@ Basic_CheckCannotAttract_Terminate:
     PopOrEnd 
 
 Basic_CheckAlreadyUnderSafeguard:
-    ; If already under the effect of Safeguard, score -8.
+    // If already under the effect of Safeguard, score -8.
     IfSideCondition AI_BATTLER_ATTACKER, SIDE_CONDITION_SAFEGUARD, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckMemento:
-    ; If the target's ability blocks the stat drop and the attacker does not have Mold Breaker,
-    ; score -10.
+    // If the target's ability blocks the stat drop and the attacker does not have Mold Breaker,
+    // score -10.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_MOLD_BREAKER, Basic_CheckMemento_CheckStatStages
     LoadBattlerAbility AI_BATTLER_DEFENDER
@@ -766,104 +766,104 @@ Basic_CheckMemento:
     IfLoadedEqualTo ABILITY_WHITE_SMOKE, ScoreMinus10
 
 Basic_CheckMemento_CheckStatStages:
-    ; If the target's Attack is already at -6, score -10.
+    // If the target's Attack is already at -6, score -10.
     IfStatStageEqualTo AI_BATTLER_DEFENDER, BATTLE_STAT_ATTACK, 0, ScoreMinus10
 
-    ; If the target's SpAttack is already at -6, score -8.
+    // If the target's SpAttack is already at -6, score -8.
     IfStatStageEqualTo AI_BATTLER_DEFENDER, BATTLE_STAT_SP_ATTACK, 0, ScoreMinus8
 
-    ; If the attacker is on their last Pokemon, score -10.
+    // If the attacker is on their last Pokemon, score -10.
     CountAlivePartyBattlers AI_BATTLER_ATTACKER
     IfLoadedEqualTo 0, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckBatonPass:
-    ; If the attacker is on its last Pokemon, score -10.
+    // If the attacker is on its last Pokemon, score -10.
     CountAlivePartyBattlers AI_BATTLER_ATTACKER
     IfLoadedEqualTo 0, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckRainDance:
-    ; If the attacker's ability is Swift Swim or Hydration, skip the defender-Hydration check below.
+    // If the attacker's ability is Swift Swim or Hydration, skip the defender-Hydration check below.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_SWIFT_SWIM, Basic_CheckCurrentWeatherIsRain
     IfLoadedEqualTo ABILITY_HYDRATION, Basic_CheckCurrentWeatherIsRain
 
-    ; If the target's ability is Hydration and they are currently statused, score -8.
+    // If the target's ability is Hydration and they are currently statused, score -8.
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedNotEqualTo ABILITY_HYDRATION, Basic_CheckCurrentWeatherIsRain
     IfStatus AI_BATTLER_DEFENDER, MON_CONDITION_ANY, ScoreMinus8
 
 Basic_CheckCurrentWeatherIsRain:
-    ; If the weather is currently Rain, score -8.
+    // If the weather is currently Rain, score -8.
     LoadCurrentWeather 
     IfLoadedEqualTo AI_WEATHER_RAINING, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckSunnyDay:
-    ; If the attacker's ability is any of Flower Gift, Leaf Guard, or Solar Power, skip the defender-
-    ; Hydration check below.
+    // If the attacker's ability is any of Flower Gift, Leaf Guard, or Solar Power, skip the defender-
+    // Hydration check below.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_FLOWER_GIFT, Basic_CheckCurrentWeatherIsSun
     IfLoadedEqualTo ABILITY_LEAF_GUARD, Basic_CheckCurrentWeatherIsSun
     IfLoadedEqualTo ABILITY_SOLAR_POWER, Basic_CheckCurrentWeatherIsSun
 
-    ; If the target's ability is Hydration and they are currently statused, score -10.
-    ; Why does this consider Hydration? This is clearly a bug, but what was the intention?
+    // If the target's ability is Hydration and they are currently statused, score -10.
+    // Why does this consider Hydration? This is clearly a bug, but what was the intention?
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedNotEqualTo ABILITY_HYDRATION, Basic_CheckCurrentWeatherIsSun
     IfStatus AI_BATTLER_DEFENDER, MON_CONDITION_ANY, ScoreMinus10
 
 Basic_CheckCurrentWeatherIsSun:
-    ; If the weather is currently Sun, score -8.
+    // If the weather is currently Sun, score -8.
     LoadCurrentWeather 
     IfLoadedEqualTo AI_WEATHER_SUNNY, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckFutureSight:
-    ; If either the attacker or the target are currently under the effect of Future Sight, score -12.
+    // If either the attacker or the target are currently under the effect of Future Sight, score -12.
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_FUTURE_SIGHT, ScoreMinus12
     IfSideCondition AI_BATTLER_ATTACKER, SIDE_CONDITION_FUTURE_SIGHT, ScoreMinus12
     PopOrEnd 
 
 Basic_CheckFirstTurnInBattle:
-    ; If it is not the attacker's first turn in battle, score -10.
+    // If it is not the attacker's first turn in battle, score -10.
     LoadIsFirstTurnInBattle AI_BATTLER_ATTACKER
     IfLoadedEqualTo FALSE, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckMaxStockpile:
-    ; If the Stockpile count is already at 3, score -10.
+    // If the Stockpile count is already at 3, score -10.
     LoadStockpileCount AI_BATTLER_ATTACKER
     IfLoadedEqualTo 3, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckCanSpitUpOrSwallow:
-    ; If the target is immune to the move by its typing or the Stockpile count is 0, score -10.
-    ; Note that this means that Swallow will never be used against a Ghost-type Pokemon, even though
-    ; it would still have an effect.
+    // If the target is immune to the move by its typing or the Stockpile count is 0, score -10.
+    // Note that this means that Swallow will never be used against a Ghost-type Pokemon, even though
+    // it would still have an effect.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, ScoreMinus10
     LoadStockpileCount AI_BATTLER_ATTACKER
     IfLoadedEqualTo 0, ScoreMinus10
 
-    ; Treat Swallow like a standard recovery move.
+    // Treat Swallow like a standard recovery move.
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_SWALLOW, Basic_CheckCanRecoverHP
     PopOrEnd 
 
 Basic_CheckHail:
-    ; If the current weather is Hail, score -8.
+    // If the current weather is Hail, score -8.
     LoadCurrentWeather 
     IfLoadedEqualTo AI_WEATHER_HAILING, ScoreMinus8
 
-    ; If any opposing battler's ability is Ice Body, score -8.
+    // If any opposing battler's ability is Ice Body, score -8.
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedNotEqualTo ABILITY_ICE_BODY, Basic_CheckHail_Terminate
     AddToMoveScore -8
 
-    ; If an attacker's ability is also Ice Body, score +8 (undo the previous modifier).
-    ; This feels like a bug of misintention; the intention here seems to be for an attacker with
-    ; Ice Body to have an incentive to use Hail, but that is not realized. Instead, such an
-    ; attacker can only have a disincentive undone.
+    // If an attacker's ability is also Ice Body, score +8 (undo the previous modifier).
+    // This feels like a bug of misintention; the intention here seems to be for an attacker with
+    // Ice Body to have an incentive to use Hail, but that is not realized. Instead, such an
+    // attacker can only have a disincentive undone.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedNotEqualTo ABILITY_ICE_BODY, Basic_CheckHail_Terminate
     AddToMoveScore 8
@@ -872,12 +872,12 @@ Basic_CheckHail_Terminate:
     PopOrEnd 
 
 Basic_CheckTorment:
-    ; If the target is already under the effect, score -10.
+    // If the target is already under the effect, score -10.
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_TORMENT, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckCannotBurn:
-    ; If the target cannot be burned for any reason, score -10.
+    // If the target cannot be burned for any reason, score -10.
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_WATER_VEIL, ScoreMinus10
     IfLoadedEqualTo ABILITY_MAGIC_GUARD, ScoreMinus10
@@ -890,13 +890,13 @@ Basic_CheckCannotBurn:
     PopOrEnd 
 
 Basic_CheckHelpingHand:
-    ; If the battle type is not Doubles, score -10.
+    // If the battle type is not Doubles, score -10.
     LoadBattleType 
     IfLoadedNotMask BATTLE_TYPE_DOUBLES, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckCanRemoveItem:
-    ; If the defender's ability is Sticky Hold or they do not have a held item, score -10.
+    // If the defender's ability is Sticky Hold or they do not have a held item, score -10.
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_STICKY_HOLD, ScoreMinus10
     LoadHeldItem AI_BATTLER_DEFENDER
@@ -904,35 +904,35 @@ Basic_CheckCanRemoveItem:
     PopOrEnd 
 
 Basic_CheckAlreadyIngrained:
-    ; If the attacker is already under the effect, score -10.
+    // If the attacker is already under the effect, score -10.
     IfMoveEffect AI_BATTLER_ATTACKER, MOVE_EFFECT_INGRAIN, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckCanRecycle:
-    ; If there is no item to be recycled, score -10.
+    // If there is no item to be recycled, score -10.
     LoadRecycleItem AI_BATTLER_ATTACKER
     IfLoadedEqualTo ITEM_NONE, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckCanImprison:
-    ; If either the attacker or a target are under the effect of Imprison, score -10.
+    // If either the attacker or a target are under the effect of Imprison, score -10.
     IfMoveEffect AI_BATTLER_ATTACKER, MOVE_EFFECT_IMPRISON, ScoreMinus10
     IfMoveEffect AI_BATTLER_DEFENDER, MOVE_EFFECT_IMPRISONED, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckCanRefreshStatus:
-    ; If the attacker is not Burned, Poisoned, or Paralyzed, score -10.
+    // If the attacker is not Burned, Poisoned, or Paralyzed, score -10.
     IfNotStatus AI_BATTLER_ATTACKER, MON_CONDITION_FACADE_BOOST, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckCanMudSport:
-    ; If the attacker is already under the respective effect, score -10.
+    // If the attacker is already under the respective effect, score -10.
     IfMoveEffect AI_BATTLER_ATTACKER, MOVE_EFFECT_MUD_SPORT, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckTickle:
-    ; If the target's ability is Clear Body or White Smoke and the attacker's ability is not
-    ; Mold Breaker, score -10.
+    // If the target's ability is Clear Body or White Smoke and the attacker's ability is not
+    // Mold Breaker, score -10.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_MOLD_BREAKER, Basic_CheckTickle_CheckStatStages
     LoadBattlerAbility AI_BATTLER_DEFENDER
@@ -940,15 +940,15 @@ Basic_CheckTickle:
     IfLoadedEqualTo ABILITY_WHITE_SMOKE, ScoreMinus10
 
 Basic_CheckTickle_CheckStatStages:
-    ; If the target's Attack is at -6, score -10.
-    ; If the target's Defense is at -6, score -8.
+    // If the target's Attack is at -6, score -10.
+    // If the target's Defense is at -6, score -8.
     IfStatStageEqualTo AI_BATTLER_DEFENDER, BATTLE_STAT_ATTACK, 0, ScoreMinus10
     IfStatStageEqualTo AI_BATTLER_DEFENDER, BATTLE_STAT_DEFENSE, 0, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckCosmicPower:
-    ; If the attacker's ability is Simple and either Defense or SpDefense are already at
-    ; +3, score -10.
+    // If the attacker's ability is Simple and either Defense or SpDefense are already at
+    // +3, score -10.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedNotEqualTo ABILITY_SIMPLE, Basic_CheckCosmicPower_NoSimple
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_DEFENSE, 8, ScoreMinus10
@@ -956,15 +956,15 @@ Basic_CheckCosmicPower:
     PopOrEnd 
 
 Basic_CheckCosmicPower_NoSimple:
-    ; If the attacker's Defense is already at +6, score -10.
-    ; If the attacker's SpDefense is already at +6, score -8.
+    // If the attacker's Defense is already at +6, score -10.
+    // If the attacker's SpDefense is already at +6, score -8.
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_DEFENSE, 12, ScoreMinus10
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_SP_DEFENSE, 12, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckBulkUp:
-    ; If the attacker's ability is Simple and either Attack or Defense are already at
-    ; +3, score -10.
+    // If the attacker's ability is Simple and either Attack or Defense are already at
+    // +3, score -10.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedNotEqualTo ABILITY_SIMPLE, Basic_CheckBulkUp_NoSimple
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 8, ScoreMinus10
@@ -972,20 +972,20 @@ Basic_CheckBulkUp:
     PopOrEnd 
 
 Basic_CheckBulkUp_NoSimple:
-    ; If the attacker's Attack is already at +6, score -10.
-    ; If the attacker's Defense is already at +6, score -8.
+    // If the attacker's Attack is already at +6, score -10.
+    // If the attacker's Defense is already at +6, score -8.
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 12, ScoreMinus10
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_DEFENSE, 12, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckWaterSport:
-    ; If the attacker is already under the respective effect, score -10.
+    // If the attacker is already under the respective effect, score -10.
     IfMoveEffect AI_BATTLER_ATTACKER, MOVE_EFFECT_WATER_SPORT, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckCalmMind:
-    ; If the attacker's ability is Simple and either SpAttack or SpDefense are already at
-    ; +3, score -10.
+    // If the attacker's ability is Simple and either SpAttack or SpDefense are already at
+    // +3, score -10.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedNotEqualTo ABILITY_SIMPLE, Basic_CheckCalmMind_NoSimple
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_SP_ATTACK, 8, ScoreMinus10
@@ -993,18 +993,18 @@ Basic_CheckCalmMind:
     PopOrEnd 
 
 Basic_CheckCalmMind_NoSimple:
-    ; If the attacker's SpAttack is already at +6, score -10.
-    ; If the attacker's SpDefense is already at +6, score -8.
+    // If the attacker's SpAttack is already at +6, score -10.
+    // If the attacker's SpDefense is already at +6, score -8.
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_SP_ATTACK, 12, ScoreMinus10
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_SP_DEFENSE, 12, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckDragonDance:
-    ; If Trick Room is in effect, score -10.
+    // If Trick Room is in effect, score -10.
     IfFieldConditionsMask FIELD_CONDITION_TRICK_ROOM, ScoreMinus10
 
-    ; If the attacker's ability is Simple and either Attack or Speed are already at
-    ; +3, score -10.
+    // If the attacker's ability is Simple and either Attack or Speed are already at
+    // +3, score -10.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedNotEqualTo ABILITY_SIMPLE, Basic_CheckDragonDance_NoSimple
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 8, ScoreMinus10
@@ -1012,37 +1012,37 @@ Basic_CheckDragonDance:
     PopOrEnd 
 
 Basic_CheckDragonDance_NoSimple:
-    ; If the attacker's Attack is already at +6, score -10.
-    ; If the attacker's Speed is already at +6, score -8.
+    // If the attacker's Attack is already at +6, score -10.
+    // If the attacker's Speed is already at +6, score -8.
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 12, ScoreMinus10
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_SPEED, 12, ScoreMinus8
     PopOrEnd 
 
 Basic_CheckCamouflage:
-    ; If the attacker is already under the respective effect, score -10.
+    // If the attacker is already under the respective effect, score -10.
     IfMoveEffect AI_BATTLER_ATTACKER, MOVE_EFFECT_CAMOUFLAGE, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckGravityActive:
-    ; If Gravity is already active, score -10.
+    // If Gravity is already active, score -10.
     IfFieldConditionsMask FIELD_CONDITION_GRAVITY, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckMiracleEye:
-    ; If the target is already under the respective effect, score -10.
+    // If the target is already under the respective effect, score -10.
     IfMoveEffect AI_BATTLER_DEFENDER, MOVE_EFFECT_MIRACLE_EYE, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckHealingWish:
-    ; Start at -20
+    // Start at -20
     AddToMoveScore -20
 
-    ; If the attacker is on their last Pokemon, score additional -10.
+    // If the attacker is on their last Pokemon, score additional -10.
     CountAlivePartyBattlers AI_BATTLER_ATTACKER
     IfLoadedEqualTo 0, ScoreMinus10
 
-    ; If none of the attacker's party members are statused or at less than 100% HP,
-    ; score additional -10.
+    // If none of the attacker's party members are statused or at less than 100% HP,
+    // score additional -10.
     IfPartyMemberStatus AI_BATTLER_ATTACKER, MON_CONDITION_ANY, Basic_CheckHealingWish_Terminate
     IfAnyPartyMemberIsWounded AI_BATTLER_ATTACKER, Basic_CheckHealingWish_Terminate
     GoTo ScoreMinus10
@@ -1051,8 +1051,8 @@ Basic_CheckHealingWish_Terminate:
     PopOrEnd 
 
 Basic_CheckNaturalGift:
-    ; If the attacker does not have an eligible berry or the target is immune to that berry's
-    ; Natural Gift type, score -10.
+    // If the attacker does not have an eligible berry or the target is immune to that berry's
+    // Natural Gift type, score -10.
     LoadHeldItem AI_BATTLER_ATTACKER
     IfLoadedNotInTable Basic_NaturalGiftBerries, ScoreMinus10
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, ScoreMinus10
@@ -1126,8 +1126,8 @@ Basic_NaturalGiftBerries:
     TableEntry TABLE_END
 
 Basic_CheckTailwind:
-    ; If Trick Room is currently active or Tailwind is already active for the attacker's side
-    ; of the field, score -10.
+    // If Trick Room is currently active or Tailwind is already active for the attacker's side
+    // of the field, score -10.
     IfFieldConditionsMask FIELD_CONDITION_TRICK_ROOM, ScoreMinus10
     IfSideCondition AI_BATTLER_ATTACKER, SIDE_CONDITION_TAILWIND, ScoreMinus10
     PopOrEnd 
@@ -1136,7 +1136,7 @@ Basic_CheckAcupressure:
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_SIMPLE, Basic_CheckAcupressure_Simple
 
-    ; If any of the attacker's stat stages are already at +6, score -10.
+    // If any of the attacker's stat stages are already at +6, score -10.
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 12, ScoreMinus10
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_DEFENSE, 12, ScoreMinus10
     IfStatStageEqualTo AI_BATTLER_ATTACKER, BATTLE_STAT_SPEED, 12, ScoreMinus10
@@ -1147,7 +1147,7 @@ Basic_CheckAcupressure:
     PopOrEnd 
 
 Basic_CheckAcupressure_Simple:
-    ; If the attacker's ability is Simple and any stat stage is already at +3, score -10.
+    // If the attacker's ability is Simple and any stat stage is already at +3, score -10.
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 8, ScoreMinus10
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_DEFENSE, 8, ScoreMinus10
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_SPEED, 8, ScoreMinus10
@@ -1158,38 +1158,38 @@ Basic_CheckAcupressure_Simple:
     PopOrEnd 
 
 Basic_CheckMetalBurst:
-    ; If the target is immune to Metal Burst due to its typing (?), score -10.
+    // If the target is immune to Metal Burst due to its typing (?), score -10.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, ScoreMinus10
 
-    ; If the target's ability is Stall or they are holding a Shiny Stone, score -10.
-    ; BUG: This should use the command LoadHeldItemEffect to check for the Lagging Tail
-    ; effect.
+    // If the target's ability is Stall or they are holding a Shiny Stone, score -10.
+    // BUG: This should use the command LoadHeldItemEffect to check for the Lagging Tail
+    // effect.
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_STALL, ScoreMinus10
     IfHeldItemEqualTo AI_BATTLER_DEFENDER, ITEM_SHINY_STONE, ScoreMinus10
 
-    ; If the attacker's ability is Stall or they are holding a Shiny Stone, terminate.
-    ; BUG: This should use the command LoadHeldItemEffect to check for the Lagging Tail
-    ; effect.
+    // If the attacker's ability is Stall or they are holding a Shiny Stone, terminate.
+    // BUG: This should use the command LoadHeldItemEffect to check for the Lagging Tail
+    // effect.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_STALL, Basic_CheckMetalBurst_Terminate
     IfHeldItemEqualTo AI_BATTLER_ATTACKER, ITEM_SHINY_STONE, Basic_CheckMetalBurst_Terminate
 
-    ; If the attacker is faster than the target, score -10.
+    // If the attacker is faster than the target, score -10.
     IfSpeedCompareEqualTo COMPARE_SPEED_FASTER, ScoreMinus10
 
 Basic_CheckMetalBurst_Terminate:
     PopOrEnd 
 
 Basic_CheckEmbargo:
-    ; If the target is already under the respective effect, score -10.
+    // If the target is already under the respective effect, score -10.
     IfMoveEffect AI_BATTLER_DEFENDER, MOVE_EFFECT_EMBARGO, ScoreMinus10
 
-    ; If a recyclable item for the target's side exists, terminate.
+    // If a recyclable item for the target's side exists, terminate.
     LoadRecycleItem AI_BATTLER_DEFENDER
     IfLoadedEqualTo ITEM_NONE, Basic_CheckEmbargo_Terminate
 
-    ; If the battle is taking place in the Frontier, score -10.
+    // If the battle is taking place in the Frontier, score -10.
     LoadBattleType 
     IfLoadedMask BATTLE_TYPE_FRONTIER, ScoreMinus10
 
@@ -1197,18 +1197,18 @@ Basic_CheckEmbargo_Terminate:
     PopOrEnd 
 
 Basic_CheckFling:
-    ; If the target is immune to the move due to its typing (?), score -10.
+    // If the target is immune to the move due to its typing (?), score -10.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, ScoreMinus10
 
-    ; If Fling would have 0 base power, score -10.
+    // If Fling would have 0 base power, score -10.
     LoadFlingPower AI_BATTLER_ATTACKER
     IfLoadedLessThan 10, ScoreMinus10
 
-    ; If the attacker's ability is Multitype, score -10.
+    // If the attacker's ability is Multitype, score -10.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_MULTITYPE, ScoreMinus10
 
-    ; Branch according to possible status effects.
+    // Branch according to possible status effects.
     LoadHeldItemEffect AI_BATTLER_ATTACKER
     IfLoadedInTable Basic_FlingItems_Poison, Basic_FlingPoison
     IfLoadedInTable Basic_FlingItems_Burn, Basic_FlingBurn
@@ -1278,7 +1278,7 @@ Basic_FlingBurn_AttackerChecks:
     PopOrEnd 
 
 Basic_FlingParalyze:
-    ; If the target cannot be Paralyzed, score -5.
+    // If the target cannot be Paralyzed, score -5.
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_SAFEGUARD, ScoreMinus5
     IfStatus AI_BATTLER_DEFENDER, MON_CONDITION_ANY, ScoreMinus5
     LoadBattlerAbility AI_BATTLER_DEFENDER
@@ -1299,26 +1299,26 @@ Basic_FlingItems_Paralyze:
     TableEntry TABLE_END
 
 Basic_CheckCanPsychoShift:
-    ; If the attacker does not have a status condition or the target already has a status
-    ; condition, score -10.
+    // If the attacker does not have a status condition or the target already has a status
+    // condition, score -10.
     IfNotStatus AI_BATTLER_ATTACKER, MON_CONDITION_ANY, ScoreMinus10
     IfStatus AI_BATTLER_DEFENDER, MON_CONDITION_ANY, ScoreMinus10
 
-    ; If the target is protected by Safeguard, score -10.
+    // If the target is protected by Safeguard, score -10.
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_SAFEGUARD, ScoreMinus10
 
-    ; Branch according to the attacker's status condition.
+    // Branch according to the attacker's status condition.
     IfStatus AI_BATTLER_ATTACKER, MON_CONDITION_ANY_POISON, Basic_PsychoShift_Poison
     IfStatus AI_BATTLER_ATTACKER, MON_CONDITION_BURN, Basic_PsychoShift_Burn
     IfStatus AI_BATTLER_ATTACKER, MON_CONDITION_PARALYSIS, Basic_PsychoShift_Paralysis
     GoTo Basic_PsychoShift_Terminate
 
 Basic_PsychoShift_Poison:
-    ; If the attacker has Poison Heal, score -10.
+    // If the attacker has Poison Heal, score -10.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_POISON_HEAL, ScoreMinus10
 
-    ; If the target is immune to the effects of poison for any reason, score -10.
+    // If the target is immune to the effects of poison for any reason, score -10.
     LoadTypeFrom LOAD_DEFENDER_TYPE_1
     IfLoadedEqualTo TYPE_POISON, ScoreMinus10
     IfLoadedEqualTo TYPE_STEEL, ScoreMinus10
@@ -1332,7 +1332,7 @@ Basic_PsychoShift_Poison:
     GoTo Basic_PsychoShift_Terminate
 
 Basic_PsychoShift_Burn:
-    ; If the target is immune to the effects of burn for any reason, score -10.
+    // If the target is immune to the effects of burn for any reason, score -10.
     LoadTypeFrom LOAD_DEFENDER_TYPE_1
     IfLoadedEqualTo TYPE_FIRE, ScoreMinus10
     LoadTypeFrom LOAD_DEFENDER_TYPE_2
@@ -1343,7 +1343,7 @@ Basic_PsychoShift_Burn:
     GoTo Basic_PsychoShift_Terminate
 
 Basic_PsychoShift_Paralysis:
-    ; If the target's ability is Limber, score -10.
+    // If the target's ability is Limber, score -10.
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_LIMBER, ScoreMinus10
 
@@ -1351,20 +1351,20 @@ Basic_PsychoShift_Terminate:
     PopOrEnd 
 
 Basic_CheckHealBlock:
-    ; If the target is already under the effect, score -10.
+    // If the target is already under the effect, score -10.
     IfMoveEffect AI_BATTLER_DEFENDER, MOVE_EFFECT_HEAL_BLOCK, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckPowerTrick:
-    ; If the attacker is already under the effect, score -10.
+    // If the attacker is already under the effect, score -10.
     IfMoveEffect AI_BATTLER_ATTACKER, MOVE_EFFECT_POWER_TRICK, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckGastroAcid:
-    ; If the target is already under the effect, score -10.
+    // If the target is already under the effect, score -10.
     IfMoveEffect AI_BATTLER_DEFENDER, MOVE_EFFECT_ABILITY_SUPPRESSED, ScoreMinus10
 
-    ; If the target has any of the following abilities, score -10.
+    // If the target has any of the following abilities, score -10.
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_MULTITYPE, ScoreMinus10
     IfLoadedEqualTo ABILITY_TRUANT, ScoreMinus10
@@ -1376,12 +1376,12 @@ Basic_CheckGastroAcid:
     PopOrEnd 
 
 Basic_CheckLuckyChant:
-    ; If the attacker is already under the effect, score -10.
+    // If the attacker is already under the effect, score -10.
     IfSideCondition AI_BATTLER_ATTACKER, SIDE_CONDITION_LUCKY_CHANT, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckCopycat:
-    ; If it's the first turn of the battle and the attacker is faster than its target, score -10.
+    // If it's the first turn of the battle and the attacker is faster than its target, score -10.
     LoadTurnCount 
     IfLoadedNotEqualTo 0, Basic_CheckCopycat_Terminate
     IfSpeedCompareEqualTo COMPARE_SPEED_FASTER, ScoreMinus10
@@ -1390,8 +1390,8 @@ Basic_CheckCopycat_Terminate:
     PopOrEnd 
 
 Basic_CheckPowerSwap:
-    ; If Power Swap would result in a net-negative change to stat stages for both Attack
-    ; and SpAttack, score -10.
+    // If Power Swap would result in a net-negative change to stat stages for both Attack
+    // and SpAttack, score -10.
     DiffStatStages AI_BATTLER_DEFENDER, BATTLE_STAT_ATTACK
     IfLoadedLessThan 1, Basic_CheckGuardSwap_SpAttack
     GoTo Basic_CheckPowerSwap_Terminate
@@ -1404,8 +1404,8 @@ Basic_CheckPowerSwap_Terminate:
     PopOrEnd 
 
 Basic_CheckGuardSwap:
-    ; If Guard Swap would result in a net-negative change to stat stages for both Defense
-    ; and SpDefense, score -10.
+    // If Guard Swap would result in a net-negative change to stat stages for both Defense
+    // and SpDefense, score -10.
     DiffStatStages AI_BATTLER_DEFENDER, BATTLE_STAT_DEFENSE
     IfLoadedLessThan 1, Basic_CheckGuardSwap_SpDefense
     GoTo Basic_CheckGuardSwap_Terminate
@@ -1418,7 +1418,7 @@ Basic_CheckGuardSwap_Terminate:
     PopOrEnd 
 
 Basic_CheckLastResort:
-    ; If the attacker has yet to use all of its other moves, score -10.
+    // If the attacker has yet to use all of its other moves, score -10.
     IfCanUseLastResort AI_BATTLER_ATTACKER, Basic_CheckLastResort_Terminate
     AddToMoveScore -10
 
@@ -1426,14 +1426,14 @@ Basic_CheckLastResort_Terminate:
     PopOrEnd 
 
 Basic_CheckWorrySeed:
-    ; If the target has any of the following abilities, score -10.
+    // If the target has any of the following abilities, score -10.
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_TRUANT, ScoreMinus10
     IfLoadedEqualTo ABILITY_INSOMNIA, ScoreMinus10
     IfLoadedEqualTo ABILITY_VITAL_SPIRIT, ScoreMinus10
     IfLoadedEqualTo ABILITY_MULTITYPE, ScoreMinus10
 
-    ; If the target is asleep and does not know either Sleep Talk or Snore, score -10.
+    // If the target is asleep and does not know either Sleep Talk or Snore, score -10.
     IfNotStatus AI_BATTLER_DEFENDER, MON_CONDITION_SLEEP, Basic_CheckWorrySeed_Terminate
     IfMoveKnown AI_BATTLER_DEFENDER, MOVE_SLEEP_TALK, Basic_CheckWorrySeed_Terminate
     IfMoveKnown AI_BATTLER_DEFENDER, MOVE_SNORE, Basic_CheckWorrySeed_Terminate
@@ -1443,30 +1443,30 @@ Basic_CheckWorrySeed_Terminate:
     PopOrEnd 
 
 Basic_CheckToxicSpikes:
-    ; If the target's side of the field already has 2 layers of Toxic Spikes, score -10.
+    // If the target's side of the field already has 2 layers of Toxic Spikes, score -10.
     LoadSpikesLayers AI_BATTLER_DEFENDER, SIDE_CONDITION_TOXIC_SPIKES
     IfLoadedEqualTo 2, ScoreMinus10
 
-    ; If the target is the last battler, score -10.
+    // If the target is the last battler, score -10.
     CountAlivePartyBattlers AI_BATTLER_DEFENDER
     IfLoadedEqualTo 0, ScoreMinus10
     PopOrEnd 
     PopOrEnd 
 
 Basic_CheckAquaRing:
-    ; If the attacker is already under the effect, score -10.
+    // If the attacker is already under the effect, score -10.
     IfMoveEffect AI_BATTLER_ATTACKER, MOVE_EFFECT_AQUA_RING, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckMagnetRise:
-    ; If the attacker is already under the effect, score -10.
+    // If the attacker is already under the effect, score -10.
     IfMoveEffect AI_BATTLER_ATTACKER, MOVE_EFFECT_MAGNET_RISE, ScoreMinus10
 
-    ; If the attacker's ability is Levitate, score -10.
+    // If the attacker's ability is Levitate, score -10.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_LEVITATE, ScoreMinus10
 
-    ; If either of the attacker's types are Flying, score -10.
+    // If either of the attacker's types are Flying, score -10.
     LoadTypeFrom LOAD_ATTACKER_TYPE_1
     IfLoadedEqualTo TYPE_FLYING, ScoreMinus10
     LoadTypeFrom LOAD_ATTACKER_TYPE_2
@@ -1474,22 +1474,22 @@ Basic_CheckMagnetRise:
     PopOrEnd 
 
 Basic_CheckDefog:
-    ; If the target's Evasion is not at -6 or their side of the field has Light Screen or
-    ; Reflect, ignore all other checks.
+    // If the target's Evasion is not at -6 or their side of the field has Light Screen or
+    // Reflect, ignore all other checks.
     IfStatStageNotEqualTo AI_BATTLER_DEFENDER, BATTLE_STAT_EVASION, 0, Basic_CheckDefog_Terminate
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_LIGHT_SCREEN, Basic_CheckDefog_Terminate
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_REFLECT, Basic_CheckDefog_Terminate
 
-    ; If the current weather is Deep Fog, ignore all other checks.
+    // If the current weather is Deep Fog, ignore all other checks.
     LoadCurrentWeather 
     IfLoadedEqualTo AI_WEATHER_DEEP_FOG, Basic_CheckDefog_Terminate
 
-    ; If the target is on their last Pokemon, score -10.
+    // If the target is on their last Pokemon, score -10.
     CountAlivePartyBattlers AI_BATTLER_DEFENDER
     IfLoadedEqualTo 0, ScoreMinus10
 
-    ; If the target's side of the field has none of Spikes, Stealth Rock, or Toxic Spikes
-    ; active, score -10.
+    // If the target's side of the field has none of Spikes, Stealth Rock, or Toxic Spikes
+    // active, score -10.
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_SPIKES, Basic_CheckDefog_Terminate
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_STEALTH_ROCK, Basic_CheckDefog_Terminate
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_TOXIC_SPIKES, Basic_CheckDefog_Terminate
@@ -1499,15 +1499,15 @@ Basic_CheckDefog_Terminate:
     PopOrEnd 
 
 Basic_CheckTrickRoom:
-    ; If the attacker is faster than the target, score -10.
-    ; Treat speed ties as being faster than the target.
+    // If the attacker is faster than the target, score -10.
+    // Treat speed ties as being faster than the target.
     IfSpeedCompareEqualTo COMPARE_SPEED_FASTER, ScoreMinus10
     IfSpeedCompareEqualTo COMPARE_SPEED_TIE, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckCaptivate:
-    ; If the target's ability is any of Oblivious, Clear Body, or White Smoke and the attacker's
-    ; ability is not Mold Breaker, score -10.
+    // If the target's ability is any of Oblivious, Clear Body, or White Smoke and the attacker's
+    // ability is not Mold Breaker, score -10.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_MOLD_BREAKER, Basic_CheckCaptivate_CheckGender
     LoadBattlerAbility AI_BATTLER_DEFENDER
@@ -1516,7 +1516,7 @@ Basic_CheckCaptivate:
     IfLoadedEqualTo ABILITY_WHITE_SMOKE, ScoreMinus10
 
 Basic_CheckCaptivate_CheckGender:
-    ; If the target and the attacker share gender or the target has no gender, score -10.
+    // If the target and the attacker share gender or the target has no gender, score -10.
     LoadGender AI_BATTLER_ATTACKER
     IfLoadedEqualTo GENDER_MALE, Basic_CheckCaptivate_CheckMale
     IfLoadedEqualTo GENDER_FEMALE, Basic_CheckCaptivate_CheckFemale
@@ -1533,29 +1533,29 @@ Basic_CheckCaptivate_CheckFemale:
     GoTo ScoreMinus10
 
 Basic_CheckCaptivate_CheckStatStage:
-    ; If the target is already at -6, score -10.
+    // If the target is already at -6, score -10.
     IfStatStageLessThan AI_BATTLER_DEFENDER, BATTLE_STAT_SP_ATTACK, 1, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckStealthRock:
-    ; If the target's side of the field is already under the effect of Stealth Rock, score -10.
+    // If the target's side of the field is already under the effect of Stealth Rock, score -10.
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_STEALTH_ROCK, ScoreMinus10
 
-    ; If the target is on their last Pokemon, score -10.
+    // If the target is on their last Pokemon, score -10.
     CountAlivePartyBattlers AI_BATTLER_DEFENDER
     IfLoadedEqualTo 0, ScoreMinus10
     PopOrEnd 
 
 Basic_CheckLunarDance:
-    ; Start at -20
+    // Start at -20
     AddToMoveScore -20
 
-    ; If the attacker is on their last Pokemon, score additional -10.
+    // If the attacker is on their last Pokemon, score additional -10.
     CountAlivePartyBattlers AI_BATTLER_ATTACKER
     IfLoadedEqualTo 0, ScoreMinus10
 
-    ; If none of the attacker's party members are statused, at less than 100% HP, or at
-    ; less than full PP on all of their moves, score -10.
+    // If none of the attacker's party members are statused, at less than 100% HP, or at
+    // less than full PP on all of their moves, score -10.
     IfAnyPartyMemberIsWounded AI_BATTLER_ATTACKER, Basic_CheckLunarDance_Terminate
     IfPartyMemberStatus AI_BATTLER_ATTACKER, MON_CONDITION_ANY, Basic_CheckLunarDance_Terminate
     IfAnyPartyMemberUsedPP AI_BATTLER_ATTACKER, Basic_CheckLunarDance_Terminate
@@ -1580,7 +1580,7 @@ ScoreMinus5:
     AddToMoveScore -5
     PopOrEnd 
 
-ScoreMinus6: ; unused
+ScoreMinus6: // unused
     AddToMoveScore -6
     PopOrEnd 
 
@@ -1621,10 +1621,10 @@ ScorePlus10:
     PopOrEnd 
 
 Expert_Main:
-    ; This flag will never target its partner.
+    // This flag will never target its partner.
     IfTargetIsPartner Terminate
 
-    ; Evaluate moves which match a known effect according to this jump table.
+    // Evaluate moves which match a known effect according to this jump table.
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_STATUS_SLEEP, Expert_StatusSleep
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_RECOVER_HALF_DAMAGE_DEALT, Expert_DrainMove
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_HALVE_DEFENSE, Expert_Explosion
@@ -1804,12 +1804,12 @@ Expert_Main:
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_FAINT_FULL_RESTORE_NEXT_MON, Expert_HealingWish
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_SHADOW_FORCE, Expert_ShadowForce
 
-    ; All other moves have no additional logic.
+    // All other moves have no additional logic.
     PopOrEnd 
 
 Expert_StatusSleep:
-    ; If the attacker knows a move which requires the target to be asleep (Dream Eater or Nightmare
-    ; effects), 50% chance of score +1.
+    // If the attacker knows a move which requires the target to be asleep (Dream Eater or Nightmare
+    // effects), 50% chance of score +1.
     IfMoveEffectKnown AI_BATTLER_ATTACKER, BATTLE_EFFECT_RECOVER_DAMAGE_SLEEP, Expert_StatusSleep_TryScorePlus1
     IfMoveEffectKnown AI_BATTLER_ATTACKER, BATTLE_EFFECT_STATUS_NIGHTMARE, Expert_StatusSleep_TryScorePlus1
     GoTo Expert_StatusSleep_End
@@ -1822,7 +1822,7 @@ Expert_StatusSleep_End:
     PopOrEnd 
 
 Expert_DrainMove:
-    ; If the target is immune to or resists the move, ~80.5% chance of score -3.
+    // If the target is immune to or resists the move, ~80.5% chance of score -3.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_DrainMove_TryScoreMinus3
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_DrainMove_TryScoreMinus3
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_DrainMove_TryScoreMinus3
@@ -1836,20 +1836,20 @@ Expert_DrainMove_End:
     PopOrEnd 
 
 Expert_Explosion:
-    ; If the target's Evasion is at +1 stage or higher, additional score -1 to all further modifiers.
-    ;
-    ; If the target's Evasion is at +3 stages or higher, 50% chance of additional score -1 to all further modifiers.
-    ;
-    ; Apply an additional modifier according to the user's current HP (as a percentage):
-    ;
-    ; | User HP (%)   | Additional Qualifier | Modifier                 |
-    ; | ------------: | -------------------- | ------------------------ |
-    ; |        >= 80% | Faster than target   | 80.5% chance of score -3 |
-    ; |        >= 80% | Slower than target   | 80.5% chance of score -1 |
-    ; |         > 50% | N/A                  | 80.5% chance of score -1 |
-    ; | <= 50%, > 30% | N/A                  | 50% chance of score +1   |
-    ; |        <= 30% | N/A                  | 80.5% chance of score +1 |
-    ;
+    // If the target's Evasion is at +1 stage or higher, additional score -1 to all further modifiers.
+    //
+    // If the target's Evasion is at +3 stages or higher, 50% chance of additional score -1 to all further modifiers.
+    //
+    // Apply an additional modifier according to the user's current HP (as a percentage):
+    //
+    // | User HP (%)   | Additional Qualifier | Modifier                 |
+    // | ------------: | -------------------- | ------------------------ |
+    // |        >= 80% | Faster than target   | 80.5% chance of score -3 |
+    // |        >= 80% | Slower than target   | 80.5% chance of score -1 |
+    // |         > 50% | N/A                  | 80.5% chance of score -1 |
+    // | <= 50%, > 30% | N/A                  | 50% chance of score +1   |
+    // |        <= 30% | N/A                  | 80.5% chance of score +1 |
+    //
     IfStatStageLessThan AI_BATTLER_DEFENDER, BATTLE_STAT_EVASION, 7, Expert_Explosion_CheckUserHighHP
     AddToMoveScore -1
     IfStatStageLessThan AI_BATTLER_DEFENDER, BATTLE_STAT_EVASION, 10, Expert_Explosion_CheckUserHighHP
@@ -1881,9 +1881,9 @@ Expert_Explosion_End:
     PopOrEnd 
 
 Expert_DreamEater:
-    ; If the target is immune to or resists the move, always score -1 instead of the above.
-    ;
-    ; If the target does not resist the move and is asleep, 80.1% chance of score +3.
+    // If the target is immune to or resists the move, always score -1 instead of the above.
+    //
+    // If the target does not resist the move and is asleep, 80.1% chance of score +3.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_DreamEater_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_DreamEater_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_DreamEater_ScoreMinus1
@@ -1902,10 +1902,10 @@ Expert_DreamEater_End:
     PopOrEnd 
 
 Expert_MirrorMove:
-    ; If the attacker is faster than its target and the last-used move by that target is in the below
-    ; list, 50% chance of score +2.
-    ;
-    ; Otherwise, if the last-used move by the target is *not* in the table, 68.75% chance of score -1.
+    // If the attacker is faster than its target and the last-used move by that target is in the below
+    // list, 50% chance of score +2.
+    //
+    // Otherwise, if the last-used move by the target is *not* in the table, 68.75% chance of score -1.
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_MirrorMove_TryScoreMinus1
     LoadBattlerPreviousMove AI_BATTLER_DEFENDER
     IfLoadedNotInTable Expert_MirrorMove_MoveTable, Expert_MirrorMove_TryScoreMinus1
@@ -1973,15 +1973,15 @@ Expert_MirrorMove_MoveTable:
     TableEntry TABLE_END
 
 Expert_StatusAttackUp:
-    ; If the attacker is at +3 stat stage or higher, ~60.9% chance of additional score -1.
-    ;
-    ; If the attacker is at 100% HP, 50% chance of additional score +2.
-    ;
-    ; If the attacker's HP is > 70%, no further score changes.
-    ;
-    ; If the attacker's HP is < 40%, additional score -2.
-    ;
-    ; Otherwise, ~84.4% chance of additional score -2.
+    // If the attacker is at +3 stat stage or higher, ~60.9% chance of additional score -1.
+    //
+    // If the attacker is at 100% HP, 50% chance of additional score +2.
+    //
+    // If the attacker's HP is > 70%, no further score changes.
+    //
+    // If the attacker's HP is < 40%, additional score -2.
+    //
+    // Otherwise, ~84.4% chance of additional score -2.
     IfStatStageLessThan AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 9, Expert_StatusAttackUp_CheckUserAtMaxHP
     IfRandomLessThan 100, Expert_StatusAttackUp_CheckUserHPRange
     AddToMoveScore -1
@@ -2004,18 +2004,18 @@ Expert_StatusAttackUp_End:
     PopOrEnd 
 
 Expert_StatusDefenseUp:
-    ; If the attacker is at +3 stat stage or higher, ~60.9% chance of additional score -1.
-    ;
-    ; If the attacker is at 100% HP, 50% chance of additional score +2.
-    ;
-    ; If the attacker's HP is >= 70%, ~78.1% chance to suppress all further score modifiers.
-    ;
-    ; If the attacker's HP is < 40%, additional score -2.
-    ;
-    ; Otherwise:
-    ; - If the target's last-used move was a Status move, ~76.6% chance of score -2.
-    ; - If the target's last-used move was a Special move, 58.6% chance of score -2.
-    ; - Otherwise, score -2.
+    // If the attacker is at +3 stat stage or higher, ~60.9% chance of additional score -1.
+    //
+    // If the attacker is at 100% HP, 50% chance of additional score +2.
+    //
+    // If the attacker's HP is >= 70%, ~78.1% chance to suppress all further score modifiers.
+    //
+    // If the attacker's HP is < 40%, additional score -2.
+    //
+    // Otherwise:
+    // - If the target's last-used move was a Status move, ~76.6% chance of score -2.
+    // - If the target's last-used move was a Special move, 58.6% chance of score -2.
+    // - Otherwise, score -2.
     IfStatStageLessThan AI_BATTLER_ATTACKER, BATTLE_STAT_DEFENSE, 9, Expert_StatusDefenseUp_CheckUserAtMaxHP
     IfRandomLessThan 100, Expert_StatusDefenseUp_CheckUserHighHP
     AddToMoveScore -1
@@ -2061,9 +2061,9 @@ Expert_StatusDefenseUp_PreSplitPhysicalTypes:
     TableEntry TABLE_END
 
 Expert_StatusSpeedUp:
-    ; If the AI is faster than its target, score -3.
-    ;
-    ; If the AI is slower than its target, 72.7% chance of score +3.
+    // If the AI is faster than its target, score -3.
+    //
+    // If the AI is slower than its target, 72.7% chance of score +3.
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_StatusSpeedUp_TryScorePlus3
     AddToMoveScore -3
     GoTo Expert_StatusSpeedUp_End
@@ -2076,15 +2076,15 @@ Expert_StatusSpeedUp_End:
     PopOrEnd 
 
 Expert_StatusSpAttackUp:
-    ; If the attacker is at +3 stat stage or higher, ~60.9% chance of additional score -1.
-    ;
-    ; If the attacker is at 100% HP, 50% chance of additional score +2.
-    ;
-    ; If the attacker's HP is > 70%, no further score changes.
-    ;
-    ; If the attacker's HP is < 40%, additional score -2.
-    ;
-    ; Otherwise, ~84.4% chance of additional score -2.
+    // If the attacker is at +3 stat stage or higher, ~60.9% chance of additional score -1.
+    //
+    // If the attacker is at 100% HP, 50% chance of additional score +2.
+    //
+    // If the attacker's HP is > 70%, no further score changes.
+    //
+    // If the attacker's HP is < 40%, additional score -2.
+    //
+    // Otherwise, ~84.4% chance of additional score -2.
     IfStatStageLessThan AI_BATTLER_ATTACKER, BATTLE_STAT_SP_ATTACK, 9, Expert_StatusSpAttackUp_CheckUserAtMaxHP
     IfRandomLessThan 100, Expert_StatusSpAttackUp_CheckUserHPRange
     AddToMoveScore -1
@@ -2107,18 +2107,18 @@ Expert_StatusSpAttackUp_End:
     PopOrEnd 
 
 Expert_StatusSpDefenseUp:
-    ; If the attacker is at +3 stat stage or higher, ~60.9% chance of additional score -1.
-    ;
-    ; If the attacker is at 100% HP, 50% chance of additional score +2.
-    ;
-    ; If the attacker's HP is >= 70%, ~78.1% chance to suppress all further score modifiers.
-    ;
-    ; If the attacker's HP is < 40%, additional score -2.
-    ;
-    ; Otherwise:
-    ; - If the target's last-used move was a Status move, ~76.6% chance of score -2.
-    ; - If the target's last-used move was a Physical move, 58.6% chance of score -2.
-    ; - Otherwise, score -2.
+    // If the attacker is at +3 stat stage or higher, ~60.9% chance of additional score -1.
+    //
+    // If the attacker is at 100% HP, 50% chance of additional score +2.
+    //
+    // If the attacker's HP is >= 70%, ~78.1% chance to suppress all further score modifiers.
+    //
+    // If the attacker's HP is < 40%, additional score -2.
+    //
+    // Otherwise:
+    // - If the target's last-used move was a Status move, ~76.6% chance of score -2.
+    // - If the target's last-used move was a Physical move, 58.6% chance of score -2.
+    // - Otherwise, score -2.
     IfStatStageLessThan AI_BATTLER_ATTACKER, BATTLE_STAT_SP_DEFENSE, 9, Expert_StatusSpDefenseUp_CheckUserAtMaxHP
     IfRandomLessThan 100, Expert_StatusSpDefenseUp_CheckUserHighHP
     AddToMoveScore -1
@@ -2164,9 +2164,9 @@ Expert_StatusSpDefenseUp_PreSplitPhysicalTypes:
     TableEntry TABLE_END
 
 Expert_StatusAccuracyUp:
-    ; If the attacker is at +3 stat stage or higher, ~80.5% chance of additional score -2.
-    ;
-    ; If the attacker's HP is at < 70%, score -2.
+    // If the attacker is at +3 stat stage or higher, ~80.5% chance of additional score -2.
+    //
+    // If the attacker's HP is at < 70%, score -2.
     IfStatStageLessThan AI_BATTLER_ATTACKER, BATTLE_STAT_ACCURACY, 9, Expert_StatusAccuracyUp_TryScoreMinus2
     IfRandomLessThan 50, Expert_StatusAccuracyUp_TryScoreMinus2
     AddToMoveScore -2
@@ -2179,24 +2179,24 @@ Expert_StatusAccuracyUp_End:
     PopOrEnd 
 
 Expert_StatusEvasionUp:
-    ; If the attacker's HP is >= 90%, ~60.9% chance of additional score +3.
-    ;
-    ; If the attacker is at +3 stat stage or higher, 50% chance of additional score -1.
-    ;
-    ; If the target is Badly Poisoned:
-    ; - If the attacker's HP is > 50%, ~80.5% chance of additional score +3.
-    ; - If the attacker's HP is <= 50%, ~55.3% chance of additional score +3.
-    ;
-    ; If the target is affected by Leech Seed, ~72.7% chance of additional score +3.
-    ;
-    ; If the attacker is affected by Ingrain or Aqua Ring, 50% chance of additional score +2.
-    ;
-    ; If the target is affected by Curse, ~72.7% chance of additional score +3.
-    ;
-    ; If the attacker's HP is > 70%, suppress all further modifiers. Otherwise:
-    ; - If the attacker is at exactly +0 stat stage, no further score modifiers.
-    ; - If either the attacker's HP or the target's HP are < 40%, score -2.
-    ; - Otherwise, ~72.7% chance of score -2.
+    // If the attacker's HP is >= 90%, ~60.9% chance of additional score +3.
+    //
+    // If the attacker is at +3 stat stage or higher, 50% chance of additional score -1.
+    //
+    // If the target is Badly Poisoned:
+    // - If the attacker's HP is > 50%, ~80.5% chance of additional score +3.
+    // - If the attacker's HP is <= 50%, ~55.3% chance of additional score +3.
+    //
+    // If the target is affected by Leech Seed, ~72.7% chance of additional score +3.
+    //
+    // If the attacker is affected by Ingrain or Aqua Ring, 50% chance of additional score +2.
+    //
+    // If the target is affected by Curse, ~72.7% chance of additional score +3.
+    //
+    // If the attacker's HP is > 70%, suppress all further modifiers. Otherwise:
+    // - If the attacker is at exactly +0 stat stage, no further score modifiers.
+    // - If either the attacker's HP or the target's HP are < 40%, score -2.
+    // - Otherwise, ~72.7% chance of score -2.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 90, Expert_StatusEvasionUp_CheckUserStatStage
     IfRandomLessThan 100, Expert_StatusEvasionUp_CheckUserStatStage
     AddToMoveScore 3
@@ -2251,10 +2251,10 @@ Expert_StatusEvasionUp_End:
     PopOrEnd 
 
 Expert_BypassAccuracyMove:
-    ; If the target is at +5 Evasion or higher, or the attacker is at -5 Accuracy or lower, 60.9%
-    ; chance of score +2, 39.1% chance of score +1.
-    ;
-    ; If the target is at +3 Evasion or higher, or the attacker is at -3 Accuracy or lower, score +1.
+    // If the target is at +5 Evasion or higher, or the attacker is at -5 Accuracy or lower, 60.9%
+    // chance of score +2, 39.1% chance of score +1.
+    //
+    // If the target is at +3 Evasion or higher, or the attacker is at -3 Accuracy or lower, score +1.
     IfStatStageGreaterThan AI_BATTLER_DEFENDER, BATTLE_STAT_EVASION, 10, Expert_BypassAccuracyMove_ScorePlus1
     IfStatStageLessThan AI_BATTLER_ATTACKER, BATTLE_STAT_ACCURACY, 2, Expert_BypassAccuracyMove_ScorePlus1
     IfStatStageGreaterThan AI_BATTLER_DEFENDER, BATTLE_STAT_EVASION, 8, Expert_BypassAccuracyMove_TryScorePlus1
@@ -2272,14 +2272,14 @@ Expert_BypassAccuracyMove_End:
     PopOrEnd 
 
 Expert_StatusAttackDown:
-    ; If the target is at any stat stage other than +0, additional score -1. Also, further modify
-    ; the score according to all of the following which apply:
-    ; - If the attacker's HP is at 90% or lower, additional score -1.
-    ; - If the target is at -3 stat stage or lower, 80.5% chance of additional score -2.
-    ;
-    ; If the target's HP is at 70% or lower, additional score -2.
-    ;
-    ; If the move last used by the target was not a Special move, 50% chance of score -2.
+    // If the target is at any stat stage other than +0, additional score -1. Also, further modify
+    // the score according to all of the following which apply:
+    // - If the attacker's HP is at 90% or lower, additional score -1.
+    // - If the target is at -3 stat stage or lower, 80.5% chance of additional score -2.
+    //
+    // If the target's HP is at 70% or lower, additional score -2.
+    //
+    // If the move last used by the target was not a Special move, 50% chance of score -2.
     IfStatStageEqualTo AI_BATTLER_DEFENDER, BATTLE_STAT_ATTACK, 6, Expert_StatusAttackDown_CheckTargetHP
     AddToMoveScore -1
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 90, Expert_StatusAttackDown_CheckTargetStatStage
@@ -2313,11 +2313,11 @@ Expert_StatusAttackDown_PreSplitPhysicalTypes:
     TableEntry TABLE_END
 
 Expert_StatusDefenseDown:
-    ; If the attacker's HP is < 70%, 80.5% chance of additional score -2.
-    ;
-    ; If the target's stat stage is otherwise at -3 or lower, 80.5% chance of additional score -2.
-    ;
-    ; If the target's HP is < 70%, score -2.
+    // If the attacker's HP is < 70%, 80.5% chance of additional score -2.
+    //
+    // If the target's stat stage is otherwise at -3 or lower, 80.5% chance of additional score -2.
+    //
+    // If the target's HP is < 70%, score -2.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 70, Expert_StatusDefenseDown_TryScoreMinus2
     IfStatStageGreaterThan AI_BATTLER_DEFENDER, BATTLE_STAT_DEFENSE, 3, Expert_StatusDefenseDown_CheckTargetHP
 
@@ -2333,9 +2333,9 @@ Expert_StatusDefenseDown_End:
     PopOrEnd 
 
 Expert_SpeedDownOnHit:
-    ; If the target is immune to or would resist the move, do not apply any further modifiers.
-    ;
-    ; Treat the exact moves Icy Wind, Rock Tomb, and Mud Shot as Speed-reducing status moves.
+    // If the target is immune to or would resist the move, do not apply any further modifiers.
+    //
+    // Treat the exact moves Icy Wind, Rock Tomb, and Mud Shot as Speed-reducing status moves.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_SpeedDownOnHit_End
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_SpeedDownOnHit_End
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_SpeedDownOnHit_End
@@ -2348,9 +2348,9 @@ Expert_SpeedDownOnHit_End:
     PopOrEnd 
 
 Expert_StatusSpeedDown:
-    ; If the attacker is slower than its target, 72.7% chance of score +2.
-    ;
-    ; If the attacker is faster than its target, score -3.
+    // If the attacker is slower than its target, 72.7% chance of score +2.
+    //
+    // If the attacker is faster than its target, score -3.
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_StatusSpeedDown_TryScorePlus2
     AddToMoveScore -3
     GoTo Expert_StatusSpeedDown_End
@@ -2363,14 +2363,14 @@ Expert_StatusSpeedDown_End:
     PopOrEnd 
 
 Expert_StatusSpAttackDown:
-    ; If the target is at any stat stage other than +0, additional score -1. Also, further modify
-    ; the score according to all of the following which apply:
-    ; - If the attacker's HP is at 90% or lower, additional score -1.
-    ; - If the target is at -3 stat stage or lower, 80.5% chance of additional score -2.
-    ;
-    ; If the target's HP is at 70% or lower, additional score -2.
-    ;
-    ; If the move last used by the target was not a Physical move, 50% chance of score -2.
+    // If the target is at any stat stage other than +0, additional score -1. Also, further modify
+    // the score according to all of the following which apply:
+    // - If the attacker's HP is at 90% or lower, additional score -1.
+    // - If the target is at -3 stat stage or lower, 80.5% chance of additional score -2.
+    //
+    // If the target's HP is at 70% or lower, additional score -2.
+    //
+    // If the move last used by the target was not a Physical move, 50% chance of score -2.
     IfStatStageEqualTo AI_BATTLER_DEFENDER, BATTLE_STAT_SP_ATTACK, 6, Expert_StatusSpAttackDown_CheckTargetHP
     AddToMoveScore -1
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 90, Expert_StatusSpAttackDown_CheckTargetStatStage
@@ -2406,11 +2406,11 @@ Expert_StatusSpAttackDown_PreSplitSpecialTypes:
     TableEntry TABLE_END
 
 Expert_StatusSpDefenseDown:
-    ; If the attacker's HP is < 70%, 80.5% chance of additional score -2.
-    ;
-    ; If the target's stat stage is otherwise at -3 or lower, 80.5% chance of additional score -2.
-    ;
-    ; If the target's HP is < 70%, score -2.
+    // If the attacker's HP is < 70%, 80.5% chance of additional score -2.
+    //
+    // If the target's stat stage is otherwise at -3 or lower, 80.5% chance of additional score -2.
+    //
+    // If the target's HP is < 70%, score -2.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 70, Expert_StatusSpDefenseDown_TryScoreMinus2
     IfStatStageGreaterThan AI_BATTLER_DEFENDER, BATTLE_STAT_SP_DEFENSE, 3, Expert_StatusSpDefenseDown_CheckTargetHP
 
@@ -2426,23 +2426,23 @@ Expert_StatusSpDefenseDown_End:
     PopOrEnd 
 
 Expert_StatusAccuracyDown:
-    ; If the target's HP is <= 70% and the attacker's HP is NOT >= 70%, 60.9% chance of additional
-    ; score -1.
-    ;
-    ; If the attacker is at -2 accuracy or lower, 68.75% chance of additional score -2.
-    ;
-    ; If the target is Badly Poisoned, ~72.7% chance of additional score +2.
-    ;
-    ; If the target is affected by Leech Seed, ~72.7% chance of additional score +2.
-    ;
-    ; If the attacker is affected by Ingrain or Aqua Ring, 50% chance of additional score +1.
-    ;
-    ; If the target is affected by Curse, ~72.7% chance of additional score +2.
-    ;
-    ; If the attacker's HP is > 70%, suppress all further modifiers. Otherwise:
-    ; - If the attacker is at exactly +0 stat stage, no further score modifiers.
-    ; - If either the attacker's HP or the target's HP are < 40%, score -2.
-    ; - Otherwise, ~72.7% chance of score -2.
+    // If the target's HP is <= 70% and the attacker's HP is NOT >= 70%, 60.9% chance of additional
+    // score -1.
+    //
+    // If the attacker is at -2 accuracy or lower, 68.75% chance of additional score -2.
+    //
+    // If the target is Badly Poisoned, ~72.7% chance of additional score +2.
+    //
+    // If the target is affected by Leech Seed, ~72.7% chance of additional score +2.
+    //
+    // If the attacker is affected by Ingrain or Aqua Ring, 50% chance of additional score +1.
+    //
+    // If the target is affected by Curse, ~72.7% chance of additional score +2.
+    //
+    // If the attacker's HP is > 70%, suppress all further modifiers. Otherwise:
+    // - If the attacker is at exactly +0 stat stage, no further score modifiers.
+    // - If either the attacker's HP or the target's HP are < 40%, score -2.
+    // - Otherwise, ~72.7% chance of score -2.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 70, Expert_StatusAccuracyDown_TryScoreMinus1
     IfHPPercentGreaterThan AI_BATTLER_DEFENDER, 70, Expert_StatusAccuracyDown_CheckUserAccuracy
 
@@ -2495,11 +2495,11 @@ Expert_StatusAccuracyDown_End:
     PopOrEnd 
 
 Expert_StatusEvasionDown:
-    ; If the attacker's HP is < 70%, 80.5% chance of additional score -2.
-    ;
-    ; Otherwise, if the target's stat stage is -3 or lower, 80.5% chance of additional score -2.
-    ;
-    ; If the target's HP is <= 70%, score -2.
+    // If the attacker's HP is < 70%, 80.5% chance of additional score -2.
+    //
+    // Otherwise, if the target's stat stage is -3 or lower, 80.5% chance of additional score -2.
+    //
+    // If the target's HP is <= 70%, score -2.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 70, Expert_StatusEvasionDown_TryScoreMinus2
     IfStatStageGreaterThan AI_BATTLER_DEFENDER, BATTLE_STAT_EVASION, 3, Expert_StatusEvasionDown_CheckTargetHP
 
@@ -2515,13 +2515,13 @@ Expert_StatusEvasionDown_End:
     PopOrEnd 
 
 Expert_Haze:
-    ; If any of the attacker's stat stages are at +3 or higher, or any of the target's stat stages
-    ; are at -3 or lower, 80.4% chance of additional score -3.
-    ;
-    ; If any of the attacker's stat stages are at -3 or lower, or any of the target's stat stages
-    ; are at +3 or higher, 80.4% chance of additional score +3.
-    ;
-    ; Otherwise, score -1.
+    // If any of the attacker's stat stages are at +3 or higher, or any of the target's stat stages
+    // are at -3 or lower, 80.4% chance of additional score -3.
+    //
+    // If any of the attacker's stat stages are at -3 or lower, or any of the target's stat stages
+    // are at +3 or higher, 80.4% chance of additional score +3.
+    //
+    // Otherwise, score -1.
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 8, Expert_Haze_TryScoreMinus3
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_DEFENSE, 8, Expert_Haze_TryScoreMinus3
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_SP_ATTACK, 8, Expert_Haze_TryScoreMinus3
@@ -2561,7 +2561,7 @@ Expert_Haze_End:
     PopOrEnd 
 
 Expert_Bide:
-    ; If the attacker's HP is <= 90%, score -2.
+    // If the attacker's HP is <= 90%, score -2.
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 90, Expert_Bide_End
     AddToMoveScore -2
 
@@ -2569,20 +2569,20 @@ Expert_Bide_End:
     PopOrEnd 
 
 Expert_ForceSwitch:
-    ; If the target has been in battle for longer than more than 3 turns, 75% chance of score +2.
-    ;
-    ; If the target's side of the field has Spikes, Stealth Rock, or Toxic Spikes set, 50% chance of
-    ; score +2.
-    ;
-    ; If the target has a stat stage of +3 or higher in any of the following stats, 50% chance of
-    ; score +2:
-    ; - Attack
-    ; - Defense
-    ; - SpAttack
-    ; - SpDefense
-    ; - Evasion
-    ;
-    ; Otherwise, score -3.
+    // If the target has been in battle for longer than more than 3 turns, 75% chance of score +2.
+    //
+    // If the target's side of the field has Spikes, Stealth Rock, or Toxic Spikes set, 50% chance of
+    // score +2.
+    //
+    // If the target has a stat stage of +3 or higher in any of the following stats, 50% chance of
+    // score +2:
+    // - Attack
+    // - Defense
+    // - SpAttack
+    // - SpDefense
+    // - Evasion
+    //
+    // Otherwise, score -3.
     LoadBattlerTurnCount AI_BATTLER_DEFENDER
     IfLoadedGreaterThan 3, Expert_ForceSwitch_75PercentScorePlus2
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_SPIKES, Expert_ForceSwitch_50PercentScorePlus2
@@ -2608,9 +2608,9 @@ Expert_ForceSwitch_End:
     PopOrEnd 
 
 Expert_Conversion:
-    ; If the attacker's HP is <= 90%, additional score -2.
-    ;
-    ; If it is NOT the first global turn of the battle, ~78.1% chance of score -2.
+    // If the attacker's HP is <= 90%, additional score -2.
+    //
+    // If it is NOT the first global turn of the battle, ~78.1% chance of score -2.
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 90, Expert_Conversion_CheckTurnCount
     AddToMoveScore -2
 
@@ -2623,8 +2623,8 @@ Expert_Conversion_End:
     PopOrEnd 
 
 Expert_Synthesis:
-    ; Treat Synthesis-type effects like any other recovery move, but additional score -2 if the
-    ; weather is Hail, Rain, or Sand.
+    // Treat Synthesis-type effects like any other recovery move, but additional score -2 if the
+    // weather is Hail, Rain, or Sand.
     LoadCurrentWeather 
     IfLoadedEqualTo AI_WEATHER_HAILING, Expert_Synthesis_ScoreMinus2
     IfLoadedEqualTo AI_WEATHER_RAINING, Expert_Synthesis_ScoreMinus2
@@ -2635,14 +2635,14 @@ Expert_Synthesis_ScoreMinus2:
     AddToMoveScore -2
 
 Expert_Recovery:
-    ; If the attacker is at full HP, score -3 and terminate.
-    ;
-    ; If the attacker is faster than its opponent, score -8 and terminate.
-    ;
-    ; If the attacker is at 70% HP or more, ~88.3% chance of score -3 and terminate.
-    ;
-    ; If the opponent does not know Snatch, ~92.2% chance of score +2.
-    ; If the opponent does know Snatch, ~56.2% chance of score +2.
+    // If the attacker is at full HP, score -3 and terminate.
+    //
+    // If the attacker is faster than its opponent, score -8 and terminate.
+    //
+    // If the attacker is at 70% HP or more, ~88.3% chance of score -3 and terminate.
+    //
+    // If the opponent does not know Snatch, ~92.2% chance of score +2.
+    // If the opponent does know Snatch, ~56.2% chance of score +2.
     IfHPPercentEqualTo AI_BATTLER_ATTACKER, 100, Expert_Recovery_ScoreMinus3AndEnd
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_Recovery_CheckHP
     AddToMoveScore -8
@@ -2675,13 +2675,13 @@ Expert_Recovery_End:
     PopOrEnd 
 
 Expert_ToxicLeechSeed:
-    ; If the attacker has at least one damaging move, apply all of the following which apply:
-    ; - If the attacker's HP <= 50%, 80.5% chance of additional score -3.
-    ; - If the defender's HP <= 50%, 80.5% chance of additional score -3.
-    ;
-    ; If the attacker knows a move that either increases its Special Defense by 1 stage or acts as
-    ; Protect, 76.6% chance of score +2. (Note: no such move exists in Vanilla that only raises
-    ; Special Defense by 1 stage.)
+    // If the attacker has at least one damaging move, apply all of the following which apply:
+    // - If the attacker's HP <= 50%, 80.5% chance of additional score -3.
+    // - If the defender's HP <= 50%, 80.5% chance of additional score -3.
+    //
+    // If the attacker knows a move that either increases its Special Defense by 1 stage or acts as
+    // Protect, 76.6% chance of score +2. (Note: no such move exists in Vanilla that only raises
+    // Special Defense by 1 stage.)
     IfAttackerHasNoDamagingMoves Expert_ToxicLeechSeed_CheckMoveEffectsKnown
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 50, Expert_ToxicLeechSeed_CheckTargetHP
     IfRandomLessThan 50, Expert_ToxicLeechSeed_CheckTargetHP
@@ -2705,11 +2705,11 @@ Expert_ToxicLeechSeed_End:
     PopOrEnd 
 
 Expert_LightScreen:
-    ; If the attacker's HP is < 50%, score -2.
-    ;
-    ; If the attacker's HP is >= 90%, 50% of additional score +1.
-    ;
-    ; If the opponent's last-used move was a Special move, 75% chance of score +1.
+    // If the attacker's HP is < 50%, score -2.
+    //
+    // If the attacker's HP is >= 90%, 50% of additional score +1.
+    //
+    // If the opponent's last-used move was a Special move, 75% chance of score +1.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 50, Expert_LightScreen_ScoreMinus2
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 90, Expert_LightScreen_CheckLastUsedMove
     IfRandomLessThan 128, Expert_LightScreen_CheckLastUsedMove
@@ -2740,18 +2740,18 @@ Expert_LightScreen_PreSplitSpecialTypes:
     TableEntry TABLE_END
 
 Expert_Rest:
-    ; If the attacker is faster than its target:
-    ; - If the attacker is at full HP, 60.9% chance of score -8 and terminate.
-    ; - If the attacker's HP is > 50%, score -3 and terminate.
-    ; - If the attacker's HP is >= 40%, 72.7% chance of score -3 and terminate.
-    ;
-    ; If the attacker is slower than its target:
-    ; - If the attacker's HP > 70%, score -3 and terminate.
-    ; - If the attacker's HP >= 60%, 80.5% chance of score -3 and terminate.
-    ;
-    ; If the opponent does not know Snatch, 96.1% chance of score +3.
-    ;
-    ; If the opponent knows Snatch, 77.3% chance of score +3.
+    // If the attacker is faster than its target:
+    // - If the attacker is at full HP, 60.9% chance of score -8 and terminate.
+    // - If the attacker's HP is > 50%, score -3 and terminate.
+    // - If the attacker's HP is >= 40%, 72.7% chance of score -3 and terminate.
+    //
+    // If the attacker is slower than its target:
+    // - If the attacker's HP > 70%, score -3 and terminate.
+    // - If the attacker's HP >= 60%, 80.5% chance of score -3 and terminate.
+    //
+    // If the opponent does not know Snatch, 96.1% chance of score +3.
+    //
+    // If the opponent knows Snatch, 77.3% chance of score +3.
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_Rest_SlowerCheckHP
     IfHPPercentNotEqualTo AI_BATTLER_ATTACKER, 100, Expert_Rest_FasterCheckHP
     AddToMoveScore -8
@@ -2787,7 +2787,7 @@ Expert_Rest_End:
     PopOrEnd 
 
 Expert_OHKOMove:
-    ; 25% chance of score +1.
+    // 25% chance of score +1.
     IfRandomLessThan 192, Expert_OHKOMove_End
     AddToMoveScore 1
 
@@ -2795,7 +2795,7 @@ Expert_OHKOMove_End:
     PopOrEnd 
 
 Expert_SuperFang:
-    ; If the target is at 50% HP or less, score -1.
+    // If the target is at 50% HP or less, score -1.
     IfHPPercentGreaterThan AI_BATTLER_DEFENDER, 50, Expert_SuperFang_End
     AddToMoveScore -1
 
@@ -2803,11 +2803,11 @@ Expert_SuperFang_End:
     PopOrEnd 
 
 Expert_BindingMove:
-    ; If the target is under any of the following conditions or effects, 50% chance of score +1:
-    ; - Toxic
-    ; - Curse
-    ; - Perish Song
-    ; - Attract
+    // If the target is under any of the following conditions or effects, 50% chance of score +1:
+    // - Toxic
+    // - Curse
+    // - Perish Song
+    // - Attract
     IfStatus AI_BATTLER_DEFENDER, MON_CONDITION_TOXIC, Expert_BindingMove_TryScorePlus1
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_CURSE, Expert_BindingMove_TryScorePlus1
     IfMoveEffect AI_BATTLER_DEFENDER, MOVE_EFFECT_PERISH_SONG, Expert_BindingMove_TryScorePlus1
@@ -2822,9 +2822,9 @@ Expert_BindingMove_End:
     PopOrEnd 
 
 Expert_HighCritical:
-    ; If the move is super-effective against the target, 50% chance of score +1.
-    ;
-    ; If the move would deal normal damage against the target, 25% chance of score +1.
+    // If the move is super-effective against the target, 50% chance of score +1.
+    //
+    // If the move would deal normal damage against the target, 25% chance of score +1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_HighCritical_End
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_HighCritical_End
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_HighCritical_End
@@ -2840,31 +2840,31 @@ Expert_HighCritical_End:
     PopOrEnd 
 
 Expert_Swagger:
-    ; If the attacker knows Psych Up:
-    ; - If the target's attack stat is -3 or higher, score -5 and terminate.
-    ; - If it is the first turn of the battle, score +5.
-    ; - Otherwise, score +3.
-    ;
-    ; Otherwise, act identically to Flatter.
+    // If the attacker knows Psych Up:
+    // - If the target's attack stat is -3 or higher, score -5 and terminate.
+    // - If it is the first turn of the battle, score +5.
+    // - Otherwise, score +3.
+    //
+    // Otherwise, act identically to Flatter.
     IfMoveKnown AI_BATTLER_ATTACKER, MOVE_PSYCH_UP, Expert_Swagger_PsychUp
 
 Expert_Flatter:
-    ; 50% chance of additional score +1.
-    ;
-    ; Otherwise, act identically to any other Confusion-inducing Status move.
+    // 50% chance of additional score +1.
+    //
+    // Otherwise, act identically to any other Confusion-inducing Status move.
     IfRandomLessThan 128, Expert_StatusConfuse
     AddToMoveScore 1
 
 Expert_StatusConfuse:
-    ; If the target's HP is <= 70%, 50% chance of additional score -1.
+    // If the target's HP is <= 70%, 50% chance of additional score -1.
     IfHPPercentGreaterThan AI_BATTLER_DEFENDER, 70, Expert_StatusConfuse_End
     IfRandomLessThan 128, Expert_StatusConfuse_CheckHP
     AddToMoveScore -1
 
 Expert_StatusConfuse_CheckHP:
-    ; If the target's HP is <= 50%, additional score -1.
-    ;
-    ; If the target's HP is also <= 30%, additional score -1.
+    // If the target's HP is <= 50%, additional score -1.
+    //
+    // If the target's HP is also <= 30%, additional score -1.
     IfHPPercentGreaterThan AI_BATTLER_DEFENDER, 50, Expert_StatusConfuse_End
     AddToMoveScore -1
     IfHPPercentGreaterThan AI_BATTLER_DEFENDER, 30, Expert_StatusConfuse_End
@@ -2888,11 +2888,11 @@ Expert_Swagger_End:
     PopOrEnd 
 
 Expert_Reflect:
-    ; If the attacker's HP is < 50%, score -2.
-    ;
-    ; If the attacker's HP is >= 90%, 50% of additional score +1.
-    ;
-    ; If the opponent's last-used move was a Physical move, 75% chance of score +1.
+    // If the attacker's HP is < 50%, score -2.
+    //
+    // If the attacker's HP is >= 90%, 50% of additional score +1.
+    //
+    // If the opponent's last-used move was a Physical move, 75% chance of score +1.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 50, Expert_Reflect_ScoreMinus2
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 90, Expert_Reflect_CheckLastUsedMove
     IfRandomLessThan 128, Expert_Reflect_CheckLastUsedMove
@@ -2924,7 +2924,7 @@ Expert_Reflect_PreSplitPhysicalTypes:
     TableEntry TABLE_END
 
 Expert_StatusPoison:
-    ; If the attacker's HP is < 50% or the defender's HP is <= 50%, score -1.
+    // If the attacker's HP is < 50% or the defender's HP is <= 50%, score -1.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 50, Expert_StatusPoison_ScoreMinus1
     IfHPPercentGreaterThan AI_BATTLER_DEFENDER, 50, Expert_StatusPoison_End
 
@@ -2935,9 +2935,9 @@ Expert_StatusPoison_End:
     PopOrEnd 
 
 Expert_StatusParalyze:
-    ; If the attacker is slower than its target, 92.2% chance of score +3.
-    ;
-    ; If the attacker's HP is <= 70%, score -1.
+    // If the attacker is slower than its target, 92.2% chance of score +3.
+    //
+    // If the attacker's HP is <= 70%, score -1.
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_StatusParalyze_TryScorePlus3
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 70, Expert_StatusParalyze_End
     AddToMoveScore -1
@@ -2951,13 +2951,13 @@ Expert_StatusParalyze_End:
     PopOrEnd 
 
 Expert_VitalThrow:
-    ; If the attacker is slower than its target, no change.
-    ;
-    ; If the attacker's HP > 60%, no change.
-    ;
-    ; If the attacker's HP < 40%, 80.5% chance of score -1.
-    ;
-    ; Otherwise, 23.9% chance of score -1.
+    // If the attacker is slower than its target, no change.
+    //
+    // If the attacker's HP > 60%, no change.
+    //
+    // If the attacker's HP < 40%, 80.5% chance of score -1.
+    //
+    // Otherwise, 23.9% chance of score -1.
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_VitalThrow_End
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 60, Expert_VitalThrow_End
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 40, Expert_VitalThrow_TryScoreMinus1
@@ -2971,23 +2971,23 @@ Expert_VitalThrow_End:
     PopOrEnd 
 
 Expert_Substitute:
-    ; If the attacker knows specifically Focus Punch, 62.5% chance of additional score +1.
-    ;
-    ; If the attacker's HP <= 90%, roll for a 60.9% chance of additional score -1 a number of times
-    ; corresponding to the attacker's HP:
-    ; - > 70%: roll once
-    ; - > 50%: roll twice
-    ; - <= 50%: roll thrice
-    ; These rolls are cumulative; e.g., an attacker at 53% HP can receive additional score -2.
-    ;
-    ; If the attacker is faster than its opponent, consider the move that the opponent last used:
-    ; - If it was a Status move that induces a non-volatile status condition and the opponent is
-    ; currently Asleep, Poisoned, Paralyzed, Burned, or Frozen, 60.9% chance of score +1.
-    ; - If it was a Status move that induces Confusion and the opponent is currently Confused, 60.9%
-    ; chance of score +1.
-    ; - If it was Leech Seed and the opponent is currently Seeded, 60.9% chance of score +1.
-    ;
-    ; Otherwise, no further score modifications.
+    // If the attacker knows specifically Focus Punch, 62.5% chance of additional score +1.
+    //
+    // If the attacker's HP <= 90%, roll for a 60.9% chance of additional score -1 a number of times
+    // corresponding to the attacker's HP:
+    // - > 70%: roll once
+    // - > 50%: roll twice
+    // - <= 50%: roll thrice
+    // These rolls are cumulative; e.g., an attacker at 53% HP can receive additional score -2.
+    //
+    // If the attacker is faster than its opponent, consider the move that the opponent last used:
+    // - If it was a Status move that induces a non-volatile status condition and the opponent is
+    // currently Asleep, Poisoned, Paralyzed, Burned, or Frozen, 60.9% chance of score +1.
+    // - If it was a Status move that induces Confusion and the opponent is currently Confused, 60.9%
+    // chance of score +1.
+    // - If it was Leech Seed and the opponent is currently Seeded, 60.9% chance of score +1.
+    //
+    // Otherwise, no further score modifications.
     IfMoveNotKnown AI_BATTLER_ATTACKER, MOVE_FOCUS_PUNCH, Expert_Substitute_CheckUserHP
     IfRandomLessThan 96, Expert_Substitute_CheckUserHP
     AddToMoveScore 1
@@ -3039,13 +3039,13 @@ Expert_Substitute_End:
     PopOrEnd 
 
 Expert_RechargeTurn:
-    ; If the opponent would resist or is immune to the move, score -1.
-    ;
-    ; If the attacker's ability is Truant, 68.75% chance of score +1.
-    ;
-    ; If the attacker is slower than the opponent and the attacker's HP is >= 60%, score -1.
-    ;
-    ; If the attacker is faster than the opponent and the attacker's HP is > 40%, score -1.
+    // If the opponent would resist or is immune to the move, score -1.
+    //
+    // If the attacker's ability is Truant, 68.75% chance of score +1.
+    //
+    // If the attacker is slower than the opponent and the attacker's HP is >= 60%, score -1.
+    //
+    // If the attacker is faster than the opponent and the attacker's HP is > 40%, score -1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_RechargeTurn_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_RechargeTurn_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_RechargeTurn_ScoreMinus1
@@ -3070,11 +3070,11 @@ Expert_RechargeTurn_End:
     PopOrEnd 
 
 Expert_Disable:
-    ; If the attacker is slower than the opponent, score +0 and terminate.
-    ;
-    ; If the opponent's last-used move was a Status move, 60.9% chance of score -1.
-    ;
-    ; If the opponent's last-used move was a Damaging move, score +1.
+    // If the attacker is slower than the opponent, score +0 and terminate.
+    //
+    // If the opponent's last-used move was a Status move, 60.9% chance of score -1.
+    //
+    // If the opponent's last-used move was a Damaging move, score +1.
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_Disable_End
     LoadBattlerPreviousMove AI_BATTLER_DEFENDER
     LoadPowerOfLoadedMove 
@@ -3090,22 +3090,22 @@ Expert_Disable_End:
     PopOrEnd 
 
 Expert_Counter:
-    ; If the opponent is asleep, confused, or infatuated, score -1 and terminate.
-    ;
-    ; If the attacker's HP <= 30%, 96.1% chance of additional score -1.
-    ;
-    ; If the attacker's HP <= 50%, 60.9% chance of additional score -1. (This stacks with the above condition.)
-    ;
-    ; If the attacker knows specifically Mirror Coat, 60.9% chance of score +4.
-    ;
-    ; If the opponent's last-used move was a Status move:
-    ; - If the opponent is Taunted, 60.9% chance of additional score +1.
-    ; - If the opponent does NOT have a type which is considered a Physical type, 49% chance of score +4.
-    ;
-    ; If the opponent's last-used move was a Damaging move:
-    ; - If the opponent is Taunted, 60.9% chance of additional score +1.
-    ; - If the last-used move was a Special move, score -1.
-    ; - If the last-used move was a Physical move, 60.9% chance of score +1.
+    // If the opponent is asleep, confused, or infatuated, score -1 and terminate.
+    //
+    // If the attacker's HP <= 30%, 96.1% chance of additional score -1.
+    //
+    // If the attacker's HP <= 50%, 60.9% chance of additional score -1. (This stacks with the above condition.)
+    //
+    // If the attacker knows specifically Mirror Coat, 60.9% chance of score +4.
+    //
+    // If the opponent's last-used move was a Status move:
+    // - If the opponent is Taunted, 60.9% chance of additional score +1.
+    // - If the opponent does NOT have a type which is considered a Physical type, 49% chance of score +4.
+    //
+    // If the opponent's last-used move was a Damaging move:
+    // - If the opponent is Taunted, 60.9% chance of additional score +1.
+    // - If the last-used move was a Special move, score -1.
+    // - If the last-used move was a Physical move, 60.9% chance of score +1.
     IfStatus AI_BATTLER_DEFENDER, MON_CONDITION_SLEEP, Expert_Counter_ScoreMinus1
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_ATTRACT, Expert_Counter_ScoreMinus1
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_CONFUSION, Expert_Counter_ScoreMinus1
@@ -3172,13 +3172,13 @@ Expert_Counter_PhysicalTypes:
     TableEntry TABLE_END
 
 Expert_Encore:
-    ; If the opponent is Disabled, 88.3% chance of score +3.
-    ;
-    ; If the attacker is slower than the opponent, score -2.
-    ;
-    ; If the opponent's last-used move is not one of a specific set of effects, score -2.
-    ;
-    ; Otherwise, 88.3% chance of score +3.
+    // If the opponent is Disabled, 88.3% chance of score +3.
+    //
+    // If the attacker is slower than the opponent, score -2.
+    //
+    // If the opponent's last-used move is not one of a specific set of effects, score -2.
+    //
+    // Otherwise, 88.3% chance of score +3.
     IfBattlerUnderEffect AI_BATTLER_DEFENDER, CHECK_DISABLE, Expert_Encore_TryScorePlus3
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_Encore_ScoreMinus2
     LoadBattlerPreviousMove AI_BATTLER_DEFENDER
@@ -3282,15 +3282,15 @@ Expert_Encore_EncouragedMoveEffects:
     TableEntry TABLE_END
 
 Expert_PainSplit:
-    ; If the opponent's HP < 80%, score -1.
-    ;
-    ; If the attacker is slower than its opponent:
-    ; - If the attacker's HP > 60%, score -1.
-    ; - Otherwise, score +1.
-    ;
-    ; If the attacker's HP > 40%, score -1.
-    ;
-    ; Otherwise, score -1.
+    // If the opponent's HP < 80%, score -1.
+    //
+    // If the attacker is slower than its opponent:
+    // - If the attacker's HP > 60%, score -1.
+    // - Otherwise, score +1.
+    //
+    // If the attacker's HP > 40%, score -1.
+    //
+    // Otherwise, score -1.
     IfHPPercentLessThan AI_BATTLER_DEFENDER, 80, Expert_PainSplit_ScoreMinus1
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_PainSplit_CheckUserHP
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 40, Expert_PainSplit_ScoreMinus1
@@ -3309,12 +3309,12 @@ Expert_PainSplit_End:
     PopOrEnd 
 
 Expert_Nightmare:
-    ; Score +2.
+    // Score +2.
     AddToMoveScore 2
     PopOrEnd 
 
 Expert_LockOn:
-    ; 50% chance of score +2.
+    // 50% chance of score +2.
     IfRandomLessThan 128, Expert_LockOn_End
     AddToMoveScore 2
 
@@ -3322,21 +3322,21 @@ Expert_LockOn_End:
     PopOrEnd 
 
 Expert_SleepTalk:
-    ; If the attacker is asleep, score +10.
-    ;
-    ; Otherwise, score -5.
+    // If the attacker is asleep, score +10.
+    //
+    // Otherwise, score -5.
     IfStatus AI_BATTLER_ATTACKER, MON_CONDITION_SLEEP, ScorePlus10
     AddToMoveScore -5
     PopOrEnd 
 
 Expert_DestinyBond:
-    ; Start at score -1. If the attacker is slower than its opponent, terminate.
-    ;
-    ; If the attacker's HP > 70%, terminate. Otherwise, 50% chance of additional score +1.
-    ;
-    ; If the attacker's HP > 50%, terminate. Otherwise, 50% chance of additional score +1.
-    ;
-    ; If the attacker's HP > 30%, terminate. Otherwise, 60.9% chance of additional score +2.
+    // Start at score -1. If the attacker is slower than its opponent, terminate.
+    //
+    // If the attacker's HP > 70%, terminate. Otherwise, 50% chance of additional score +1.
+    //
+    // If the attacker's HP > 50%, terminate. Otherwise, 50% chance of additional score +1.
+    //
+    // If the attacker's HP > 30%, terminate. Otherwise, 60.9% chance of additional score +2.
     AddToMoveScore -1
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_DestinyBond_End
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 70, Expert_DestinyBond_End
@@ -3357,16 +3357,16 @@ Expert_DestinyBond_End:
     PopOrEnd 
 
 Expert_Reversal:
-    ; If the attacker is slower than its opponent:
-    ; - If the attacker's HP > 60%, score -1.
-    ; - If the attacker's HP > 40%, score +0.
-    ; - Otherwise, 60.9% chance of score +1.
-    ;
-    ; If the attacker is faster than its opponent:
-    ; - If the attacker's HP > 33%, score -1.
-    ; - If the attacker's HP > 20%, score +0.
-    ; - If the attacker's HP >= 8%, 60.9% chance of score +1.
-    ; - If the attacker's HP < 8%, 60.9% chance of score +2, 39.1% chance of score +1.
+    // If the attacker is slower than its opponent:
+    // - If the attacker's HP > 60%, score -1.
+    // - If the attacker's HP > 40%, score +0.
+    // - Otherwise, 60.9% chance of score +1.
+    //
+    // If the attacker is faster than its opponent:
+    // - If the attacker's HP > 33%, score -1.
+    // - If the attacker's HP > 20%, score +0.
+    // - If the attacker's HP >= 8%, 60.9% chance of score +1.
+    // - If the attacker's HP < 8%, 60.9% chance of score +2, 39.1% chance of score +1.
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_Reversal_SlowerCheckHP
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 33, Expert_Reversal_ScoreMinus1
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 20, Expert_Reversal_End
@@ -3393,8 +3393,8 @@ Expert_Reversal_End:
     PopOrEnd 
 
 Expert_HealBell:
-    ; If neither the attacker nor any of its party members have a non-volatile status condition,
-    ; score -5.
+    // If neither the attacker nor any of its party members have a non-volatile status condition,
+    // score -5.
     IfStatus AI_BATTLER_ATTACKER, MON_CONDITION_ANY, Expert_HealBell_End
     IfPartyMemberStatus AI_BATTLER_ATTACKER, MON_CONDITION_ANY, Expert_HealBell_End
     AddToMoveScore -5
@@ -3403,9 +3403,9 @@ Expert_HealBell_End:
     PopOrEnd 
 
 Expert_Thief:
-    ; If the opponent's held item does NOT have one of the encouraged effects, score -2.
-    ;
-    ; Otherwise, 80.5% chance of score +1.
+    // If the opponent's held item does NOT have one of the encouraged effects, score -2.
+    //
+    // Otherwise, 80.5% chance of score +1.
     LoadHeldItemEffect AI_BATTLER_DEFENDER
     IfLoadedNotInTable Expert_Thief_EncouragedItemEffects, Expert_Thief_ScoreMinus2
     IfRandomLessThan 50, Expert_Thief_End
@@ -3447,20 +3447,20 @@ Expert_Thief_EncouragedItemEffects:
     TableEntry TABLE_END
 
 Expert_Curse:
-    ; If the attacker has a Ghost typing:
-    ; - If the attacker's HP > 80%, score +0.
-    ; - Otherwise, score -1.
-    ;
-    ; If the attacker's Defense stat stage is at +3 or higher, score +0 and terminate.
-    ;
-    ; If the attacker knows the move Gyro Ball or Trick Room, 87.5% chance of additional score +1.
-    ;
-    ; 50% chance from here-on of additional score +1.
-    ;
-    ; If the attacker's Defense stat stage is at +1 or lower, 50% chance of additional score +1.
-    ;
-    ; If the attacker's Defense stat stage is at +0 or lower, 50% chance of additional score +1.
-    ; (This is cumulative with the previous check.)
+    // If the attacker has a Ghost typing:
+    // - If the attacker's HP > 80%, score +0.
+    // - Otherwise, score -1.
+    //
+    // If the attacker's Defense stat stage is at +3 or higher, score +0 and terminate.
+    //
+    // If the attacker knows the move Gyro Ball or Trick Room, 87.5% chance of additional score +1.
+    //
+    // 50% chance from here-on of additional score +1.
+    //
+    // If the attacker's Defense stat stage is at +1 or lower, 50% chance of additional score +1.
+    //
+    // If the attacker's Defense stat stage is at +0 or lower, 50% chance of additional score +1.
+    // (This is cumulative with the previous check.)
     LoadTypeFrom LOAD_ATTACKER_TYPE_1
     IfLoadedEqualTo TYPE_GHOST, Expert_Curse_GhostCheckHP
     LoadTypeFrom LOAD_ATTACKER_TYPE_2
@@ -3497,39 +3497,39 @@ Expert_Curse_End:
     PopOrEnd 
 
 Expert_Protect:
-    ; If the opponent knows either Feint or Shadow Force, 50% chance of additional score -2.
-    ;
-    ; If the attacker has used Protect more than once already, score -2 and terminate.
-    ;
-    ; If the attacker is under any of the following effects and is also not Locked Onto by an
-    ; opponent, score -2 and terminate:
-    ; - Toxic
-    ; - Curse
-    ; - Perish Song
-    ; - Attract
-    ; - Leech Seed
-    ; - Yawn
-    ;
-    ; If the opponent knows a Recovery move (not weather-based or Rest) or Defense Curl and the
-    ; attacker is not Locked On to a target, score -2 and terminate.
-    ;
-    ; If the opponent is under any of the following effects, additional score +2:
-    ; - Toxic
-    ; - Curse
-    ; - Perish Song
-    ; - Attract
-    ; - Leech Seed
-    ; - Yawn
-    ;
-    ; Otherwise, if the battle is doubles, additional score +2.
-    ;
-    ; Otherwise, if the attacker is Locked Onto by an opponent, additional score +2.
-    ;
-    ; Otherwise, 33.2% chance of additional score +2.
-    ;
-    ; 50% of additional score -1 from here-on.
-    ;
-    ; If the attacker used Protect last turn, score -1 and 50% chance of additional score -1.
+    // If the opponent knows either Feint or Shadow Force, 50% chance of additional score -2.
+    //
+    // If the attacker has used Protect more than once already, score -2 and terminate.
+    //
+    // If the attacker is under any of the following effects and is also not Locked Onto by an
+    // opponent, score -2 and terminate:
+    // - Toxic
+    // - Curse
+    // - Perish Song
+    // - Attract
+    // - Leech Seed
+    // - Yawn
+    //
+    // If the opponent knows a Recovery move (not weather-based or Rest) or Defense Curl and the
+    // attacker is not Locked On to a target, score -2 and terminate.
+    //
+    // If the opponent is under any of the following effects, additional score +2:
+    // - Toxic
+    // - Curse
+    // - Perish Song
+    // - Attract
+    // - Leech Seed
+    // - Yawn
+    //
+    // Otherwise, if the battle is doubles, additional score +2.
+    //
+    // Otherwise, if the attacker is Locked Onto by an opponent, additional score +2.
+    //
+    // Otherwise, 33.2% chance of additional score +2.
+    //
+    // 50% of additional score -1 from here-on.
+    //
+    // If the attacker used Protect last turn, score -1 and 50% chance of additional score -1.
     IfMoveKnown AI_BATTLER_DEFENDER, MOVE_FEINT, Expert_Protect_TryScoreMinus2
     IfMoveKnown AI_BATTLER_DEFENDER, MOVE_SHADOW_FORCE, Expert_Protect_TryScoreMinus2
     GoTo Expert_Protect_CheckStatusConditions
@@ -3586,9 +3586,9 @@ Expert_Protect_End:
     PopOrEnd 
 
 Expert_Spikes:
-    ; 50% chance of score +0 and terminate. Otherwise, start at score +1.
-    ;
-    ; If the attacker knows either Roar or Whirlwind, 75% chance of additional score +1.
+    // 50% chance of score +0 and terminate. Otherwise, start at score +1.
+    //
+    // If the attacker knows either Roar or Whirlwind, 75% chance of additional score +1.
     IfRandomLessThan 128, Expert_Spikes_End
     AddToMoveScore 1
     IfMoveKnown AI_BATTLER_ATTACKER, MOVE_ROAR, Expert_Spikes_TryScorePlus1
@@ -3603,12 +3603,12 @@ Expert_Spikes_End:
     PopOrEnd 
 
 Expert_Foresight:
-    ; If the attacker has a Ghost typing, 47.3% chance of score +2.
-    ; BUG: This should instead check the opponent's typing.
-    ;
-    ; If the target's Evasion stat stage is at +3 or higher, 68.75% chance of score +2.
-    ;
-    ; Otherwise, score -2.
+    // If the attacker has a Ghost typing, 47.3% chance of score +2.
+    // BUG: This should instead check the opponent's typing.
+    //
+    // If the target's Evasion stat stage is at +3 or higher, 68.75% chance of score +2.
+    //
+    // Otherwise, score -2.
     LoadTypeFrom LOAD_ATTACKER_TYPE_1
     IfLoadedEqualTo TYPE_GHOST, Expert_Foresight_FirstRoll
     LoadTypeFrom LOAD_ATTACKER_TYPE_2
@@ -3628,9 +3628,9 @@ Expert_Foresight_End:
     PopOrEnd 
 
 Expert_Endure:
-    ; If the attacker's HP < 4%, score -1.
-    ;
-    ; If the attacker's HP < 35%, 72.7% chance of score +1.
+    // If the attacker's HP < 4%, score -1.
+    //
+    // If the attacker's HP < 35%, 72.7% chance of score +1.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 4, Expert_Endure_ScoreMinus1
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 35, Expert_Endure_TryScorePlus1
 
@@ -3646,18 +3646,18 @@ Expert_Endure_End:
     PopOrEnd 
 
 Expert_BatonPass:
-    ; If any of the attacker's stat stages are at +3 or higher, 68.75% chance of score +2 if either
-    ; of the following is true:
-    ; - The attacker is slower than its target and has HP <= 70%
-    ; - The attacker is faster than its target and has HP <= 60%
-    ; If neither are true, score +0.
-    ;
-    ; If any of the attacker's stat stages are at +2, score -2 if either of the following is true:
-    ; - The attacker is slower than its target and has HP <= 70%
-    ; - The attacker is faster than its target and has HP <= 60%
-    ; If neither are true, score +0.
-    ;
-    ; Otherwise, score -2.
+    // If any of the attacker's stat stages are at +3 or higher, 68.75% chance of score +2 if either
+    // of the following is true:
+    // - The attacker is slower than its target and has HP <= 70%
+    // - The attacker is faster than its target and has HP <= 60%
+    // If neither are true, score +0.
+    //
+    // If any of the attacker's stat stages are at +2, score -2 if either of the following is true:
+    // - The attacker is slower than its target and has HP <= 70%
+    // - The attacker is faster than its target and has HP <= 60%
+    // If neither are true, score +0.
+    //
+    // Otherwise, score -2.
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 8, Expert_BatonPass_HighStatStage_CheckSpeedAndHP
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_DEFENSE, 8, Expert_BatonPass_HighStatStage_CheckSpeedAndHP
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_SP_ATTACK, 8, Expert_BatonPass_HighStatStage_CheckSpeedAndHP
@@ -3701,12 +3701,12 @@ Expert_BatonPass_End:
     PopOrEnd 
 
 Expert_Pursuit:
-    ; If it is the attacker's first turn in battle, 50% chance of additional score +1.
-    ;
-    ; If it is NOT the attacker's first turn in battle and the opponent has a Ghost or Psychic
-    ; typing, 50% chance of additional score +1.
-    ;
-    ; If the opponent knows specifically the move U-turn, 50% chance of additional score +1.
+    // If it is the attacker's first turn in battle, 50% chance of additional score +1.
+    //
+    // If it is NOT the attacker's first turn in battle and the opponent has a Ghost or Psychic
+    // typing, 50% chance of additional score +1.
+    //
+    // If the opponent knows specifically the move U-turn, 50% chance of additional score +1.
     LoadIsFirstTurnInBattle AI_BATTLER_ATTACKER
     IfLoadedNotEqualTo FALSE, Expert_Pursuit_TryScorePlus1
     LoadTypeFrom LOAD_DEFENDER_TYPE_1
@@ -3732,15 +3732,15 @@ Expert_Pursuit_End:
     PopOrEnd 
 
 Expert_RainDance:
-    ; If the attacker is slower than its opponent and has the ability Swift Swim, score +1 and
-    ; terminate.
-    ;
-    ; If the attacker's HP < 40%, score -1.
-    ;
-    ; If the current weather is Hail, Sun, or Sandstorm, score +1.
-    ;
-    ; If the attacker has the ability Rain Dish or is statused and has the ability Hydration,
-    ; score +1.
+    // If the attacker is slower than its opponent and has the ability Swift Swim, score +1 and
+    // terminate.
+    //
+    // If the attacker's HP < 40%, score -1.
+    //
+    // If the current weather is Hail, Sun, or Sandstorm, score +1.
+    //
+    // If the attacker has the ability Rain Dish or is statused and has the ability Hydration,
+    // score +1.
     IfSpeedCompareEqualTo COMPARE_SPEED_FASTER, Expert_RainDance_OtherChecks
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_SWIFT_SWIM, Expert_RainDance_ScorePlus1
@@ -3768,14 +3768,14 @@ Expert_RainDance_End:
     PopOrEnd 
 
 Expert_SunnyDay:
-    ; If the attacker's HP < 40%, score -1.
-    ;
-    ; If the current weather is Hail, Rain, or Sandstorm, score +1.
-    ;
-    ; If the attacker has the ability Flower Gift or is statused and has the ability Leaf Guard,
-    ; score +1.
-    ; BUG: This should check instead if the attacker is NOT statused, as Leaf Guard has no
-    ; effect on existing status conditions.
+    // If the attacker's HP < 40%, score -1.
+    //
+    // If the current weather is Hail, Rain, or Sandstorm, score +1.
+    //
+    // If the attacker has the ability Flower Gift or is statused and has the ability Leaf Guard,
+    // score +1.
+    // BUG: This should check instead if the attacker is NOT statused, as Leaf Guard has no
+    // effect on existing status conditions.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 40, Expert_SunnyDay_ScoreMinus1
     LoadCurrentWeather 
     IfLoadedEqualTo AI_WEATHER_HAILING, Expert_SunnyDay_ScorePlus1
@@ -3798,7 +3798,7 @@ Expert_SunnyDay_End:
     PopOrEnd 
 
 Expert_BellyDrum:
-    ; If the attacker is at less than 90% HP, score -2.
+    // If the attacker is at less than 90% HP, score -2.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 90, Expert_BellyDrum_ScoreMinus2
     GoTo Expert_BellyDrum_End
 
@@ -3809,14 +3809,14 @@ Expert_BellyDrum_End:
     PopOrEnd 
 
 Expert_PsychUp:
-    ; If the opponent has any of Attack, Defense, SpAttack, SpDefense, or Evasion at +3 stages or
-    ; higher:
-    ; - If the attacker's Evasion stat is at +0 stages or lower, score +2.
-    ; - If the attacker has any of Attack, Defense, SpAttack, or SpDefense at +0 stages or lower,
-    ; score +1.
-    ; - Otherwise, 80.4% chance of score -2.
-    ;
-    ; Otherwise, score -2.
+    // If the opponent has any of Attack, Defense, SpAttack, SpDefense, or Evasion at +3 stages or
+    // higher:
+    // - If the attacker's Evasion stat is at +0 stages or lower, score +2.
+    // - If the attacker has any of Attack, Defense, SpAttack, or SpDefense at +0 stages or lower,
+    // score +1.
+    // - Otherwise, 80.4% chance of score -2.
+    //
+    // Otherwise, score -2.
     IfStatStageGreaterThan AI_BATTLER_DEFENDER, BATTLE_STAT_ATTACK, 8, Expert_PsychUp_CheckUserStatStages
     IfStatStageGreaterThan AI_BATTLER_DEFENDER, BATTLE_STAT_DEFENSE, 8, Expert_PsychUp_CheckUserStatStages
     IfStatStageGreaterThan AI_BATTLER_DEFENDER, BATTLE_STAT_SP_ATTACK, 8, Expert_PsychUp_CheckUserStatStages
@@ -3847,22 +3847,22 @@ Expert_PsychUp_End:
     PopOrEnd 
 
 Expert_MirrorCoat:
-    ; If the opponent is asleep, confused, or infatuated, score -1 and terminate.
-    ;
-    ; If the attacker's HP <= 30%, 96.1% chance of additional score -1.
-    ;
-    ; If the attacker's HP <= 50%, 60.9% chance of additional score -1. (This stacks with the above condition.)
-    ;
-    ; If the attacker knows specifically Counter, 60.9% chance of score +4.
-    ;
-    ; If the opponent's last-used move was a Status move:
-    ; - If the opponent is Taunted, 60.9% chance of additional score +1.
-    ; - If the opponent does NOT have a type which is considered a Special type, 49% chance of score +4.
-    ;
-    ; If the opponent's last-used move was a Damaging move:
-    ; - If the opponent is Taunted, 60.9% chance of additional score +1.
-    ; - If the last-used move was a Physical move, score -1.
-    ; - If the last-used move was a Special move, 60.9% chance of score +1.
+    // If the opponent is asleep, confused, or infatuated, score -1 and terminate.
+    //
+    // If the attacker's HP <= 30%, 96.1% chance of additional score -1.
+    //
+    // If the attacker's HP <= 50%, 60.9% chance of additional score -1. (This stacks with the above condition.)
+    //
+    // If the attacker knows specifically Counter, 60.9% chance of score +4.
+    //
+    // If the opponent's last-used move was a Status move:
+    // - If the opponent is Taunted, 60.9% chance of additional score +1.
+    // - If the opponent does NOT have a type which is considered a Special type, 49% chance of score +4.
+    //
+    // If the opponent's last-used move was a Damaging move:
+    // - If the opponent is Taunted, 60.9% chance of additional score +1.
+    // - If the last-used move was a Physical move, score -1.
+    // - If the last-used move was a Special move, 60.9% chance of score +1.
     IfStatus AI_BATTLER_DEFENDER, MON_CONDITION_SLEEP, Expert_MirrorCoat_ScoreMinus1
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_ATTRACT, Expert_MirrorCoat_ScoreMinus1
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_CONFUSION, Expert_MirrorCoat_ScoreMinus1
@@ -3928,15 +3928,15 @@ Expert_MirrorCoat_SpecialTypes:
     TableEntry TABLE_END
 
 Expert_ChargeTurnNoInvuln:
-    ; If the opponent resists or is immune to the move, score -2 and terminate.
-    ;
-    ; If the move would skip its charge turn in Sun and the current weather is Sun, score +2.
-    ;
-    ; If the attacker is holding a Power Herb, score +2.
-    ;
-    ; If the opponent knows the move Protect, score -2.
-    ;
-    ; If the attacker's HP <= 38%, score -1.
+    // If the opponent resists or is immune to the move, score -2 and terminate.
+    //
+    // If the move would skip its charge turn in Sun and the current weather is Sun, score +2.
+    //
+    // If the attacker is holding a Power Herb, score +2.
+    //
+    // If the opponent knows the move Protect, score -2.
+    //
+    // If the attacker's HP <= 38%, score -1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_ChargeTurnNoInvuln_ScoreMinus2
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_ChargeTurnNoInvuln_ScoreMinus2
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_ChargeTurnNoInvuln_ScoreMinus2
@@ -3987,30 +3987,30 @@ Expert_UnusedSolarbeam_End:
     PopOrEnd 
 
 Expert_ChargeTurnWithInvuln:
-    ; If the attacker is holding a Power Herb, score +2.
-    ;
-    ; If the opponent knows a Protect move, score -1.
-    ;
-    ; If the opponent is immune to or would resist the move, score +1. (Bug?)
-    ;
-    ; If the opponent is under any of the following conditions, score +1:
-    ; - Toxic
-    ; - Curse
-    ; - Leech Seed
-    ;
-    ; If the current weather is Sand or Hail and the attacker's type makes them immune to the
-    ; corresponding damage effect, 68.75% chance of score +1.
-    ;
-    ; If the attacker is faster than its opponent and the opponent's last-used move is not an
-    ; always-hit effect (e.g. Aerial Ace), 68.75% chance of score +1.
+    // If the attacker is holding a Power Herb, score +2.
+    //
+    // If the opponent knows a Protect move, score -1.
+    //
+    // If the opponent is immune to or would resist the move, score +1. (Bug?)
+    //
+    // If the opponent is under any of the following conditions, score +1:
+    // - Toxic
+    // - Curse
+    // - Leech Seed
+    //
+    // If the current weather is Sand or Hail and the attacker's type makes them immune to the
+    // corresponding damage effect, 68.75% chance of score +1.
+    //
+    // If the attacker is faster than its opponent and the opponent's last-used move is not an
+    // always-hit effect (e.g. Aerial Ace), 68.75% chance of score +1.
     IfHeldItemEqualTo AI_BATTLER_ATTACKER, ITEM_POWER_HERB, Expert_ChargeTurnNoInvuln_ScorePlus2
     IfMoveEffectNotKnown AI_BATTLER_DEFENDER, BATTLE_EFFECT_PROTECT, Expert_ShadowForce
     AddToMoveScore -1
     GoTo Expert_ChargeTurnWithInvuln_End
 
 Expert_ShadowForce:
-    ; Shadow Force is handled identically to ChargeTurnWithInvuln, but only gets score +1 for Power Herb
-    ; and does not consider if the opponent knows a Protect move (which it would bypass).
+    // Shadow Force is handled identically to ChargeTurnWithInvuln, but only gets score +1 for Power Herb
+    // and does not consider if the opponent knows a Protect move (which it would bypass).
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_ChargeTurnWithInvuln_ScorePlus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_ChargeTurnWithInvuln_ScorePlus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_ChargeTurnWithInvuln_ScorePlus1
@@ -4069,12 +4069,12 @@ Expert_ChargeTurnWithInvuln_SandImmuneTypes:
     TableEntry TABLE_END
 
 Expert_FakeOut:
-    ; Score +2.
+    // Score +2.
     AddToMoveScore 2
     PopOrEnd 
 
 Expert_SpitUp:
-    ; If the attacker's Stockpile count is 2 or higher, 68.75% chance of score +2.
+    // If the attacker's Stockpile count is 2 or higher, 68.75% chance of score +2.
     LoadStockpileCount AI_BATTLER_ATTACKER
     IfLoadedLessThan 2, Expert_SpitUp_End
     IfRandomLessThan 80, Expert_SpitUp_End
@@ -4084,12 +4084,12 @@ Expert_SpitUp_End:
     PopOrEnd 
 
 Expert_Hail:
-    ; If the attacker's HP < 40%, score -1 and terminate.
-    ;
-    ; If the current weather is Sun, Rain, or Sand, additional score +1. If the attacker also knows
-    ; the move Blizzard, additional score +2.
-    ;
-    ; If the attacker has the ability Ice Body, additional score +2.
+    // If the attacker's HP < 40%, score -1 and terminate.
+    //
+    // If the current weather is Sun, Rain, or Sand, additional score +1. If the attacker also knows
+    // the move Blizzard, additional score +2.
+    //
+    // If the attacker has the ability Ice Body, additional score +2.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 40, Expert_Hail_ScoreMinus1
     LoadCurrentWeather 
     IfLoadedEqualTo AI_WEATHER_SUNNY, Expert_Hail_ScorePlus1AndCheckBlizzard
@@ -4115,8 +4115,8 @@ Expert_Hail_End:
     PopOrEnd 
 
 Expert_Facade:
-    ; If the opponent has a status condition which would boost Facade, score +1.
-    ; BUG: This should instead check if the attacker has such a status condition.
+    // If the opponent has a status condition which would boost Facade, score +1.
+    // BUG: This should instead check if the attacker has such a status condition.
     IfNotStatus AI_BATTLER_DEFENDER, MON_CONDITION_FACADE_BOOST, Expert_Facade_End
     AddToMoveScore 1
 
@@ -4124,15 +4124,15 @@ Expert_Facade_End:
     PopOrEnd 
 
 Expert_FocusPunch:
-    ; If the opponent is immune to or would resist the move, score -1.
-    ;
-    ; If the attacker is behind a Substitute, score +5.
-    ;
-    ; If the opponent is asleep, score +1.
-    ;
-    ; If the opponent is confused or infatuated, 60.9% chance of score +1.
-    ;
-    ; If it is not the attacker's first turn in battle, 21.875% chance of score +1.
+    // If the opponent is immune to or would resist the move, score -1.
+    //
+    // If the attacker is behind a Substitute, score +5.
+    //
+    // If the opponent is asleep, score +1.
+    //
+    // If the opponent is confused or infatuated, 60.9% chance of score +1.
+    //
+    // If it is not the attacker's first turn in battle, 21.875% chance of score +1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_FocusPunch_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_FocusPunch_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_FocusPunch_ScoreMinus1
@@ -4160,7 +4160,7 @@ Expert_FocusPunch_End:
     PopOrEnd 
 
 Expert_SmellingSalts:
-    ; If the opponent is paralyzed, score +1.
+    // If the opponent is paralyzed, score +1.
     IfStatus AI_BATTLER_DEFENDER, MON_CONDITION_PARALYSIS, Expert_SmellingSalts_ScorePlus1
     GoTo Expert_SmellingSalts_End
 
@@ -4171,51 +4171,51 @@ Expert_SmellingSalts_End:
     PopOrEnd 
 
 Expert_Trick:
-    ; If the attacker is holding a Disruptive item:
-    ; - If the opponent is holding a bad item to trade with, score -3.
-    ; - Otherwise, score +5.
-    ;
-    ; If the attacker is holding an item that poisons its bearer:
-    ; - If the opponent is holding a bad item to trade with, score -3.
-    ; - If the opponent does not meet any of the following criteria, score +5:
-    ;   - Has a non-volatile status condition.
-    ;   - Is protected by Safeguard.
-    ;   - Has a Steel or Poison typing.
-    ;   - Has the ability Immunity, Magic Guard, or Poison Heal.
-    ; - If the attacker meets any of the following criteria, score -3:
-    ;   - Has a non-volatile status condition.
-    ;   - Is protected by Safeguard.
-    ;   - Has a Steel or Poison typing.
-    ;   - Has the ability Immunity, Magic Guard, Poison Heal, or Klutz.
-    ; - Otherwise, score +5.
-    ;
-    ; If the attacker is holding an item that burns its bearer:
-    ; - If the opponent is holding a bad item to trade with, score -3.
-    ; - If the opponent does not meet any of the following criteria, score +5:
-    ;   - Has a non-volatile status condition.
-    ;   - Is protected by Safeguard.
-    ;   - Has a Fire typing.
-    ;   - Has the ability Water Veil or Magic Guard.
-    ; - If the attacker meets any of the following criteria, score -3:
-    ;   - Has a non-volatile status condition.
-    ;   - Is protected by Safeguard.
-    ;   - Has a Fire typing.
-    ;   - Has the ability Water Veil, Magic Guard, or Klutz.
-    ; - Otherwise, score +5.
-    ;
-    ; If the attacker is holding Black Sludge:
-    ; - If the opponent is holding a bad item to trade with, score -3.
-    ; - If the opponent does not meet any of the following criteria, score +5:
-    ;   - Has a Poison typing.
-    ;   - Has the ability Magic Guard.
-    ; - If the attacker meets any of the following criteria, score -3:
-    ;   - Has a Poison typing.
-    ;   - Has the ability Magic Guard or Klutz.
-    ; - Otherwise, score +5.
-    ;
-    ; If the attacker is holding a Flavor Berry:
-    ; - If the opponent is holding a bad item to trade with or a flavor berry, score -3.
-    ; - Otherwise, 80.5% chance of score +2.
+    // If the attacker is holding a Disruptive item:
+    // - If the opponent is holding a bad item to trade with, score -3.
+    // - Otherwise, score +5.
+    //
+    // If the attacker is holding an item that poisons its bearer:
+    // - If the opponent is holding a bad item to trade with, score -3.
+    // - If the opponent does not meet any of the following criteria, score +5:
+    //   - Has a non-volatile status condition.
+    //   - Is protected by Safeguard.
+    //   - Has a Steel or Poison typing.
+    //   - Has the ability Immunity, Magic Guard, or Poison Heal.
+    // - If the attacker meets any of the following criteria, score -3:
+    //   - Has a non-volatile status condition.
+    //   - Is protected by Safeguard.
+    //   - Has a Steel or Poison typing.
+    //   - Has the ability Immunity, Magic Guard, Poison Heal, or Klutz.
+    // - Otherwise, score +5.
+    //
+    // If the attacker is holding an item that burns its bearer:
+    // - If the opponent is holding a bad item to trade with, score -3.
+    // - If the opponent does not meet any of the following criteria, score +5:
+    //   - Has a non-volatile status condition.
+    //   - Is protected by Safeguard.
+    //   - Has a Fire typing.
+    //   - Has the ability Water Veil or Magic Guard.
+    // - If the attacker meets any of the following criteria, score -3:
+    //   - Has a non-volatile status condition.
+    //   - Is protected by Safeguard.
+    //   - Has a Fire typing.
+    //   - Has the ability Water Veil, Magic Guard, or Klutz.
+    // - Otherwise, score +5.
+    //
+    // If the attacker is holding Black Sludge:
+    // - If the opponent is holding a bad item to trade with, score -3.
+    // - If the opponent does not meet any of the following criteria, score +5:
+    //   - Has a Poison typing.
+    //   - Has the ability Magic Guard.
+    // - If the attacker meets any of the following criteria, score -3:
+    //   - Has a Poison typing.
+    //   - Has the ability Magic Guard or Klutz.
+    // - Otherwise, score +5.
+    //
+    // If the attacker is holding a Flavor Berry:
+    // - If the opponent is holding a bad item to trade with or a flavor berry, score -3.
+    // - Otherwise, 80.5% chance of score +2.
     LoadHeldItemEffect AI_BATTLER_ATTACKER
     IfLoadedInTable Expert_Trick_DisruptiveItems, Expert_Trick_CheckOpponentItem
     IfLoadedInTable Expert_Trick_PoisoningItems, Expert_Trick_CheckOpponentForPoison
@@ -4338,7 +4338,7 @@ Expert_Trick_FlavorBerries:
     TableEntry TABLE_END
 
 Expert_Trick_DisruptiveItems:
-    ; BUG: This list does not include Macho Brace.
+    // BUG: This list does not include Macho Brace.
     TableEntry HOLD_EFFECT_CHOICE_ATK
     TableEntry HOLD_EFFECT_CHOICE_SPATK
     TableEntry HOLD_EFFECT_CHOICE_SPEED
@@ -4410,9 +4410,9 @@ Expert_Trick_BadOpponentItems:
     TableEntry TABLE_END
 
 Expert_ChangeUserAbility:
-    ; If the attacker has a desirable ability, score -1.
-    ;
-    ; If the opponent has a desirable ability, 80.5% chance of score +2.
+    // If the attacker has a desirable ability, score -1.
+    //
+    // If the opponent has a desirable ability, 80.5% chance of score +2.
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedInTable Expert_ChangeUserAbility_DesirableAbilities, Expert_ChangeUserAbility_ScoreMinus1
     LoadBattlerAbility AI_BATTLER_DEFENDER
@@ -4458,17 +4458,17 @@ Expert_ChangeUserAbility_DesirableAbilities:
     TableEntry TABLE_END
 
 Expert_Ingrain:
-    ; No score change.
+    // No score change.
     PopOrEnd 
 
 Expert_Superpower:
-    ; If the opponent would resist or is immune to the move, score -1.
-    ;
-    ; If the attacker's Attack stat stage is at -1 or lower, score -1.
-    ;
-    ; If the attacker is slower than its opponent and has HP >= 60%, score -1.
-    ;
-    ; If the attacker is faster than its opponent and has HP > 40%, score -1.
+    // If the opponent would resist or is immune to the move, score -1.
+    //
+    // If the attacker's Attack stat stage is at -1 or lower, score -1.
+    //
+    // If the attacker is slower than its opponent and has HP >= 60%, score -1.
+    //
+    // If the attacker is faster than its opponent and has HP > 40%, score -1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_Superpower_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_Superpower_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_Superpower_ScoreMinus1
@@ -4487,11 +4487,11 @@ Expert_Superpower_End:
     PopOrEnd 
 
 Expert_MagicCoat:
-    ; If the opponent's HP <= 30%, 60.9% chance of additional score -1.
-    ;
-    ; If it is the attacker's first turn in battle, 41.4% chance of score +1.
-    ;
-    ; If it is not the attacker's first turn in battle, 88.3% chance of score -1.
+    // If the opponent's HP <= 30%, 60.9% chance of additional score -1.
+    //
+    // If it is the attacker's first turn in battle, 41.4% chance of score +1.
+    //
+    // If it is not the attacker's first turn in battle, 88.3% chance of score -1.
     IfHPPercentGreaterThan AI_BATTLER_DEFENDER, 30, Expert_MagicCoat_CheckUserFirstTurn
     IfRandomLessThan 100, Expert_MagicCoat_CheckUserFirstTurn
     AddToMoveScore -1
@@ -4512,12 +4512,12 @@ Expert_MagicCoat_End:
     PopOrEnd 
 
 Expert_Recycle:
-    ; If the attacker's Recyclable item is *not* any of the following, score -2:
-    ; - Chesto Berry
-    ; - Lum Berry
-    ; - Starf Berry
-    ;
-    ; Otherwise, 80.5% chance of score +1.
+    // If the attacker's Recyclable item is *not* any of the following, score -2:
+    // - Chesto Berry
+    // - Lum Berry
+    // - Starf Berry
+    //
+    // Otherwise, 80.5% chance of score +1.
     LoadRecycleItem AI_BATTLER_ATTACKER
     IfLoadedNotInTable Expert_Recycle_DesirableItems, Expert_Recycle_ScoreMinus2
     IfRandomLessThan 50, Expert_Recycle_End
@@ -4537,9 +4537,9 @@ Expert_Recycle_DesirableItems:
     TableEntry TABLE_END
 
 Expert_Revenge:
-    ; If the opponent is asleep, infatuated, or confused, score -2.
-    ;
-    ; Otherwise, 70.3% chance of score -2, 29.7% chance of score +2.
+    // If the opponent is asleep, infatuated, or confused, score -2.
+    //
+    // Otherwise, 70.3% chance of score -2, 29.7% chance of score +2.
     IfStatus AI_BATTLER_DEFENDER, MON_CONDITION_SLEEP, Expert_Revenge_ScoreMinus2
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_ATTRACT, Expert_Revenge_ScoreMinus2
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_CONFUSION, Expert_Revenge_ScoreMinus2
@@ -4554,7 +4554,7 @@ Expert_Revenge_End:
     PopOrEnd 
 
 Expert_BrickBreak:
-    ; If the opponent's side of the field is under the effect of Reflect or Light Screen, score +1.
+    // If the opponent's side of the field is under the effect of Reflect or Light Screen, score +1.
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_REFLECT, Expert_BrickBreak_ScorePlus1
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_LIGHT_SCREEN, Expert_BrickBreak_ScorePlus1
     GoTo Expert_BrickBreak_End
@@ -4566,8 +4566,8 @@ Expert_BrickBreak_End:
     PopOrEnd 
 
 Expert_KnockOff:
-    ; If the opponent's HP >= 30% and it is not the attacker's first turn in battle, 29.7% chance of
-    ; score +1.
+    // If the opponent's HP >= 30% and it is not the attacker's first turn in battle, 29.7% chance of
+    // score +1.
     IfHPPercentLessThan AI_BATTLER_DEFENDER, 30, Expert_KnockOff_End
     LoadIsFirstTurnInBattle AI_BATTLER_ATTACKER
     IfLoadedGreaterThan FALSE, Expert_KnockOff_End
@@ -4578,15 +4578,15 @@ Expert_KnockOff_End:
     PopOrEnd 
 
 Expert_Endeavor:
-    ; If the opponent's HP < 70%, score -1 and terminate.
-    ;
-    ; If the attacker is slower than its opponent:
-    ; - If the attacker's HP > 50%, score -1.
-    ; - Otherwise, score +1.
-    ;
-    ; If the attacker is faster than its opponent:
-    ; - If the attacker's HP > 40%, score -1.
-    ; - Otherwise, score +1.
+    // If the opponent's HP < 70%, score -1 and terminate.
+    //
+    // If the attacker is slower than its opponent:
+    // - If the attacker's HP > 50%, score -1.
+    // - Otherwise, score +1.
+    //
+    // If the attacker is faster than its opponent:
+    // - If the attacker's HP > 40%, score -1.
+    // - Otherwise, score +1.
     IfHPPercentLessThan AI_BATTLER_DEFENDER, 70, Expert_Endeavor_ScoreMinus1
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_Endeavor_SlowerCheckHP
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 40, Expert_Endeavor_ScoreMinus1
@@ -4605,13 +4605,13 @@ Expert_Endeavor_End:
     PopOrEnd 
 
 Expert_WaterSpout:
-    ; If the opponent resists or is immune to the move, score -1.
-    ;
-    ; If the attacker is slower than its opponent and the opponent's HP <= 70%, score -1.
-    ;
-    ; If the attacker is faster than its opponent and the opponent's HP <= 50%, score -1.
-    ;
-    ; BUG: This should instead check for the user's HP.
+    // If the opponent resists or is immune to the move, score -1.
+    //
+    // If the attacker is slower than its opponent and the opponent's HP <= 70%, score -1.
+    //
+    // If the attacker is faster than its opponent and the opponent's HP <= 50%, score -1.
+    //
+    // BUG: This should instead check for the user's HP.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_WaterSpout_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_WaterSpout_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_WaterSpout_ScoreMinus1
@@ -4629,7 +4629,7 @@ Expert_WaterSpout_End:
     PopOrEnd 
 
 Expert_Imprison:
-    ; If it is not the attacker's first turn in battle, 60.9% chance of score +2.
+    // If it is not the attacker's first turn in battle, 60.9% chance of score +2.
     LoadIsFirstTurnInBattle AI_BATTLER_ATTACKER
     IfLoadedGreaterThan FALSE, Expert_Imprison_End
     IfRandomLessThan 100, Expert_Imprison_End
@@ -4639,7 +4639,7 @@ Expert_Imprison_End:
     PopOrEnd 
 
 Expert_Refresh:
-    ; If the opponent's HP < 50%, score -1.
+    // If the opponent's HP < 50%, score -1.
     IfHPPercentLessThan AI_BATTLER_DEFENDER, 50, Expert_Refresh_ScoreMinus1
     GoTo Expert_Refresh_End
 
@@ -4650,19 +4650,19 @@ Expert_Refresh_End:
     PopOrEnd 
 
 Expert_Snatch:
-    ; If it is the attacker's first turn in battle, 41.4% chance of score +2.
-    ;
-    ; 11.7% chance of score +0 and terminate.
-    ;
-    ; If the attacker is slower than its opponent:
-    ; - If the opponent's HP > 25%, 88.3% chance of score -2.
-    ; - If the opponent knows a flat-Recovery move or Defense Curl, 41.4% chance of score +2.
-    ; - Otherwise, 10.2% chance of score +1.
-    ;
-    ; If the attacker is faster than its opponent:
-    ; - If the attacker is not at full HP, 88.3% chance of score -2.
-    ; - If the opponent's HP < 70%, 88.3% chance of score -2.
-    ; - Otherwise, 67.6% chance of score -2.
+    // If it is the attacker's first turn in battle, 41.4% chance of score +2.
+    //
+    // 11.7% chance of score +0 and terminate.
+    //
+    // If the attacker is slower than its opponent:
+    // - If the opponent's HP > 25%, 88.3% chance of score -2.
+    // - If the opponent knows a flat-Recovery move or Defense Curl, 41.4% chance of score +2.
+    // - Otherwise, 10.2% chance of score +1.
+    //
+    // If the attacker is faster than its opponent:
+    // - If the attacker is not at full HP, 88.3% chance of score -2.
+    // - If the opponent's HP < 70%, 88.3% chance of score -2.
+    // - Otherwise, 67.6% chance of score -2.
     LoadIsFirstTurnInBattle AI_BATTLER_ATTACKER
     IfLoadedEqualTo TRUE, Expert_Snatch_TryScorePlus2
     IfRandomLessThan 30, Expert_Snatch_End
@@ -4696,9 +4696,9 @@ Expert_Snatch_End:
     PopOrEnd 
 
 Expert_MudSport:
-    ; If the attacker's HP < 50%, score -1.
-    ;
-    ; If the opponent has an Electric typing, score +1.
+    // If the attacker's HP < 50%, score -1.
+    //
+    // If the opponent has an Electric typing, score +1.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 50, Expert_MudSport_ScoreMinus1
     LoadTypeFrom LOAD_DEFENDER_TYPE_1
     IfLoadedEqualTo TYPE_ELECTRIC, Expert_MudSport_ScorePlus1
@@ -4717,11 +4717,11 @@ Expert_MudSport_End:
     PopOrEnd 
 
 Expert_Overheat:
-    ; If the opponent resists or is immune to the move, score -1.
-    ;
-    ; If the attacker is faster than its opponent and the attacker's HP is <= 60%, score -1.
-    ;
-    ; If the attacker is slower than its opponent and the attacker's HP is <= 80%, score -1.
+    // If the opponent resists or is immune to the move, score -1.
+    //
+    // If the attacker is faster than its opponent and the attacker's HP is <= 60%, score -1.
+    //
+    // If the attacker is slower than its opponent and the attacker's HP is <= 80%, score -1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_Overheat_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_Overheat_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_Overheat_ScoreMinus1
@@ -4739,9 +4739,9 @@ Expert_Overheat_End:
     PopOrEnd 
 
 Expert_WaterSport:
-    ; If the attacker's HP < 50%, score -1.
-    ;
-    ; If the opponent has a Fire typing, score +1.
+    // If the attacker's HP < 50%, score -1.
+    //
+    // If the opponent has a Fire typing, score +1.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 50, Expert_WaterSport_ScoreMinus1
     LoadTypeFrom LOAD_DEFENDER_TYPE_1
     IfLoadedEqualTo TYPE_FIRE, Expert_WaterSport_ScorePlus1
@@ -4760,9 +4760,9 @@ Expert_WaterSport_End:
     PopOrEnd 
 
 Expert_DragonDance:
-    ; If the attacker is slower than its opponent, 50% chance of score +1.
-    ;
-    ; If the attacker's HP <= 50%, 72.7% chance of score -1.
+    // If the attacker is slower than its opponent, 50% chance of score +1.
+    //
+    // If the attacker's HP <= 50%, 72.7% chance of score -1.
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_DragonDance_TryScorePlus1
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 50, Expert_DragonDance_End
     IfRandomLessThan 70, Expert_DragonDance_End
@@ -4777,10 +4777,10 @@ Expert_DragonDance_End:
     PopOrEnd 
 
 Expert_Gravity:
-    ; If the opponent has Levitate, is under the effect of Magnet Rise, or has a Flying typing, 75%
-    ; chance of score +1.
-    ;
-    ; If the attacker's HP >= 60%, 37.5% chance of score +1.
+    // If the opponent has Levitate, is under the effect of Magnet Rise, or has a Flying typing, 75%
+    // chance of score +1.
+    //
+    // If the attacker's HP >= 60%, 37.5% chance of score +1.
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_LEVITATE, Expert_Gravity_TryScorePlus1
     IfMoveEffect AI_BATTLER_DEFENDER, MOVE_EFFECT_MAGNET_RISE, Expert_Gravity_TryScorePlus1
@@ -4800,11 +4800,11 @@ Expert_Gravity_End:
     PopOrEnd 
 
 Expert_MiracleEye:
-    ; If the opponent has a Dark typing, 47.3% chance of score +2.
-    ;
-    ; If the opponent's Evasion stat stage is at +3 or higher, 68.75% chance of score +2.
-    ;
-    ; Otherwise, score -2.
+    // If the opponent has a Dark typing, 47.3% chance of score +2.
+    //
+    // If the opponent's Evasion stat stage is at +3 or higher, 68.75% chance of score +2.
+    //
+    // Otherwise, score -2.
     LoadTypeFrom LOAD_DEFENDER_TYPE_1
     IfLoadedEqualTo TYPE_DARK, Expert_MiracleEye_ExtraRandomGate
     LoadTypeFrom LOAD_DEFENDER_TYPE_2
@@ -4824,9 +4824,9 @@ Expert_MiracleEye_End:
     PopOrEnd 
 
 Expert_WakeUpSlap:
-    ; If the opponent resists or is immune to the move, score -1.
-    ;
-    ; If the opponent is asleep, score +1.
+    // If the opponent resists or is immune to the move, score -1.
+    //
+    // If the opponent is asleep, score +1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_WakeUpSlap_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_WakeUpSlap_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_WakeUpSlap_ScoreMinus1
@@ -4844,9 +4844,9 @@ Expert_WakeUpSlap_End:
     PopOrEnd 
 
 Expert_HammerArm:
-    ; If the opponent resists or is immune to the move, score -1.
-    ;
-    ; If the attacker is slower than its opponent, score +1.
+    // If the opponent resists or is immune to the move, score -1.
+    //
+    // If the attacker is slower than its opponent, score +1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_HammerArm_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_HammerArm_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_HammerArm_ScoreMinus1
@@ -4864,13 +4864,13 @@ Expert_HammerArm_End:
     PopOrEnd 
 
 Expert_GyroBall:
-    ; No score changes.
+    // No score changes.
     PopOrEnd 
 
 Expert_Brine:
-    ; If the opponent resists or is immune to the move, score -1.
-    ;
-    ; If the opponent's HP <= 50%, 50% chance of score +1, 50% chance of score +2.
+    // If the opponent resists or is immune to the move, score -1.
+    //
+    // If the opponent's HP <= 50%, 50% chance of score +1, 50% chance of score +2.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_Brine_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_Brine_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_Brine_ScoreMinus1
@@ -4887,24 +4887,24 @@ Expert_Brine_End:
     PopOrEnd 
 
 Expert_Feint:
-    ; If the opponent does not know Protect, 75% chance of score +0.
-    ;
-    ; If the attacker is under any of the following conditions, 50% chance of additional score +1:
-    ; - Toxic
-    ; - Curse
-    ; - Perish Song
-    ; - Attract
-    ; - Leech Seed
-    ; - Yawn
-    ;
-    ; Otherwise, if the opponent is not at maximum HP and is holding Leftovers or Black Sludge, 50%
-    ; chance of additional score +1.
-    ;
-    ; If the opponent's Protect chain is 0, 50% chance of score +1.
-    ;
-    ; If the opponent's Protect chain is 1, 25% chance of score +1.
-    ;
-    ; Otherwise, score -2.
+    // If the opponent does not know Protect, 75% chance of score +0.
+    //
+    // If the attacker is under any of the following conditions, 50% chance of additional score +1:
+    // - Toxic
+    // - Curse
+    // - Perish Song
+    // - Attract
+    // - Leech Seed
+    // - Yawn
+    //
+    // Otherwise, if the opponent is not at maximum HP and is holding Leftovers or Black Sludge, 50%
+    // chance of additional score +1.
+    //
+    // If the opponent's Protect chain is 0, 50% chance of score +1.
+    //
+    // If the opponent's Protect chain is 1, 25% chance of score +1.
+    //
+    // Otherwise, score -2.
     IfMoveEffectKnown AI_BATTLER_DEFENDER, BATTLE_EFFECT_PROTECT, Expert_Feint_CheckConditions
     IfRandomLessThan 64, Expert_Feint_CheckConditions
     GoTo Expert_Feint_End
@@ -4952,11 +4952,11 @@ Expert_Feint_GradualRecoveryItems:
     TableEntry TABLE_END
 
 Expert_Pluck:
-    ; If the opponent resists or is immune to the move, score -1.
-    ;
-    ; If it is the attacker's first turn in battle, 75% chance of additional score +1.
-    ;
-    ; 50% chance of score +1.
+    // If the opponent resists or is immune to the move, score -1.
+    //
+    // If it is the attacker's first turn in battle, 75% chance of additional score +1.
+    //
+    // 50% chance of score +1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_Pluck_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_Pluck_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_Pluck_ScoreMinus1
@@ -4977,15 +4977,15 @@ Expert_Pluck_End:
     PopOrEnd 
 
 Expert_Tailwind:
-    ; 25% chance of flat score +0.
-    ;
-    ; If the attacker is faster than its opponent, score -1.
-    ;
-    ; If the attacker's HP <= 30%, score -1.
-    ;
-    ; If the attacker's HP > 75%, score +1.
-    ;
-    ; Otherwise, 75% chance of score +1.
+    // 25% chance of flat score +0.
+    //
+    // If the attacker is faster than its opponent, score -1.
+    //
+    // If the attacker's HP <= 30%, score -1.
+    //
+    // If the attacker's HP > 75%, score +1.
+    //
+    // Otherwise, 75% chance of score +1.
     IfRandomLessThan 64, Expert_Tailwind_End
     IfSpeedCompareEqualTo COMPARE_SPEED_FASTER, Expert_Tailwind_ScoreMinus1
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 31, Expert_Tailwind_ScoreMinus1
@@ -5003,11 +5003,11 @@ Expert_Tailwind_End:
     PopOrEnd 
 
 Expert_Acupressure:
-    ; If the attacker's HP <= 50%, score -1.
-    ;
-    ; If the attacker's HP > 90%, 75% chance of score +1.
-    ;
-    ; Otherwise, 37.5% chance of score +1.
+    // If the attacker's HP <= 50%, score -1.
+    //
+    // If the attacker's HP > 90%, 75% chance of score +1.
+    //
+    // Otherwise, 37.5% chance of score +1.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 51, Expert_Acupressure_ScoreMinus1
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 90, Expert_Acupressure_TryScorePlus1
     IfRandomLessThan 128, Expert_Acupressure_End
@@ -5024,22 +5024,22 @@ Expert_Acupressure_End:
     PopOrEnd 
 
 Expert_MetalBurst:
-    ; If the opponent is asleep, infatuated, or confused or they know any of the following move
-    ; effects, score -1 and terminate:
-    ; - Avalanche / Revenge
-    ; - Focus Punch
-    ; - Vital Throw
-    ;
-    ; If the attacker's HP <= 30%, 96% chance of additional score -1.
-    ;
-    ; If the attacker's HP <= 50%, 60.9% chance of additional score -1.
-    ;
-    ; If the attacker's HP > 50%, 25% chance of additional score +1.
-    ;
-    ; If the opponent's last-used move was not a Status move and they are not Taunted, 60.9% chance
-    ; of additional score +1.
-    ;
-    ; If the opponent is not Taunted, 60.9% chance of score +1.
+    // If the opponent is asleep, infatuated, or confused or they know any of the following move
+    // effects, score -1 and terminate:
+    // - Avalanche / Revenge
+    // - Focus Punch
+    // - Vital Throw
+    //
+    // If the attacker's HP <= 30%, 96% chance of additional score -1.
+    //
+    // If the attacker's HP <= 50%, 60.9% chance of additional score -1.
+    //
+    // If the attacker's HP > 50%, 25% chance of additional score +1.
+    //
+    // If the opponent's last-used move was not a Status move and they are not Taunted, 60.9% chance
+    // of additional score +1.
+    //
+    // If the opponent is not Taunted, 60.9% chance of score +1.
     IfStatus AI_BATTLER_DEFENDER, MON_CONDITION_SLEEP, Expert_MetalBurst_ScoreMinus1
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_ATTRACT, Expert_MetalBurst_ScoreMinus1
     IfVolatileStatus AI_BATTLER_DEFENDER, VOLATILE_CONDITION_CONFUSION, Expert_MetalBurst_ScoreMinus1
@@ -5080,21 +5080,21 @@ Expert_MetalBurst_End:
     PopOrEnd 
 
 Expert_UTurn:
-    ; If the opponent resists or is immune to the move, score -1 and terminate.
-    ;
-    ; If the attacker is the last living party member, score +2 and terminate.
-    ;
-    ; If the attacker has a super-effective move on its opponent, 75% chance of additional score -2.
-    ;
-    ; If no party member deals more damage than the attacker, 75% chance of score -2 and terminate.
-    ;
-    ; If the opponent's HP > 70%, 75% chance of additional score +1.
-    ;
-    ; If the opponent's HP > 30%, 50% chance of additional score +1. (Cumulative with the prior check)
-    ;
-    ; Otherwise, 25% chance of additional score +1.
-    ;
-    ; If the attacker is faster than its opponent, score +1. Otherwise, 50% chance of score +1.
+    // If the opponent resists or is immune to the move, score -1 and terminate.
+    //
+    // If the attacker is the last living party member, score +2 and terminate.
+    //
+    // If the attacker has a super-effective move on its opponent, 75% chance of additional score -2.
+    //
+    // If no party member deals more damage than the attacker, 75% chance of score -2 and terminate.
+    //
+    // If the opponent's HP > 70%, 75% chance of additional score +1.
+    //
+    // If the opponent's HP > 30%, 50% chance of additional score +1. (Cumulative with the prior check)
+    //
+    // Otherwise, 25% chance of additional score +1.
+    //
+    // If the attacker is faster than its opponent, score +1. Otherwise, 50% chance of score +1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_UTurn_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_UTurn_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_UTurn_ScoreMinus1
@@ -5142,11 +5142,11 @@ Expert_UTurn_End:
     PopOrEnd 
 
 Expert_CloseCombat:
-    ; If the opponent resists or is immune to the move, score -1.
-    ;
-    ; If the attacker is slower than its opponent and its HP <= 80%, score -1.
-    ;
-    ; If the attacker is faster than its opponent and its HP <= 60%, score -1.
+    // If the opponent resists or is immune to the move, score -1.
+    //
+    // If the attacker is slower than its opponent and its HP <= 80%, score -1.
+    //
+    // If the attacker is faster than its opponent and its HP <= 60%, score -1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_CloseCombat_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_CloseCombat_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_CloseCombat_ScoreMinus1
@@ -5164,10 +5164,10 @@ Expert_CloseCombat_End:
     PopOrEnd 
 
 Expert_Payback:
-    ; If the opponent resists or is immune to the move, score -1.
-    ;
-    ; If the attacker is slower than its opponent and the attacker's HP >= 30%, 75% chance of
-    ; score +1.
+    // If the opponent resists or is immune to the move, score -1.
+    //
+    // If the attacker is slower than its opponent and the attacker's HP >= 30%, 75% chance of
+    // score +1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_Payback_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_Payback_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_Payback_ScoreMinus1
@@ -5184,12 +5184,12 @@ Expert_Payback_End:
     PopOrEnd 
 
 Expert_Assurance:
-    ; If the opponent resists or is immune to the move, score -1.
-    ;
-    ; If the attacker is slower than its opponent:
-    ; - If the attacker's ability is Rough Skin, 50% chance of score +1.
-    ; - If the attacker is holding a Jaboca Berry or Rowap Berry, 50% chance of score +1.
-    ; - Otherwise, 25% chance of score +1.
+    // If the opponent resists or is immune to the move, score -1.
+    //
+    // If the attacker is slower than its opponent:
+    // - If the attacker's ability is Rough Skin, 50% chance of score +1.
+    // - If the attacker is holding a Jaboca Berry or Rowap Berry, 50% chance of score +1.
+    // - Otherwise, 25% chance of score +1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_Assurance_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_Assurance_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_Assurance_ScoreMinus1
@@ -5218,7 +5218,7 @@ Expert_Assurance_RecoilBerries:
     TableEntry TABLE_END
 
 Expert_Embargo:
-    ; 50% chance of score +1.
+    // 50% chance of score +1.
     IfRandomLessThan 128, Expert_Embargo_End
     AddToMoveScore 1
 
@@ -5226,24 +5226,24 @@ Expert_Embargo_End:
     PopOrEnd 
 
 Expert_Fling:
-    ; If the opponent resists or is immune to the move and the attacker is holding an item other than
-    ; any of the following, score -1:
-    ; - King's Rock
-    ; - Razor Fang
-    ; - Poison Barb
-    ; - Toxic Orb
-    ; - Flame Orb
-    ; - Light Ball
-    ;
-    ; If the attacker's item would grant Fling < 30 base power, score -2.
-    ;
-    ; If the attacker's item would grant Fling > 90 base power, 75% chance of score +1, and:
-    ; - If the opponent is weak to the move, additional score +4.
-    ; - Otherwise, 50% chance of additional score +1.
-    ;
-    ; If the attacker's item would grant Fling > 60 base power, 75% chance of score +1.
-    ;
-    ; Otherwise, 50% chance of score -1.
+    // If the opponent resists or is immune to the move and the attacker is holding an item other than
+    // any of the following, score -1:
+    // - King's Rock
+    // - Razor Fang
+    // - Poison Barb
+    // - Toxic Orb
+    // - Flame Orb
+    // - Light Ball
+    //
+    // If the attacker's item would grant Fling < 30 base power, score -2.
+    //
+    // If the attacker's item would grant Fling > 90 base power, 75% chance of score +1, and:
+    // - If the opponent is weak to the move, additional score +4.
+    // - Otherwise, 50% chance of additional score +1.
+    //
+    // If the attacker's item would grant Fling > 60 base power, 75% chance of score +1.
+    //
+    // Otherwise, 50% chance of score -1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_Fling_CheckAttackerItem
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_Fling_CheckAttackerItem
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_Fling_CheckAttackerItem
@@ -5291,9 +5291,9 @@ Expert_Fling_DesirableFlingEffects:
     TableEntry TABLE_END
 
 Expert_PsychoShift:
-    ; If the attacker does not have any status condition, score -10.
-    ;
-    ; If the opponent's HP >= 30%, 50% chance of score +1.
+    // If the attacker does not have any status condition, score -10.
+    //
+    // If the opponent's HP >= 30%, 50% chance of score +1.
     IfNotStatus AI_BATTLER_ATTACKER, MON_CONDITION_ANY, ScoreMinus10
     IfRandomLessThan 128, Expert_PsychoShift_End
     IfHPPercentLessThan AI_BATTLER_DEFENDER, 30, Expert_PsychoShift_End
@@ -5303,21 +5303,21 @@ Expert_PsychoShift_End:
     PopOrEnd 
 
 Expert_TrumpCard:
-    ; If the opponent resists or is immune to the move, score -1.
-    ;
-    ; If the move has 1 PP remaining, score +3.
-    ;
-    ; If the move has 2 PP remaining, 60.9% chance of score +2, 39.1% chance of score +1.
-    ;
-    ; If the move has 3 PP remaining, 60.9% chance of score +1.
-    ;
-    ; If the opponent's ability is Pressure, 88.3% chance of additional score +1.
-    ;
-    ; If the opponent's Evasion stat stage is +5 or higher or the attacker's Accuracy stat stage is
-    ; -5 or lower, 60.9% chance of score +2, 39.1% chance of score +1.
-    ;
-    ; If the opponent's Evasion stat stage is +3 or higher or the attacker's Accuracy stat stage is
-    ; -3 or lower, 60.9% chance of score +1.
+    // If the opponent resists or is immune to the move, score -1.
+    //
+    // If the move has 1 PP remaining, score +3.
+    //
+    // If the move has 2 PP remaining, 60.9% chance of score +2, 39.1% chance of score +1.
+    //
+    // If the move has 3 PP remaining, 60.9% chance of score +1.
+    //
+    // If the opponent's ability is Pressure, 88.3% chance of additional score +1.
+    //
+    // If the opponent's Evasion stat stage is +5 or higher or the attacker's Accuracy stat stage is
+    // -5 or lower, 60.9% chance of score +2, 39.1% chance of score +1.
+    //
+    // If the opponent's Evasion stat stage is +3 or higher or the attacker's Accuracy stat stage is
+    // -3 or lower, 60.9% chance of score +1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_TrumpCard_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_TrumpCard_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_TrumpCard_ScoreMinus1
@@ -5356,23 +5356,23 @@ Expert_TrumpCard_End:
     PopOrEnd 
 
 Expert_HealBlock:
-    ; If the opponent knows a move with any of the following effects, 90.2% chance of score +1:
-    ; - Dream Eater
-    ; - Restore half HP
-    ; - Roost
-    ; - Sun-boosted recovery
-    ; - Rest
-    ; - Swallow
-    ; - Draining moves
-    ; - Ingrain
-    ; - Aqua Ring
-    ; - Leech Seed
-    ; - Lunar Dance, Healing Wish
-    ;
-    ; If the attacker is under the effect of Leech Seed or the opponent is under the effect of Ingrain
-    ; or Aqua Ring, 90.2% chance of score +1.
-    ;
-    ; Otherwise, 56.4% chance of score +1.
+    // If the opponent knows a move with any of the following effects, 90.2% chance of score +1:
+    // - Dream Eater
+    // - Restore half HP
+    // - Roost
+    // - Sun-boosted recovery
+    // - Rest
+    // - Swallow
+    // - Draining moves
+    // - Ingrain
+    // - Aqua Ring
+    // - Leech Seed
+    // - Lunar Dance, Healing Wish
+    //
+    // If the attacker is under the effect of Leech Seed or the opponent is under the effect of Ingrain
+    // or Aqua Ring, 90.2% chance of score +1.
+    //
+    // Otherwise, 56.4% chance of score +1.
     IfMoveEffectKnown AI_BATTLER_DEFENDER, BATTLE_EFFECT_RECOVER_DAMAGE_SLEEP, Expert_HealBlock_TryScorePlus1
     IfMoveEffectKnown AI_BATTLER_DEFENDER, BATTLE_EFFECT_RESTORE_HALF_HP, Expert_HealBlock_TryScorePlus1
     IfMoveEffectKnown AI_BATTLER_DEFENDER, BATTLE_EFFECT_HEAL_HALF_REMOVE_FLYING_TYPE, Expert_HealBlock_TryScorePlus1
@@ -5400,16 +5400,16 @@ Expert_HealBlock_End:
     PopOrEnd 
 
 Expert_WringOut:
-    ; If the opponent resists or is immune to the move, score -1.
-    ;
-    ; If the opponent's HP < 50%, score -1.
-    ;
-    ; If the opponent is at full HP:
-    ; - Start with 90.2% chance of score +1.
-    ; - If the attacker is faster than its opponent, additional score +2.
-    ; - If the attacker is slower than its opponent, additional score +1.
-    ;
-    ; If the opponent's HP > 85%, 90.2% chance of score +1.
+    // If the opponent resists or is immune to the move, score -1.
+    //
+    // If the opponent's HP < 50%, score -1.
+    //
+    // If the opponent is at full HP:
+    // - Start with 90.2% chance of score +1.
+    // - If the attacker is faster than its opponent, additional score +2.
+    // - If the attacker is slower than its opponent, additional score +1.
+    //
+    // If the opponent's HP > 85%, 90.2% chance of score +1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_WringOut_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_WringOut_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_WringOut_ScoreMinus1
@@ -5437,11 +5437,11 @@ Expert_WringOut_End:
     PopOrEnd 
 
 Expert_PowerTrick:
-    ; If the attacker's HP > 90%, 62.5% chance of score +1.
-    ;
-    ; If the attacker's HP > 60%, 50% chance of score +1.
-    ;
-    ; If the attacker's HP > 30%, 35.9% chance of score +1.
+    // If the attacker's HP > 90%, 62.5% chance of score +1.
+    //
+    // If the attacker's HP > 60%, 50% chance of score +1.
+    //
+    // If the attacker's HP > 30%, 35.9% chance of score +1.
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 90, Expert_PowerTrick_LikelyScorePlus1
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 60, Expert_PowerTrick_CoinFlipScorePlus1
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 30, Expert_PowerTrick_UnlikelyScorePlus1
@@ -5466,15 +5466,15 @@ Expert_PowerTrick_End:
     PopOrEnd 
 
 Expert_GastroAcid:
-    ; 25% chance of score +0 and terminate.
-    ;
-    ; If the opponent's HP > 70%, score +1.
-    ;
-    ; If the opponent's HP <= 70%, 50% chance of score +0, 50% chance of score -1.
-    ;
-    ; If the opponent's HP <= 50%, 50% chance of score -1, 50% chance of score -2.
-    ;
-    ; If the opponent's HP <= 30%, 50% chance of score -2, 50% chance of score -3.
+    // 25% chance of score +0 and terminate.
+    //
+    // If the opponent's HP > 70%, score +1.
+    //
+    // If the opponent's HP <= 70%, 50% chance of score +0, 50% chance of score -1.
+    //
+    // If the opponent's HP <= 50%, 50% chance of score -1, 50% chance of score -2.
+    //
+    // If the opponent's HP <= 30%, 50% chance of score -2, 50% chance of score -3.
     IfRandomLessThan 64, Expert_GastroAcid_End
     AddToMoveScore 1
     IfHPPercentGreaterThan AI_BATTLER_DEFENDER, 70, Expert_GastroAcid_End
@@ -5491,11 +5491,11 @@ Expert_GastroAcid_End:
     PopOrEnd 
 
 Expert_LuckyChant:
-    ; If the attacker's HP < 70%, score -1.
-    ;
-    ; If the opponent knows a move with a high critical-hit ratio, score +1.
-    ;
-    ; Otherwise, 25% chance of score +1.
+    // If the attacker's HP < 70%, score -1.
+    //
+    // If the opponent knows a move with a high critical-hit ratio, score +1.
+    //
+    // Otherwise, 25% chance of score +1.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 70, Expert_LuckyChant_ScoreMinus1
     IfMoveEffectKnown AI_BATTLER_DEFENDER, BATTLE_EFFECT_HIGH_CRITICAL, Expert_LuckyChant_ScorePlus1
     IfMoveEffectKnown AI_BATTLER_DEFENDER, BATTLE_EFFECT_HIGH_CRITICAL_BURN_HIT, Expert_LuckyChant_ScorePlus1
@@ -5514,13 +5514,13 @@ Expert_LuckyChant_End:
     PopOrEnd 
 
 Expert_MeFirst:
-    ; If the attacker is slower than its opponent, score -2.
-    ;
-    ; If the attacker deals more damage than its opponent, 87.5% chance of additional score +1.
-    ;
-    ; If the opponent's last-used move was a Damaging move, 50% chance of additional score +1.
-    ;
-    ; 75% chance of score +1.
+    // If the attacker is slower than its opponent, score -2.
+    //
+    // If the attacker deals more damage than its opponent, 87.5% chance of additional score +1.
+    //
+    // If the opponent's last-used move was a Damaging move, 50% chance of additional score +1.
+    //
+    // 75% chance of score +1.
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_MeFirst_ScoreMinus2
     IfBattlerDealsMoreDamage AI_BATTLER_DEFENDER, USE_MAX_DAMAGE, Expert_MeFirst_TryScorePlus1
     GoTo Expert_MeFirst_CheckLastUsedMove
@@ -5547,12 +5547,12 @@ Expert_MeFirst_End:
     PopOrEnd 
 
 Expert_Copycat:
-    ; If the attacker is slower than its opponent, deals less damage than its opponent, and the
-    ; opponent's last-used move is not an encouraged move, 68.75% chance of score -1.
-    ;
-    ; If the attacker is faster than its opponent:
-    ; - If the attacker deals more damage than its opponent, 87.5% chance of score +2.
-    ; - If the opponent's last-used move is an encouraged move, 50% chance of score +2.
+    // If the attacker is slower than its opponent, deals less damage than its opponent, and the
+    // opponent's last-used move is not an encouraged move, 68.75% chance of score -1.
+    //
+    // If the attacker is faster than its opponent:
+    // - If the attacker deals more damage than its opponent, 87.5% chance of score +2.
+    // - If the opponent's last-used move is an encouraged move, 50% chance of score +2.
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_Copycat_CheckMoveEncouraged
     IfBattlerDealsMoreDamage AI_BATTLER_DEFENDER, USE_MAX_DAMAGE, Expert_Copycat_TryScorePlus2
     LoadBattlerPreviousMove AI_BATTLER_DEFENDER
@@ -5627,76 +5627,76 @@ Expert_Copycat_EncouragedMoves:
     TableEntry TABLE_END
 
 Expert_PowerSwap:
-    ; Find the difference in stat stages between the attacker and its opponent for the Attack stat.
-    ;
-    ; If the difference is > 3:
-    ; - If the difference in SpAttack stages > 3:
-    ;   - 50% chance of score +5.
-    ;   - 25% chance of score +4.
-    ;   - 12.5% chance of score +3.
-    ;   - 6.25% chance of score +2.
-    ;   - 3.125% chance of score +1.
-    ;   - 3.125% chance of score +0.
-    ; - If the difference in SpAttack stages > 1:
-    ;   - 50% chance of score +4.
-    ;   - 25% chance of score +3.
-    ;   - 12.5% chance of score +2.
-    ;   - 6.25% chance of score +1.
-    ;   - 6.25% chance of score +0.
-    ; - If the difference in SpAttack stages = 0:
-    ;   - 50% chance of score +3.
-    ;   - 25% chance of score +2.
-    ;   - 12.5% chance of score +1.
-    ;   - 12.5% chance of score +0.
-    ; - Otherwise, no score change.
-    ;
-    ; If the difference is > 1:
-    ; - If the difference in SpAttack stages > 3:
-    ;   - 50% chance of score +4.
-    ;   - 25% chance of score +3.
-    ;   - 12.5% chance of score +2.
-    ;   - 6.25% chance of score +1.
-    ;   - 6.25% chance of score +0.
-    ; - If the difference in SpAttack stages > 1:
-    ;   - 50% chance of score +3.
-    ;   - 25% chance of score +2.
-    ;   - 12.5% chance of score +1.
-    ;   - 12.5% chance of score +0.
-    ; - If the difference in SpAttack stages = 0:
-    ;   - 50% chance of score +2.
-    ;   - 25% chance of score +1.
-    ;   - 25% chance of score +0.
-    ; - Otherwise, no score change.
-    ;
-    ; If the difference is > 0:
-    ; - If the difference in SpAttack stages > 3:
-    ;   - 50% chance of score +3.
-    ;   - 25% chance of score +2.
-    ;   - 12.5% chance of score +1.
-    ;   - 12.5% chance of score +0.
-    ; - If the difference in SpAttack stages > 1:
-    ;   - 50% chance of score +2.
-    ;   - 25% chance of score +1.
-    ;   - 25% chance of score +0.
-    ; - If the difference in SpAttack stages = 0:
-    ;   - 50% chance of score +1.
-    ;   - 50% chance of score +0.
-    ; - Otherwise, no score change.
-    ;
-    ; If the difference = 0:
-    ; - If the difference in SpAttack stages > 3:
-    ;   - 50% chance of score +3.
-    ;   - 25% chance of score +2.
-    ;   - 12.5% chance of score +1.
-    ;   - 12.5% chance of score +0.
-    ; - If the difference in SpAttack stages > 1:
-    ;   - 50% chance of score +2.
-    ;   - 25% chance of score +1.
-    ;   - 25% chance of score +0.
-    ; - If the difference in SpAttack stages > 0:
-    ;   - 50% chance of score +1.
-    ;   - 50% chance of score +0.
-    ; - Otherwise, no score change.
+    // Find the difference in stat stages between the attacker and its opponent for the Attack stat.
+    //
+    // If the difference is > 3:
+    // - If the difference in SpAttack stages > 3:
+    //   - 50% chance of score +5.
+    //   - 25% chance of score +4.
+    //   - 12.5% chance of score +3.
+    //   - 6.25% chance of score +2.
+    //   - 3.125% chance of score +1.
+    //   - 3.125% chance of score +0.
+    // - If the difference in SpAttack stages > 1:
+    //   - 50% chance of score +4.
+    //   - 25% chance of score +3.
+    //   - 12.5% chance of score +2.
+    //   - 6.25% chance of score +1.
+    //   - 6.25% chance of score +0.
+    // - If the difference in SpAttack stages = 0:
+    //   - 50% chance of score +3.
+    //   - 25% chance of score +2.
+    //   - 12.5% chance of score +1.
+    //   - 12.5% chance of score +0.
+    // - Otherwise, no score change.
+    //
+    // If the difference is > 1:
+    // - If the difference in SpAttack stages > 3:
+    //   - 50% chance of score +4.
+    //   - 25% chance of score +3.
+    //   - 12.5% chance of score +2.
+    //   - 6.25% chance of score +1.
+    //   - 6.25% chance of score +0.
+    // - If the difference in SpAttack stages > 1:
+    //   - 50% chance of score +3.
+    //   - 25% chance of score +2.
+    //   - 12.5% chance of score +1.
+    //   - 12.5% chance of score +0.
+    // - If the difference in SpAttack stages = 0:
+    //   - 50% chance of score +2.
+    //   - 25% chance of score +1.
+    //   - 25% chance of score +0.
+    // - Otherwise, no score change.
+    //
+    // If the difference is > 0:
+    // - If the difference in SpAttack stages > 3:
+    //   - 50% chance of score +3.
+    //   - 25% chance of score +2.
+    //   - 12.5% chance of score +1.
+    //   - 12.5% chance of score +0.
+    // - If the difference in SpAttack stages > 1:
+    //   - 50% chance of score +2.
+    //   - 25% chance of score +1.
+    //   - 25% chance of score +0.
+    // - If the difference in SpAttack stages = 0:
+    //   - 50% chance of score +1.
+    //   - 50% chance of score +0.
+    // - Otherwise, no score change.
+    //
+    // If the difference = 0:
+    // - If the difference in SpAttack stages > 3:
+    //   - 50% chance of score +3.
+    //   - 25% chance of score +2.
+    //   - 12.5% chance of score +1.
+    //   - 12.5% chance of score +0.
+    // - If the difference in SpAttack stages > 1:
+    //   - 50% chance of score +2.
+    //   - 25% chance of score +1.
+    //   - 25% chance of score +0.
+    // - If the difference in SpAttack stages > 0:
+    //   - 50% chance of score +1.
+    //   - 50% chance of score +0.
+    // - Otherwise, no score change.
     DiffStatStages AI_BATTLER_DEFENDER, BATTLE_STAT_ATTACK
     IfLoadedGreaterThan 3, Expert_PowerSwap_CheckSpAttack_HighDiff
     IfLoadedGreaterThan 1, Expert_PowerSwap_CheckSpAttack_MediumDiff
@@ -5761,76 +5761,76 @@ Expert_PowerSwap_CheckSpAttack_End:
     PopOrEnd 
 
 Expert_GuardSwap:
-    ; Find the difference in stat stages between the attacker and its opponent for the Defense stat.
-    ;
-    ; If the difference is > 3:
-    ; - If the difference in SpDefense stages > 3:
-    ;   - 50% chance of score +5.
-    ;   - 25% chance of score +4.
-    ;   - 12.5% chance of score +3.
-    ;   - 6.25% chance of score +2.
-    ;   - 3.125% chance of score +1.
-    ;   - 3.125% chance of score +0.
-    ; - If the difference in SpDefense stages > 1:
-    ;   - 50% chance of score +4.
-    ;   - 25% chance of score +3.
-    ;   - 12.5% chance of score +2.
-    ;   - 6.25% chance of score +1.
-    ;   - 6.25% chance of score +0.
-    ; - If the difference in SpDefense stages = 0:
-    ;   - 50% chance of score +3.
-    ;   - 25% chance of score +2.
-    ;   - 12.5% chance of score +1.
-    ;   - 12.5% chance of score +0.
-    ; - Otherwise, no score change.
-    ;
-    ; If the difference is > 1:
-    ; - If the difference in SpDefense stages > 3:
-    ;   - 50% chance of score +4.
-    ;   - 25% chance of score +3.
-    ;   - 12.5% chance of score +2.
-    ;   - 6.25% chance of score +1.
-    ;   - 6.25% chance of score +0.
-    ; - If the difference in SpDefense stages > 1:
-    ;   - 50% chance of score +3.
-    ;   - 25% chance of score +2.
-    ;   - 12.5% chance of score +1.
-    ;   - 12.5% chance of score +0.
-    ; - If the difference in SpDefense stages = 0:
-    ;   - 50% chance of score +2.
-    ;   - 25% chance of score +1.
-    ;   - 25% chance of score +0.
-    ; - Otherwise, no score change.
-    ;
-    ; If the difference is > 0:
-    ; - If the difference in SpDefense stages > 3:
-    ;   - 50% chance of score +3.
-    ;   - 25% chance of score +2.
-    ;   - 12.5% chance of score +1.
-    ;   - 12.5% chance of score +0.
-    ; - If the difference in SpDefense stages > 1:
-    ;   - 50% chance of score +2.
-    ;   - 25% chance of score +1.
-    ;   - 25% chance of score +0.
-    ; - If the difference in SpDefense stages = 0:
-    ;   - 50% chance of score +1.
-    ;   - 50% chance of score +0.
-    ; - Otherwise, no score change.
-    ;
-    ; If the difference = 0:
-    ; - If the difference in SpDefense stages > 3:
-    ;   - 50% chance of score +3.
-    ;   - 25% chance of score +2.
-    ;   - 12.5% chance of score +1.
-    ;   - 12.5% chance of score +0.
-    ; - If the difference in SpDefense stages > 1:
-    ;   - 50% chance of score +2.
-    ;   - 25% chance of score +1.
-    ;   - 25% chance of score +0.
-    ; - If the difference in SpDefense stages > 0:
-    ;   - 50% chance of score +1.
-    ;   - 50% chance of score +0.
-    ; - Otherwise, no score change.
+    // Find the difference in stat stages between the attacker and its opponent for the Defense stat.
+    //
+    // If the difference is > 3:
+    // - If the difference in SpDefense stages > 3:
+    //   - 50% chance of score +5.
+    //   - 25% chance of score +4.
+    //   - 12.5% chance of score +3.
+    //   - 6.25% chance of score +2.
+    //   - 3.125% chance of score +1.
+    //   - 3.125% chance of score +0.
+    // - If the difference in SpDefense stages > 1:
+    //   - 50% chance of score +4.
+    //   - 25% chance of score +3.
+    //   - 12.5% chance of score +2.
+    //   - 6.25% chance of score +1.
+    //   - 6.25% chance of score +0.
+    // - If the difference in SpDefense stages = 0:
+    //   - 50% chance of score +3.
+    //   - 25% chance of score +2.
+    //   - 12.5% chance of score +1.
+    //   - 12.5% chance of score +0.
+    // - Otherwise, no score change.
+    //
+    // If the difference is > 1:
+    // - If the difference in SpDefense stages > 3:
+    //   - 50% chance of score +4.
+    //   - 25% chance of score +3.
+    //   - 12.5% chance of score +2.
+    //   - 6.25% chance of score +1.
+    //   - 6.25% chance of score +0.
+    // - If the difference in SpDefense stages > 1:
+    //   - 50% chance of score +3.
+    //   - 25% chance of score +2.
+    //   - 12.5% chance of score +1.
+    //   - 12.5% chance of score +0.
+    // - If the difference in SpDefense stages = 0:
+    //   - 50% chance of score +2.
+    //   - 25% chance of score +1.
+    //   - 25% chance of score +0.
+    // - Otherwise, no score change.
+    //
+    // If the difference is > 0:
+    // - If the difference in SpDefense stages > 3:
+    //   - 50% chance of score +3.
+    //   - 25% chance of score +2.
+    //   - 12.5% chance of score +1.
+    //   - 12.5% chance of score +0.
+    // - If the difference in SpDefense stages > 1:
+    //   - 50% chance of score +2.
+    //   - 25% chance of score +1.
+    //   - 25% chance of score +0.
+    // - If the difference in SpDefense stages = 0:
+    //   - 50% chance of score +1.
+    //   - 50% chance of score +0.
+    // - Otherwise, no score change.
+    //
+    // If the difference = 0:
+    // - If the difference in SpDefense stages > 3:
+    //   - 50% chance of score +3.
+    //   - 25% chance of score +2.
+    //   - 12.5% chance of score +1.
+    //   - 12.5% chance of score +0.
+    // - If the difference in SpDefense stages > 1:
+    //   - 50% chance of score +2.
+    //   - 25% chance of score +1.
+    //   - 25% chance of score +0.
+    // - If the difference in SpDefense stages > 0:
+    //   - 50% chance of score +1.
+    //   - 50% chance of score +0.
+    // - Otherwise, no score change.
     DiffStatStages AI_BATTLER_DEFENDER, BATTLE_STAT_DEFENSE
     IfLoadedGreaterThan 3, Expert_GuardSwap_CheckSpDefense_HighDiff
     IfLoadedGreaterThan 1, Expert_GuardSwap_CheckSpDefense_MediumDiff
@@ -5895,28 +5895,28 @@ Expert_GuardSwap_End:
     PopOrEnd 
 
 Expert_Punishment:
-    ; If the opponent resists or is immune to the move, score +0.
-    ;
-    ; Sum the total positive stat stages for the opponent:
-    ; - If > 6:
-    ;     - 50% chance of score +4
-    ;     - 25% chance of score +3
-    ;     - 12.5% chance of score +2
-    ;     - 6.25% chance of score +1
-    ;     - 6.25% chance of score +0
-    ; - If = 6:
-    ;     - 50% chance of score +3
-    ;     - 25% chance of score +2
-    ;     - 12.5% chance of score +1
-    ;     - 12.5% chance of score +0
-    ; - If = 5:
-    ;     - 50% chance of score +2
-    ;     - 25% chance of score +1
-    ;     - 25% chance of score +0
-    ; - If > 2:
-    ;     - 50% chance of score +1
-    ;     - 50% chance of score +0
-    ; - Otherwise, score +0.
+    // If the opponent resists or is immune to the move, score +0.
+    //
+    // Sum the total positive stat stages for the opponent:
+    // - If > 6:
+    //     - 50% chance of score +4
+    //     - 25% chance of score +3
+    //     - 12.5% chance of score +2
+    //     - 6.25% chance of score +1
+    //     - 6.25% chance of score +0
+    // - If = 6:
+    //     - 50% chance of score +3
+    //     - 25% chance of score +2
+    //     - 12.5% chance of score +1
+    //     - 12.5% chance of score +0
+    // - If = 5:
+    //     - 50% chance of score +2
+    //     - 25% chance of score +1
+    //     - 25% chance of score +0
+    // - If > 2:
+    //     - 50% chance of score +1
+    //     - 50% chance of score +0
+    // - Otherwise, score +0.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_Punishment_End
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_Punishment_End
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_Punishment_End
@@ -5948,9 +5948,9 @@ Expert_Punishment_End:
     PopOrEnd 
 
 Expert_LastResort:
-    ; If the opponent resists or is immune to the move, score -1.
-    ;
-    ; If the attacker can use Last Resort, score +1. Otherwise, score +0.
+    // If the opponent resists or is immune to the move, score -1.
+    //
+    // If the attacker can use Last Resort, score +1. Otherwise, score +0.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_LastResort_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_LastResort_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_LastResort_ScoreMinus1
@@ -5968,11 +5968,11 @@ Expert_LastResort_End:
     PopOrEnd 
 
 Expert_WorrySeed:
-    ; If the opponent knows the move Rest, additional score +1.
-    ;
-    ; If the attacker's HP >= 50%, 50% chance of additional score +1.
-    ;
-    ; 75% chance of score +1.
+    // If the opponent knows the move Rest, additional score +1.
+    //
+    // If the attacker's HP >= 50%, 50% chance of additional score +1.
+    //
+    // 75% chance of score +1.
     IfMoveNotKnown AI_BATTLER_DEFENDER, MOVE_REST, Expert_WorrySeed_CheckUserHP
     AddToMoveScore 1
 
@@ -5990,9 +5990,9 @@ Expert_WorrySeed_End:
     PopOrEnd 
 
 Expert_SuckerPunch:
-    ; If the opponent resists or is immune to the move, score -1.
-    ;
-    ; 75% chance of score +1.
+    // If the opponent resists or is immune to the move, score -1.
+    //
+    // 75% chance of score +1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_SuckerPunch_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_SuckerPunch_ScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_SuckerPunch_ScoreMinus1
@@ -6007,11 +6007,11 @@ Expert_SuckerPunch_End:
     PopOrEnd 
 
 Expert_ToxicSpikes:
-    ; 50% chance to ignore all further scoring.
-    ;
-    ; Start at score +1.
-    ;
-    ; If the attacker knows specifically the moves Roar or Whirlwind, 75% chance of additional score +1.
+    // 50% chance to ignore all further scoring.
+    //
+    // Start at score +1.
+    //
+    // If the attacker knows specifically the moves Roar or Whirlwind, 75% chance of additional score +1.
     IfRandomLessThan 128, Expert_ToxicSpikes_End
     AddToMoveScore 1
     IfMoveKnown AI_BATTLER_ATTACKER, MOVE_ROAR, Expert_ToxicSpikes_TryScorePlus1
@@ -6026,24 +6026,24 @@ Expert_ToxicSpikes_End:
     PopOrEnd 
 
 Expert_HeartSwap:
-    ; If the opponent does not have any of the following stats at +2 stage or greater and is not
-    ; under the effect of Focus Energy, score -2 and terminate:
-    ; - Attack
-    ; - Defense
-    ; - SpAttack
-    ; - SpDefense
-    ; - Evasion
-    ;
-    ; If the attacker has any of the following stats at +0 stage or lower or is not under the
-    ; effect of Focus Energy, score +1:
-    ; - Attack
-    ; - Defense
-    ; - SpAttack
-    ; - SpDefense
-    ;
-    ; If the attacker's Evasion stat is at +0 stage or lower, score +2.
-    ;
-    ; Otherwise, 80.5% chance of score -2.
+    // If the opponent does not have any of the following stats at +2 stage or greater and is not
+    // under the effect of Focus Energy, score -2 and terminate:
+    // - Attack
+    // - Defense
+    // - SpAttack
+    // - SpDefense
+    // - Evasion
+    //
+    // If the attacker has any of the following stats at +0 stage or lower or is not under the
+    // effect of Focus Energy, score +1:
+    // - Attack
+    // - Defense
+    // - SpAttack
+    // - SpDefense
+    //
+    // If the attacker's Evasion stat is at +0 stage or lower, score +2.
+    //
+    // Otherwise, 80.5% chance of score -2.
     IfStatStageGreaterThan AI_BATTLER_DEFENDER, BATTLE_STAT_ATTACK, 7, Expert_HeartSwap_CheckUserStages
     IfStatStageGreaterThan AI_BATTLER_DEFENDER, BATTLE_STAT_DEFENSE, 7, Expert_HeartSwap_CheckUserStages
     IfStatStageGreaterThan AI_BATTLER_DEFENDER, BATTLE_STAT_SP_ATTACK, 7, Expert_HeartSwap_CheckUserStages
@@ -6076,7 +6076,7 @@ Expert_HeartSwap_End:
     PopOrEnd 
 
 Expert_AquaRing:
-    ; If the attacker's HP >= 30%, 50% chance of score +1.
+    // If the attacker's HP >= 30%, 50% chance of score +1.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 30, Expert_AquaRing_End
     IfRandomLessThan 128, Expert_AquaRing_End
     AddToMoveScore 1
@@ -6085,14 +6085,14 @@ Expert_AquaRing_End:
     PopOrEnd 
 
 Expert_MagnetRise:
-    ; If the attacker's HP < 50%, ignore all further score changes.
-    ;
-    ; If the opponent knows one of the following moves, additional score +1:
-    ; - Earthquake
-    ; - Earth Power
-    ; - Fissure
-    ;
-    ; If the opponent has a Ground typing, score +1. Otherwise, 50% chance of score +1.
+    // If the attacker's HP < 50%, ignore all further score changes.
+    //
+    // If the opponent knows one of the following moves, additional score +1:
+    // - Earthquake
+    // - Earth Power
+    // - Fissure
+    //
+    // If the opponent has a Ground typing, score +1. Otherwise, 50% chance of score +1.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 50, Expert_MagnetRise_End
     IfMoveKnown AI_BATTLER_DEFENDER, MOVE_EARTHQUAKE, Expert_MagnetRise_InitialScorePlus1
     IfMoveKnown AI_BATTLER_DEFENDER, MOVE_EARTH_POWER, Expert_MagnetRise_InitialScorePlus1
@@ -6120,25 +6120,25 @@ Expert_MagnetRise_End:
     PopOrEnd 
 
 Expert_Defog:
-    ; If the opponent's side of the field is under the effect of Light Screen or Reflect:
-    ; - If the attacker's HP < 30% and there are no remaining party members:
-    ;   - 80.5% chance of additional score -2.
-    ;   - If the opponent's HP > 70%, score -2.
-    ; - Start at score +1.
-    ; - If the opponent has at least one remaining party member and their side of the field is
-    ; under the effect of Spikes, Stealth Rock, or Toxic Spikes, 50% chance of score -1.
-    ; - Proceed to the final if-block below.
-    ;
-    ; If the opponent's side of the field is under the effect of Spikes, Stealth Rock, or Toxic
-    ; Spikes, additional score -2.
-    ;
-    ; If all of the following conditions are met, score -2:
-    ; - The attacker's HP >= 70%
-    ; - The opponent's Evasion stat is at -2 stage or greater
-    ; - The opponent's HP <= 70%
-    ; Otherwise:
-    ; - 80.5% chance of additional score -2.
-    ; - If the opponent's HP <= 70% score -2.
+    // If the opponent's side of the field is under the effect of Light Screen or Reflect:
+    // - If the attacker's HP < 30% and there are no remaining party members:
+    //   - 80.5% chance of additional score -2.
+    //   - If the opponent's HP > 70%, score -2.
+    // - Start at score +1.
+    // - If the opponent has at least one remaining party member and their side of the field is
+    // under the effect of Spikes, Stealth Rock, or Toxic Spikes, 50% chance of score -1.
+    // - Proceed to the final if-block below.
+    //
+    // If the opponent's side of the field is under the effect of Spikes, Stealth Rock, or Toxic
+    // Spikes, additional score -2.
+    //
+    // If all of the following conditions are met, score -2:
+    // - The attacker's HP >= 70%
+    // - The opponent's Evasion stat is at -2 stage or greater
+    // - The opponent's HP <= 70%
+    // Otherwise:
+    // - 80.5% chance of additional score -2.
+    // - If the opponent's HP <= 70% score -2.
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_LIGHT_SCREEN, Expert_Defog_ScreenScrubbing
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_REFLECT, Expert_Defog_ScreenScrubbing
     IfSideCondition AI_BATTLER_DEFENDER, SIDE_CONDITION_SPIKES, Expert_Defog_ScoreMinus2AndEnd
@@ -6185,13 +6185,13 @@ Expert_Defog_End:
     PopOrEnd 
 
 Expert_TrickRoom:
-    ; If the battle is a Double Battle, ignore all further score modifiers.
-    ;
-    ; If the attacker's HP <= 30% and there are no remaining party members, score +0.
-    ;
-    ; If the attacker is faster than its opponent, score -1.
-    ;
-    ; If the attacker is slower than its opponent, 75% chance of score +3.
+    // If the battle is a Double Battle, ignore all further score modifiers.
+    //
+    // If the attacker's HP <= 30% and there are no remaining party members, score +0.
+    //
+    // If the attacker is faster than its opponent, score -1.
+    //
+    // If the attacker is slower than its opponent, 75% chance of score +3.
     LoadBattleType 
     IfLoadedMask BATTLE_TYPE_DOUBLES, Expert_TrickRoom_End
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 30, Expert_TrickRoom_CheckSpeed
@@ -6211,9 +6211,9 @@ Expert_TrickRoom_End:
     PopOrEnd 
 
 Expert_Blizzard:
-    ; If the opponent resists or is immune to the move, 80.5% chance of score -3.
-    ;
-    ; If the current weather is Hail, score +1.
+    // If the opponent resists or is immune to the move, 80.5% chance of score -3.
+    //
+    // If the current weather is Hail, score +1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_Blizzard_TryScoreMinus3
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_Blizzard_TryScoreMinus3
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_Blizzard_TryScoreMinus3
@@ -6231,14 +6231,14 @@ Expert_Blizzard_End:
     PopOrEnd 
 
 Expert_Captivate:
-    ; If the opponent's SpAttack stat stage is at any value other than +0:
-    ; - Start at score -1.
-    ; - If the attacker's HP <= 90%, additional score -1.
-    ; - If the opponent's SpAttack stat stage is at -3 or lower, 80.5% chance of additional score -2.
-    ;
-    ; If the opponent's HP <= 70%, additional score -2.
-    ;
-    ; If the opponent's last-used move was a Physical move, 75% chance of score -1.
+    // If the opponent's SpAttack stat stage is at any value other than +0:
+    // - Start at score -1.
+    // - If the attacker's HP <= 90%, additional score -1.
+    // - If the opponent's SpAttack stat stage is at -3 or lower, 80.5% chance of additional score -2.
+    //
+    // If the opponent's HP <= 70%, additional score -2.
+    //
+    // If the opponent's last-used move was a Physical move, 75% chance of score -1.
     IfStatStageEqualTo AI_BATTLER_DEFENDER, BATTLE_STAT_SP_ATTACK, 6, Expert_Captivate_CheckOpponentHP
     AddToMoveScore -1
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 90, Expert_Captivate_CheckLowStatStage
@@ -6263,11 +6263,11 @@ Expert_Captivate_End:
     PopOrEnd 
 
 Expert_StealthRock:
-    ; 50% chance to ignore all further score modifiers.
-    ;
-    ; Start at score +1.
-    ;
-    ; If the attacker knows either of the moves Roar or Whirlwind, 75% chance of additional score +1.
+    // 50% chance to ignore all further score modifiers.
+    //
+    // Start at score +1.
+    //
+    // If the attacker knows either of the moves Roar or Whirlwind, 75% chance of additional score +1.
     IfRandomLessThan 128, Expert_StealthRock_End
     AddToMoveScore 1
     IfMoveKnown AI_BATTLER_ATTACKER, MOVE_ROAR, Expert_StealthRock_TryScorePlus1
@@ -6284,9 +6284,9 @@ Expert_StealthRock_End:
     PopOrEnd 
 
 Expert_RecoilMove:
-    ; If the opponent resists or is immune to the move, ignore all further score modifiers.
-    ;
-    ; If the attacker has either of the abilities Rock Head or Magic Guard, score +1.
+    // If the opponent resists or is immune to the move, ignore all further score modifiers.
+    //
+    // If the attacker has either of the abilities Rock Head or Magic Guard, score +1.
     IfMoveEffectivenessEquals TYPE_MULTI_IMMUNE, Expert_RecoilMove_End
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, Expert_RecoilMove_End
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, Expert_RecoilMove_End
@@ -6302,17 +6302,17 @@ Expert_RecoilMove_End:
     PopOrEnd 
 
 Expert_HealingWish:
-    ; If the attacker's HP >= 80% and the attacker is faster than its opponent, 25% of score -5.
-    ;
-    ; If the attacker's HP > 50%, 80.5% chance of score -1.
-    ;
-    ; 75% chance to ignore this section of modifiers:
-    ; - Start at score +1.
-    ; - If the attacker does not have a super-effective move against its opponent, 25% chance of
-    ; additional score +1.
-    ; - If a party member deals more damage than the attacker, 50% chance of additional score +1.
-    ;
-    ; If the attacker's HP <= 30%, 50% chance of score +1.
+    // If the attacker's HP >= 80% and the attacker is faster than its opponent, 25% of score -5.
+    //
+    // If the attacker's HP > 50%, 80.5% chance of score -1.
+    //
+    // 75% chance to ignore this section of modifiers:
+    // - Start at score +1.
+    // - If the attacker does not have a super-effective move against its opponent, 25% chance of
+    // additional score +1.
+    // - If a party member deals more damage than the attacker, 50% chance of additional score +1.
+    //
+    // If the attacker's HP <= 30%, 50% chance of score +1.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 80, Expert_HealingWish_HappyPath
     IfSpeedCompareEqualTo COMPARE_SPEED_SLOWER, Expert_HealingWish_HappyPath
     IfRandomLessThan 192, Expert_HealingWish_End
@@ -6348,30 +6348,30 @@ Expert_HealingWish_End:
     PopOrEnd 
 
 EvalAttack_Main:
-    ; Never target the partner.
+    // Never target the partner.
     IfTargetIsPartner Terminate
 
     IfCurrentMoveKills USE_MAX_DAMAGE, EvalAttack_CheckForKill
 
-    ; If this move does not out-damage all other moves, score -1.
+    // If this move does not out-damage all other moves, score -1.
     FlagMoveDamageScore FALSE
     IfLoadedEqualTo AI_NOT_HIGHEST_DAMAGE, ScoreMinus1
 
-    ; Explosion, Focus Punch, and Sucker Punch are judged as Risky by this routine.
+    // Explosion, Focus Punch, and Sucker Punch are judged as Risky by this routine.
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_HALVE_DEFENSE, EvalAttack_RiskyAttack
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_HIT_LAST_WHIFF_IF_HIT, EvalAttack_RiskyAttack
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_HIT_FIRST_IF_TARGET_ATTACKING, EvalAttack_RiskyAttack
 
-    ; Check for quad-effectiveness.
+    // Check for quad-effectiveness.
     GoTo EvalAttack_CheckQuadEffective
 
 EvalAttack_RiskyAttack:
-    ; ~80% chance of score -2.
+    // ~80% chance of score -2.
     IfRandomLessThan 51, EvalAttack_CheckQuadEffective
     AddToMoveScore -2
 
 EvalAttack_CheckQuadEffective:
-    ; If quad-effective, 31.25% chance of score +2.
+    // If quad-effective, 31.25% chance of score +2.
     IfMoveEffectivenessEquals TYPE_MULTI_QUADRUPLE_DAMAGE, EvalAttack_TryScorePlus2
     PopOrEnd 
 
@@ -6381,21 +6381,21 @@ EvalAttack_TryScorePlus2:
     PopOrEnd 
 
 EvalAttack_CheckForKill:
-    ; Do not evaluate kills with Explosion or Self-Destruct for this routine.
+    // Do not evaluate kills with Explosion or Self-Destruct for this routine.
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_HALVE_DEFENSE, EvalAttack_Terminate
 
-    ; Randomly increase the score of a move that kills.
+    // Randomly increase the score of a move that kills.
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_HIT_LAST_WHIFF_IF_HIT, EvalAttack_TryScorePlus4
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_HIT_FIRST_IF_TARGET_ATTACKING, EvalAttack_TryScorePlus4
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_HIT_IN_3_TURNS, EvalAttack_TryScorePlus4
 
-    ; Priority kill is score +2. This is because priorty moves are low-power, and this routine prioritizes
-    ; raw damage output.
+    // Priority kill is score +2. This is because priorty moves are low-power, and this routine prioritizes
+    // raw damage output.
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_PRIORITY_1, EvalAttack_ScorePlus2
     GoTo EvalAttack_ScorePlus4
 
 EvalAttack_TryScorePlus4:
-    ; ~33.6% of the time, score +4.
+    // ~33.6% of the time, score +4.
     IfRandomLessThan 170, EvalAttack_Terminate
     GoTo EvalAttack_ScorePlus4
 
@@ -6411,15 +6411,15 @@ EvalAttack_Terminate:
 SetupFirstTurn_Main:
     IfTargetIsPartner Terminate
 
-    ; If this is not the first turn, terminate.
+    // If this is not the first turn, terminate.
     LoadTurnCount 
     IfLoadedNotEqualTo 0, SetupFirstTurn_Terminate
 
-    ; If the current move's effect is not known tobe a setup move, break.
+    // If the current move's effect is not known tobe a setup move, break.
     LoadCurrentMoveEffect 
     IfLoadedNotInTable SetupFirstTurn_SetupEffects, SetupFirstTurn_Terminate
 
-    ; 68.75% of the time, score +2.
+    // 68.75% of the time, score +2.
     IfRandomLessThan 80, SetupFirstTurn_Terminate
     AddToMoveScore 2
 
@@ -6491,14 +6491,14 @@ SetupFirstTurn_SetupEffects:
     TableEntry TABLE_END
 
 DamagePriority_Main:
-    ; Do not target your partner.
+    // Do not target your partner.
     IfTargetIsPartner Terminate
 
-    ; If the current move is not variable power or is Risky, break.
+    // If the current move is not variable power or is Risky, break.
     FlagMoveDamageScore FALSE
     IfLoadedNotEqualTo AI_NO_COMPARISON_MADE, DamagePriority_Terminate
 
-    ; ~61% of the time, score +2.
+    // ~61% of the time, score +2.
     IfRandomLessThan 100, DamagePriority_Terminate
     AddToMoveScore 2
 
@@ -6506,14 +6506,14 @@ DamagePriority_Terminate:
     PopOrEnd 
 
 Risky_Main:
-    ; Do not target your partner.
+    // Do not target your partner.
     IfTargetIsPartner Terminate
 
-    ; If the current move effect is judged to not be Risky, break;
+    // If the current move effect is judged to not be Risky, break;
     LoadCurrentMoveEffect 
     IfLoadedNotInTable Risky_RiskyEffects, Risky_Terminate
 
-    ; 50% of the time, score +2.
+    // 50% of the time, score +2.
     IfRandomLessThan 128, Risky_Terminate
     AddToMoveScore 2
 
@@ -6551,20 +6551,20 @@ Risky_RiskyEffects:
 BatonPass_Main:
     IfTargetIsPartner Terminate
 
-    ; If there are no other party members alive, break.
+    // If there are no other party members alive, break.
     CountAlivePartyBattlers AI_BATTLER_ATTACKER
     IfLoadedEqualTo 0, BatonPass_Terminate
 
-    ; If the move deals damage, ignore it for this flag.
+    // If the move deals damage, ignore it for this flag.
     FlagMoveDamageScore FALSE
     IfLoadedNotEqualTo AI_NO_COMPARISON_MADE, BatonPass_Terminate
 
-    ; If the attacker does not know Baton Pass, 31.25% chance of no score changes.
+    // If the attacker does not know Baton Pass, 31.25% chance of no score changes.
     IfMoveEffectKnown AI_BATTLER_ATTACKER, BATTLE_EFFECT_PASS_STATS_AND_STATUS, BatonPass_EvalMove
     IfRandomLessThan 80, Risky_Terminate
 
 BatonPass_EvalMove:
-    ; Handle these +2 boosting moves separately.
+    // Handle these +2 boosting moves separately.
     IfMoveEqualTo MOVE_SWORDS_DANCE, BatonPass_SetupAtHighHP
     IfMoveEqualTo MOVE_DRAGON_DANCE, BatonPass_SetupAtHighHP
     IfMoveEqualTo MOVE_CALM_MIND, BatonPass_SetupAtHighHP
@@ -6574,28 +6574,28 @@ BatonPass_EvalMove:
 
     IfMoveEqualTo MOVE_BATON_PASS, BatonPass_EvalBatonPass
 
-    ; ~92% of the time, score +3.
+    // ~92% of the time, score +3.
     IfRandomLessThan 20, Risky_Terminate
     AddToMoveScore 3
 
 BatonPass_SetupAtHighHP:
-    ; On turn 1 of the entire battle, score +5.
+    // On turn 1 of the entire battle, score +5.
     LoadTurnCount 
     IfLoadedEqualTo 0, ScorePlus5
 
-    ; If the attacker is at < 60% HP, score -10.
+    // If the attacker is at < 60% HP, score -10.
     IfHPPercentLessThan AI_BATTLER_ATTACKER, 60, ScoreMinus10
 
-    ; Otherwise, score +1.
+    // Otherwise, score +1.
     GoTo ScorePlus1
 
 BatonPass_EvalProtect:
-    ; If the current move's effect is Protect and the last move that we used
-    ; is either Detect or Protect, score -2.
+    // If the current move's effect is Protect and the last move that we used
+    // is either Detect or Protect, score -2.
     LoadBattlerPreviousMove AI_BATTLER_ATTACKER
     IfLoadedInTable BatonPass_ProtectDetect, ScoreMinus2
 
-    ; Else, score +2.
+    // Else, score +2.
     AddToMoveScore 2
     PopOrEnd 
 
@@ -6605,11 +6605,11 @@ BatonPass_ProtectDetect:
     TableEntry TABLE_END
 
 BatonPass_EvalBatonPass:
-    ; On turn 1 of the entire battle, score -2.
+    // On turn 1 of the entire battle, score -2.
     LoadTurnCount 
     IfLoadedEqualTo 0, ScoreMinus2
 
-    ; Score +1 for each positive stat stage for Attack or Special Attack
+    // Score +1 for each positive stat stage for Attack or Special Attack
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 8, ScorePlus3
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 7, ScorePlus2
     IfStatStageGreaterThan AI_BATTLER_ATTACKER, BATTLE_STAT_ATTACK, 6, ScorePlus1
@@ -6624,100 +6624,100 @@ BatonPass_Terminate:
 TagStrategy_Main:
     IfTargetIsPartner TagStrategy_Partner
 
-    ; If the move does not deal damage, skip ahead
+    // If the move does not deal damage, skip ahead
     FlagMoveDamageScore FALSE
     IfLoadedEqualTo AI_NO_COMPARISON_MADE, TagStrategy_CheckSpecialScoring
 
-    ; Flat-damage move effects have a special handler; this includes OHKO moves
+    // Flat-damage move effects have a special handler; this includes OHKO moves
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_ONE_HIT_KO, TagStrategy_ScoreMove
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_40_DAMAGE_FLAT, TagStrategy_ScoreMove
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_LEVEL_DAMAGE_FLAT, TagStrategy_ScoreMove
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_RANDOM_DAMAGE_1_TO_150_LEVEL, TagStrategy_ScoreMove
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_20_DAMAGE_FLAT, TagStrategy_ScoreMove
 
-    ; If the move is not-very-effective, try to reduce its score
+    // If the move is not-very-effective, try to reduce its score
     IfMoveEffectivenessEquals TYPE_MULTI_HALF_DAMAGE, TagStrategy_TryScoreMinus1
     IfMoveEffectivenessEquals TYPE_MULTI_QUARTER_DAMAGE, TagStrategy_TryScoreMinus2
 
-    ; All other moves
+    // All other moves
     GoTo TagStrategy_ScoreMove
 
 TagStrategy_TryScoreMinus1:
-    ; If the maximum roll would kill, do not reduce the score
+    // If the maximum roll would kill, do not reduce the score
     IfCurrentMoveKills USE_MAX_DAMAGE, TagStrategy_ScoreMove
 
-    ; If the target is on their last Pokemon, do not reduce the score
+    // If the target is on their last Pokemon, do not reduce the score
     IfHPPercentEqualTo AI_BATTLER_DEFENDER_PARTNER, 0, TagStrategy_ScoreMove
 
-    ; 75% of the time, reduce score by 1
+    // 75% of the time, reduce score by 1
     IfRandomLessThan 64, TagStrategy_ScoreMove
     AddToMoveScore -1
     GoTo TagStrategy_ScoreMove
 
 TagStrategy_TryScoreMinus2:
-    ; If the maximum roll would kill, do not reduce the score
+    // If the maximum roll would kill, do not reduce the score
     IfCurrentMoveKills USE_MAX_DAMAGE, TagStrategy_ScoreMove
 
-    ; If the target is on their last Pokemon, do not reduce the score
+    // If the target is on their last Pokemon, do not reduce the score
     IfHPPercentEqualTo AI_BATTLER_DEFENDER_PARTNER, 0, TagStrategy_ScoreMove
 
-    ; 75% of the time, reduce score by 2
+    // 75% of the time, reduce score by 2
     IfRandomLessThan 64, TagStrategy_ScoreMove
     AddToMoveScore -2
     GoTo TagStrategy_ScoreMove
 
 TagStrategy_ScoreMove:
-    ; If this is not a highest-damage move for the attacking side, handle the move "normally"
+    // If this is not a highest-damage move for the attacking side, handle the move "normally"
     CheckIfHighestDamageWithPartner USE_MAX_DAMAGE
     IfLoadedNotEqualTo AI_MOVE_IS_HIGHEST_DAMAGE, TagStrategy_CheckBeforeScoring
 
-    ; Handle Explosion and Self-Destruct like "normal" moves
+    // Handle Explosion and Self-Destruct like "normal" moves
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_HALVE_DEFENSE, TagStrategy_CheckSpecialScoring
 
-    ; Sometimes prioritize using priority +1 moves
+    // Sometimes prioritize using priority +1 moves
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_PRIORITY_1, TagStrategy_TryScorePlus1
 
-    ; 50% of the time, increase score by 1
+    // 50% of the time, increase score by 1
     IfRandomLessThan 128, TagStrategy_CheckBeforeScoring
     AddToMoveScore 1
 
-    ; Proceed to "normal" handling
+    // Proceed to "normal" handling
     GoTo TagStrategy_CheckSpecialScoring
 
 TagStrategy_TryScorePlus1:
-    ; ~80.5% of the time, increase score by 1
+    // ~80.5% of the time, increase score by 1
     IfRandomLessThan 50, TagStrategy_CheckBeforeScoring
     AddToMoveScore 1
     GoTo TagStrategy_CheckSpecialScoring
 
 TagStrategy_CheckBeforeScoring:
-    ; Flat-damage move effects have a special handler; this includes OHKO moves
+    // Flat-damage move effects have a special handler; this includes OHKO moves
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_ONE_HIT_KO, TagStrategy_CheckSpecialScoring
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_40_DAMAGE_FLAT, TagStrategy_CheckSpecialScoring
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_LEVEL_DAMAGE_FLAT, TagStrategy_CheckSpecialScoring
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_RANDOM_DAMAGE_1_TO_150_LEVEL, TagStrategy_CheckSpecialScoring
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_20_DAMAGE_FLAT, TagStrategy_CheckSpecialScoring
 
-    ; If the move is super-effective, try to increase its score
+    // If the move is super-effective, try to increase its score
     IfMoveEffectivenessEquals TYPE_MULTI_DOUBLE_DAMAGE, TagStrategy_TryPrioritizingDoubleEffective
     IfMoveEffectivenessEquals TYPE_MULTI_QUADRUPLE_DAMAGE, TagStrategy_TryPrioritizingQuadEffective
 
     GoTo TagStrategy_CheckSpecialScoring
 
 TagStrategy_TryPrioritizingDoubleEffective:
-    ; ~61% of the time, score +1
+    // ~61% of the time, score +1
     IfRandomLessThan 100, TagStrategy_CheckSpecialScoring
     AddToMoveScore 1
     GoTo TagStrategy_CheckSpecialScoring
 
 TagStrategy_TryPrioritizingQuadEffective:
-    ; 75% of the time, score +1
+    // 75% of the time, score +1
     IfRandomLessThan 64, TagStrategy_CheckSpecialScoring
     AddToMoveScore 1
     GoTo TagStrategy_CheckSpecialScoring
 
 TagStrategy_CheckSpecialScoring:
-    ; Handle each of these moves with their own routine
+    // Handle each of these moves with their own routine
     IfMoveEqualTo MOVE_SKILL_SWAP, TagStrategy_SkillSwap
     LoadTypeFrom LOAD_MOVE_TYPE
     IfMoveEqualTo MOVE_EARTHQUAKE, TagStrategy_Earthquake
@@ -6739,10 +6739,10 @@ TagStrategy_CheckSpecialScoring:
     PopOrEnd 
 
 TagStrategy_RainDance:
-    ; If the move is Rain Dance, apply modifiers for each of the attacker and partner which meet the
-    ; following conditions:
-    ;  - The battler has Hydration and is currently statused -> score +2
-    ;  - The battler has Dry Skin -> score +2
+    // If the move is Rain Dance, apply modifiers for each of the attacker and partner which meet the
+    // following conditions:
+    //  - The battler has Hydration and is currently statused -> score +2
+    //  - The battler has Dry Skin -> score +2
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_HYDRATION, TagStrategy_RainDance_SelfHasHydration
     IfLoadedEqualTo ABILITY_DRY_SKIN, TagStrategy_RainDance_SelfScorePlus2
@@ -6773,13 +6773,13 @@ TagStrategy_RainDance_End:
     PopOrEnd 
 
 TagStrategy_SunnyDay:
-    ; If the move is Sunny Day, apply modifiers for each of the attacker and partner which meet the
-    ; following conditions:
-    ;  - The battler has Leaf Guard, is not currently statused, and is at 30% HP or higher -> score +2
-    ;  - The battler has Flower Gift -> score +2
-    ;  - The battler has Dry Skin -> score -2
-    ;  - The battler has Solar Power and is at 50% HP or higher -> score +1
-    ;  - The battler has Solar Power, is at less than 50% HP -> 50% chance of score -2
+    // If the move is Sunny Day, apply modifiers for each of the attacker and partner which meet the
+    // following conditions:
+    //  - The battler has Leaf Guard, is not currently statused, and is at 30% HP or higher -> score +2
+    //  - The battler has Flower Gift -> score +2
+    //  - The battler has Dry Skin -> score -2
+    //  - The battler has Solar Power and is at 50% HP or higher -> score +1
+    //  - The battler has Solar Power, is at less than 50% HP -> 50% chance of score -2
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_LEAF_GUARD, TagStrategy_SunnyDay_SelfHasLeafGuard
     IfLoadedEqualTo ABILITY_FLOWER_GIFT, TagStrategy_SunnyDay_SelfScorePlus2
@@ -6842,11 +6842,11 @@ TagStrategy_SunnyDay_End:
     PopOrEnd 
 
 TagStrategy_Hail:
-    ; If the move is Hail, apply modifiers for each of the attacker and partner which meet the
-    ; following conditions:
-    ;  - The battler has Ice Body -> score +2
-    ;  - The battler has Snow Cloak -> score +2
-    ;  - The battler knows Blizzard -> score +2
+    // If the move is Hail, apply modifiers for each of the attacker and partner which meet the
+    // following conditions:
+    //  - The battler has Ice Body -> score +2
+    //  - The battler has Snow Cloak -> score +2
+    //  - The battler knows Blizzard -> score +2
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_ICE_BODY, TagStrategy_Hail_SelfScorePlus2
     IfLoadedEqualTo ABILITY_SNOW_CLOAK, TagStrategy_Hail_SelfScorePlus2
@@ -6871,10 +6871,10 @@ TagStrategy_Hail_End:
     PopOrEnd 
 
 TagStrategy_Sandstorm:
-    ; If the move is Sandstorm, apply modifiers for each of the attacker and partner which meet the
-    ; following conditions:
-    ;  - The battler has Sand Veil -> score +2
-    ;  - The battler has a Rock typing -> score +2
+    // If the move is Sandstorm, apply modifiers for each of the attacker and partner which meet the
+    // following conditions:
+    //  - The battler has Sand Veil -> score +2
+    //  - The battler has a Rock typing -> score +2
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_SAND_VEIL, TagStrategy_Sandstorm_SelfScorePlus2
     LoadTypeFrom LOAD_ATTACKER_TYPE_1
@@ -6903,14 +6903,14 @@ TagStrategy_Sandstorm_End:
     PopOrEnd 
 
 TagStrategy_Gravity:
-    ; If Gravity is currently active, score -30
+    // If Gravity is currently active, score -30
     IfFieldConditionsMask FIELD_CONDITION_GRAVITY, TagStrategy_PartnerScoreMinus30
 
-    ; Apply the following score modifiers:
-    ;  - For each allied battler which has Levitate, a Flying typing, or is under the effect of
-    ;    Magnet Rise -> score -5
-    ;  - For each enemy battler which has Levitate, a Flying typing, or is under the effect of
-    ;    Magnet Rise -> 75% chance of score +3
+    // Apply the following score modifiers:
+    //  - For each allied battler which has Levitate, a Flying typing, or is under the effect of
+    //    Magnet Rise -> score -5
+    //  - For each enemy battler which has Levitate, a Flying typing, or is under the effect of
+    //    Magnet Rise -> 75% chance of score +3
     CheckBattlerAbility AI_BATTLER_ATTACKER, ABILITY_LEVITATE
     IfLoadedEqualTo AI_HAVE, TagStrategy_Gravity_SelfScoreMinus5
     FlagBattlerIsType AI_BATTLER_ATTACKER, TYPE_FLYING
@@ -6964,12 +6964,12 @@ TagStrategy_Gravity_End:
     PopOrEnd 
 
 TagStrategy_TrickRoom:
-    ; If the battle has been reduced to either side having only one active Pokemon, score -30
+    // If the battle has been reduced to either side having only one active Pokemon, score -30
     IfHPPercentEqualTo AI_BATTLER_ATTACKER_PARTNER, 0, ScoreMinus30
     IfHPPercentEqualTo AI_BATTLER_DEFENDER_PARTNER, 0, ScoreMinus30
     IfHPPercentEqualTo AI_BATTLER_DEFENDER, 0, ScoreMinus30
 
-    ; Branch according to the attacker's Speed-ordering in battle
+    // Branch according to the attacker's Speed-ordering in battle
     LoadBattlerSpeedRank AI_BATTLER_ATTACKER
     IfLoadedEqualTo 0, TagStrategy_TrickRoom_SelfMovesFirst
     IfLoadedEqualTo 1, TagStrategy_TrickRoom_SelfMovesSecond
@@ -6978,34 +6978,34 @@ TagStrategy_TrickRoom:
     GoTo TagStrategy_TrickRoom_End
 
 TagStrategy_TrickRoom_SelfMovesFirst:
-    ; If our partner moves second, score -30
+    // If our partner moves second, score -30
     LoadBattlerSpeedRank AI_BATTLER_ATTACKER_PARTNER
     IfLoadedEqualTo 1, ScoreMinus30
     IfLoadedEqualTo 0, ScoreMinus30
     GoTo TagStrategy_TrickRoom_ScoreMinus5
 
 TagStrategy_TrickRoom_SelfMovesSecond:
-    ; If our partner moves before us, score -30
+    // If our partner moves before us, score -30
     LoadBattlerSpeedRank AI_BATTLER_ATTACKER_PARTNER
     IfLoadedEqualTo 0, ScoreMinus30
     GoTo TagStrategy_TrickRoom_ScoreMinus5
 
 TagStrategy_TrickRoom_SelfMovesThird:
-    ; If our partner does not move last in turn-order, score -5
+    // If our partner does not move last in turn-order, score -5
     LoadBattlerSpeedRank AI_BATTLER_ATTACKER_PARTNER
     IfLoadedNotEqualTo 3, TagStrategy_TrickRoom_ScoreMinus5
 
-    ; 75% chance of score +5, 25% chance of score -5
+    // 75% chance of score +5, 25% chance of score -5
     IfRandomLessThan 64, TagStrategy_TrickRoom_ScoreMinus5
     AddToMoveScore 5
     GoTo TagStrategy_TrickRoom_End
 
 TagStrategy_TrickRoom_SelfMovesLast:
-    ; If our partner does not move third in turn-order, score -5
+    // If our partner does not move third in turn-order, score -5
     LoadBattlerSpeedRank AI_BATTLER_ATTACKER_PARTNER
     IfLoadedNotEqualTo 2, TagStrategy_TrickRoom_ScoreMinus5
 
-    ; 75% chance of score +5, 25% chance of score -5
+    // 75% chance of score +5, 25% chance of score -5
     IfRandomLessThan 64, TagStrategy_TrickRoom_ScoreMinus5
     AddToMoveScore 5
     GoTo TagStrategy_TrickRoom_End
@@ -7017,23 +7017,23 @@ TagStrategy_TrickRoom_End:
     PopOrEnd 
 
 TagStrategy_FollowMe:
-    ; If the move is Follow Me, apply a score modifier according to the following conditional tree:
-    ;  - If the attacker's HP > 90%, and:
-    ;    - If the partner's HP > 90%, 75% chance of score -1
-    ;    - If the partner's HP is between 50% and 90%, 75% chance of score +1
-    ;    - If the partner's HP is between 30% and 50%, 75% chance of score +2
-    ;    - If the partner's HP is < 30%, 75% chance of score +3
-    ;  - If the attacker's HP is between 50% and 90%, and:
-    ;    - If the partner's HP > 90%, 75% chance of score -2
-    ;    - If the partner's HP is between 50% and 90%, 75% chance of score -1
-    ;    - If the partner's HP is between 30% and 50%, 75% chance of score +1
-    ;    - If the partner's HP is < 30%, 75% chance of score +2
-    ;  - If the attacker's HP is between 30% and 50%, and:
-    ;    - If the partner's HP > 90%, 75% chance of score -2
-    ;    - If the partner's HP is between 50% and 90%, 75% chance of score -2
-    ;    - If the partner's HP is between 30% and 50%, 75% chance of score +1
-    ;    - If the partner's HP is < 30%, 75% chance of score +2
-    ;  - If the attacker's HP < 30%, 75% chance of score -5
+    // If the move is Follow Me, apply a score modifier according to the following conditional tree:
+    //  - If the attacker's HP > 90%, and:
+    //    - If the partner's HP > 90%, 75% chance of score -1
+    //    - If the partner's HP is between 50% and 90%, 75% chance of score +1
+    //    - If the partner's HP is between 30% and 50%, 75% chance of score +2
+    //    - If the partner's HP is < 30%, 75% chance of score +3
+    //  - If the attacker's HP is between 50% and 90%, and:
+    //    - If the partner's HP > 90%, 75% chance of score -2
+    //    - If the partner's HP is between 50% and 90%, 75% chance of score -1
+    //    - If the partner's HP is between 30% and 50%, 75% chance of score +1
+    //    - If the partner's HP is < 30%, 75% chance of score +2
+    //  - If the attacker's HP is between 30% and 50%, and:
+    //    - If the partner's HP > 90%, 75% chance of score -2
+    //    - If the partner's HP is between 50% and 90%, 75% chance of score -2
+    //    - If the partner's HP is between 30% and 50%, 75% chance of score +1
+    //    - If the partner's HP is < 30%, 75% chance of score +2
+    //  - If the attacker's HP < 30%, 75% chance of score -5
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 90, TagStrategy_FollowMe_SelfHighHP
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 50, TagStrategy_FollowMe_SelfMediumHP
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 30, TagStrategy_FollowMe_SelfLowHP
@@ -7087,8 +7087,8 @@ TagStrategy_FollowMe_End:
     PopOrEnd 
 
 TagStrategy_PartnerKnowsHelpingHand:
-    ; If our partner knows Helping Hand, then damaging moves (aside from flat-damage moves)
-    ; get score +1
+    // If our partner knows Helping Hand, then damaging moves (aside from flat-damage moves)
+    // get score +1
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_ONE_HIT_KO, TagStrategy_PartnerHelpingHand_End
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_40_DAMAGE_FLAT, TagStrategy_PartnerHelpingHand_End
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_LEVEL_DAMAGE_FLAT, TagStrategy_PartnerHelpingHand_End
@@ -7112,13 +7112,13 @@ TagStrategy_Unused_2:
     PopOrEnd 
 
 TagStrategy_Earthquake:
-    ; If the move is Earthquake and our partner:
-    ;  - Is immune to Earthquake (has Levitate, a Flying typing, or Magnet Rise), score +2
-    ;  - Is weak to Earthquake (has Fire, Electric, Poison, or Rock typing), score -10
-    ;  - Otherwise, score -3
-    ;
-    ; Note that this does not check for if the partner is alive; this means that a solo
-    ; battler will score Earthquake and Magnitude an additional -3
+    // If the move is Earthquake and our partner:
+    //  - Is immune to Earthquake (has Levitate, a Flying typing, or Magnet Rise), score +2
+    //  - Is weak to Earthquake (has Fire, Electric, Poison, or Rock typing), score -10
+    //  - Otherwise, score -3
+    //
+    // Note that this does not check for if the partner is alive; this means that a solo
+    // battler will score Earthquake and Magnitude an additional -3
     IfMoveEffect AI_BATTLER_ATTACKER_PARTNER, MOVE_EFFECT_MAGNET_RISE, ScorePlus2
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_LEVITATE
     IfLoadedEqualTo AI_HAVE, ScorePlus2
@@ -7135,11 +7135,11 @@ TagStrategy_Earthquake:
     GoTo ScoreMinus3
 
 TagStrategy_FutureSight:
-    ; If the move is Future Sight or Doom Desire:
-    ;  - If we have no partner, apply no additional modifiers
-    ;  - If our partner knows Future Sight or Doom Desire and:
-    ;    - They would move before us, score -3
-    ;    - They speed-tie us, 50% chance of score -3
+    // If the move is Future Sight or Doom Desire:
+    //  - If we have no partner, apply no additional modifiers
+    //  - If our partner knows Future Sight or Doom Desire and:
+    //    - They would move before us, score -3
+    //    - They speed-tie us, 50% chance of score -3
     IfHPPercentEqualTo AI_BATTLER_ATTACKER_PARTNER, 0, TagStrategy_FutureSight_End
     IfMoveKnown AI_BATTLER_ATTACKER_PARTNER, MOVE_FUTURE_SIGHT, TagStrategy_FutureSight_CheckSelfSpeed
     IfMoveKnown AI_BATTLER_ATTACKER_PARTNER, MOVE_DOOM_DESIRE, TagStrategy_FutureSight_CheckSelfSpeed
@@ -7180,10 +7180,10 @@ TagStrategy_FutureSight_End:
     PopOrEnd 
 
 TagStrategy_SkillSwap:
-    ; If the move is Skill Swap and:
-    ;  - The attacker has Truant, Slow Start, Stall, or Klutz, score +5
-    ;  - The target has Shadow Tag, Pure Power, Huge Power, Mold Breaker, Solid Rock, Filter, or
-    ;    Flower Gift, score +2
+    // If the move is Skill Swap and:
+    //  - The attacker has Truant, Slow Start, Stall, or Klutz, score +5
+    //  - The target has Shadow Tag, Pure Power, Huge Power, Mold Breaker, Solid Rock, Filter, or
+    //    Flower Gift, score +2
     LoadBattlerAbility AI_BATTLER_ATTACKER
     IfLoadedEqualTo ABILITY_TRUANT, ScorePlus5
     IfLoadedEqualTo ABILITY_SLOW_START, ScorePlus5
@@ -7200,11 +7200,11 @@ TagStrategy_SkillSwap:
     PopOrEnd 
 
 TagStrategy_CheckElectricMove:
-    ; If the move is Discharge, handle it similarly to Earthquake. Otherwise, apply all of the
-    ; following which are met:
-    ;  - The target's partner would redirect the move with Lightning Rod, score -1; additional
-    ;    score -8 if the target's partner is also a Ground type
-    ;  - The attacker's partner has Lightning Rod, score -10
+    // If the move is Discharge, handle it similarly to Earthquake. Otherwise, apply all of the
+    // following which are met:
+    //  - The target's partner would redirect the move with Lightning Rod, score -1; additional
+    //    score -8 if the target's partner is also a Ground type
+    //  - The attacker's partner has Lightning Rod, score -10
     IfMoveEqualTo MOVE_DISCHARGE, TagStrategy_SpreadElectricMove
     CheckBattlerAbility AI_BATTLER_DEFENDER_PARTNER, ABILITY_LIGHTNING_ROD
     IfLoadedEqualTo AI_HAVE, TagStrategy_TargetProtectedByLightningRod
@@ -7223,13 +7223,13 @@ TagStrategy_PartnerHasLightningRod:
     GoTo TagStrategy_CheckElectric_End
 
 TagStrategy_SpreadElectricMove:
-    ; If our partner has Volt Absorb or Motor Drive, score +3
-    ;
-    ; If our partner otherwise has a Water or Flying typing, score -10
-    ;
-    ; If our partner otherwise has a Ground typing, score +3
-    ;
-    ; Else, score -3
+    // If our partner has Volt Absorb or Motor Drive, score +3
+    //
+    // If our partner otherwise has a Water or Flying typing, score -10
+    //
+    // If our partner otherwise has a Ground typing, score +3
+    //
+    // Else, score -3
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_MOTOR_DRIVE
     IfLoadedEqualTo AI_HAVE, ScorePlus3
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_VOLT_ABSORB
@@ -7239,9 +7239,9 @@ TagStrategy_SpreadElectricMove:
     FlagBattlerIsType AI_BATTLER_ATTACKER_PARTNER, TYPE_FLYING
     IfLoadedEqualTo AI_HAVE, ScoreMinus10
 
-    ; BUG: This should be before the checks for all other types; in its present position, the
-    ; vanilla trainer AI will never use Discharge if their partner is, e.g., Swampert or Gliscor
-    ; (which should be treated as Immune to the move, but are not).
+    // BUG: This should be before the checks for all other types; in its present position, the
+    // vanilla trainer AI will never use Discharge if their partner is, e.g., Swampert or Gliscor
+    // (which should be treated as Immune to the move, but are not).
     FlagBattlerIsType AI_BATTLER_ATTACKER_PARTNER, TYPE_GROUND
     IfLoadedEqualTo AI_HAVE, ScorePlus3
     AddToMoveScore -3
@@ -7250,10 +7250,10 @@ TagStrategy_CheckElectric_End:
     PopOrEnd 
 
 TagStrategy_CheckWaterMove:
-    ; If the move is Surf, handle it similarly to Earthquake. Otherwise, apply all of the
-    ; following which are met:
-    ;  - The target's partner would redirect the move with Storm Drain, score -1
-    ;  - The attacker's partner has Storm Drain, score -10
+    // If the move is Surf, handle it similarly to Earthquake. Otherwise, apply all of the
+    // following which are met:
+    //  - The target's partner would redirect the move with Storm Drain, score -1
+    //  - The attacker's partner has Storm Drain, score -10
     IfMoveEqualTo MOVE_SURF, TagStrategy_SpreadWaterMove
     CheckBattlerAbility AI_BATTLER_DEFENDER_PARTNER, ABILITY_STORM_DRAIN
     IfLoadedEqualTo AI_NOT_HAVE, TagStrategy_CheckPartnerStormDrain
@@ -7263,22 +7263,22 @@ TagStrategy_CheckPartnerStormDrain:
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_STORM_DRAIN
     IfLoadedEqualTo AI_HAVE, ScoreMinus10
 
-    ; This line should never result in a branch
+    // This line should never result in a branch
     IfMoveEqualTo MOVE_SURF, TagStrategy_SpreadWaterMove
     GoTo TagStrategy_CheckWater_End
 
 TagStrategy_SpreadWaterMove:
-    ; If our partner has Dry Skin or Water Absorb, score +3
-    ;
-    ; If our partner otherwise has a Ground or Fire typing, score -10
-    ;
-    ; Else, score -3
+    // If our partner has Dry Skin or Water Absorb, score +3
+    //
+    // If our partner otherwise has a Ground or Fire typing, score -10
+    //
+    // Else, score -3
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_DRY_SKIN
     IfLoadedEqualTo AI_HAVE, ScorePlus3
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_WATER_ABSORB
     IfLoadedEqualTo AI_HAVE, ScorePlus3
 
-    ; BUG: This should also include a similar check for the Rock type
+    // BUG: This should also include a similar check for the Rock type
     FlagBattlerIsType AI_BATTLER_ATTACKER_PARTNER, TYPE_GROUND
     IfLoadedEqualTo AI_HAVE, ScoreMinus10
     FlagBattlerIsType AI_BATTLER_ATTACKER_PARTNER, TYPE_FIRE
@@ -7289,12 +7289,12 @@ TagStrategy_CheckWater_End:
     PopOrEnd 
 
 TagStrategy_CheckFireMove:
-    ; If the AI's Flash Fire has been activated, score additional +1 on top of all further modifiers
-    ;
-    ; If the move is Lava Plume, then:
-    ;  - If our partner has Dry Skin or Flash Fire, score +3
-    ;  - If our partner has a Grass, Steel, Ice, or Bug typing, score -10
-    ;  - Otherwise, score -3
+    // If the AI's Flash Fire has been activated, score additional +1 on top of all further modifiers
+    //
+    // If the move is Lava Plume, then:
+    //  - If our partner has Dry Skin or Flash Fire, score +3
+    //  - If our partner has a Grass, Steel, Ice, or Bug typing, score -10
+    //  - Otherwise, score -3
     IfActivatedFlashFire AI_BATTLER_ATTACKER, TagStrategy_FlashFireScorePlus1
     GoTo TagStrategy_CheckLavaPlume
 
@@ -7337,9 +7337,9 @@ TagStrategy_ScoreMinus30:
     GoTo ScoreMinus30
 
 TagStrategy_CheckPartnerFireAbsorption:
-    ; If our partner has Flash Fire and has not yet activated Flash Fire, score +3
-    ;
-    ; Otherwise, score -30
+    // If our partner has Flash Fire and has not yet activated Flash Fire, score +3
+    //
+    // Otherwise, score -30
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_FLASH_FIRE
     IfLoadedEqualTo AI_HAVE, TagStrategy_CheckPartnerFlashFireActive
     GoTo TagStrategy_ScoreMinus30
@@ -7349,17 +7349,17 @@ TagStrategy_CheckPartnerFlashFireActive:
     GoTo ScorePlus3
 
 TagStrategy_CheckPartnerElectricAbsorption:
-    ; If our partner has Motor Drive:
-    ;  - 62.5% chance of no score change
-    ;  - If our partner is at +6 speed, score -30
-    ;  - Else, score +3
-    ;
-    ; If our partner has Volt Absorb:
-    ;  - If our partner is at 100% HP, score -10
-    ;  - If our partner's HP >90%, no score change
-    ;  - If our partner's HP >75%, 25% chance of score +3, 75% chance of no change
-    ;  - If our partner's HP >50%, 50% chance of score +3, 50% chance of no change
-    ;  - Else, 75% chance of score +3, 25% chance of no change
+    // If our partner has Motor Drive:
+    //  - 62.5% chance of no score change
+    //  - If our partner is at +6 speed, score -30
+    //  - Else, score +3
+    //
+    // If our partner has Volt Absorb:
+    //  - If our partner is at 100% HP, score -10
+    //  - If our partner's HP >90%, no score change
+    //  - If our partner's HP >75%, 25% chance of score +3, 75% chance of no change
+    //  - If our partner's HP >50%, 50% chance of score +3, 50% chance of no change
+    //  - Else, 75% chance of score +3, 25% chance of no change
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_MOTOR_DRIVE
     IfLoadedEqualTo AI_HAVE, TagStrategy_CheckPartnerMotorDrive
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_VOLT_ABSORB
@@ -7394,12 +7394,12 @@ TagStrategy_CheckElectricAbsorption_End:
     PopOrEnd 
 
 TagStrategy_CheckPartnerWaterAbsorption:
-    ; If our partner has Water Absorb or Dry Skin:
-    ;  - If our partner is at 100% HP, score -10
-    ;  - If our partner's HP >90%, no score change
-    ;  - If our partner's HP >75%, 25% chance of score +3, 75% chance of no change
-    ;  - If our partner's HP >50%, 50% chance of score +3, 50% chance of no change
-    ;  - Else, 75% chance of score +3, 25% chance of no change
+    // If our partner has Water Absorb or Dry Skin:
+    //  - If our partner is at 100% HP, score -10
+    //  - If our partner's HP >90%, no score change
+    //  - If our partner's HP >75%, 25% chance of score +3, 75% chance of no change
+    //  - If our partner's HP >50%, 50% chance of score +3, 50% chance of no change
+    //  - Else, 75% chance of score +3, 25% chance of no change
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_WATER_ABSORB
     IfLoadedEqualTo AI_HAVE, TagStrategy_PartnerWaterAbsorb
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_DRY_SKIN
@@ -7443,14 +7443,14 @@ TagStrategy_PartnerStatusMove:
     GoTo TagStrategy_PartnerScoreMinus30
 
 TagStrategy_PartnerSkillSwap:
-    ; If our partner has Truant or Slow Start, score +10.
-    ;
-    ; If we can give Levitate to an Electric-type partner, score +1; additional +1 if our partner
-    ; is mono-Electric.
-    ;
-    ; If we can give an Accuracy-increasing ability and our partner has an inaccurate move, score +3.
-    ;
-    ; Otherwise, score -30.
+    // If our partner has Truant or Slow Start, score +10.
+    //
+    // If we can give Levitate to an Electric-type partner, score +1; additional +1 if our partner
+    // is mono-Electric.
+    //
+    // If we can give an Accuracy-increasing ability and our partner has an inaccurate move, score +3.
+    //
+    // Otherwise, score -30.
     LoadBattlerAbility AI_BATTLER_DEFENDER
     IfLoadedEqualTo ABILITY_TRUANT, ScorePlus10
     IfLoadedEqualTo ABILITY_SLOW_START, ScorePlus10
@@ -7498,16 +7498,16 @@ TagStrategy_PartnerSkillSwap_ScorePlus3:
     GoTo ScorePlus3
 
 TagStrategy_PartnerWillOWisp:
-    ; If our partner has Flash Fire, handle it identically to the earlier Fire Absorption routine
-    ;
-    ; If our partner meets all of the following conditions, score +5:
-    ;  - Has the Guts ability
-    ;  - Is not currently statused
-    ;  - Does not have a Fire typing
-    ;  - Is not holding a Flame Orb or Toxic Orb
-    ;  - Is at 81% HP or greater
-    ;
-    ; Otherwise, score -30
+    // If our partner has Flash Fire, handle it identically to the earlier Fire Absorption routine
+    //
+    // If our partner meets all of the following conditions, score +5:
+    //  - Has the Guts ability
+    //  - Is not currently statused
+    //  - Does not have a Fire typing
+    //  - Is not holding a Flame Orb or Toxic Orb
+    //  - Is at 81% HP or greater
+    //
+    // Otherwise, score -30
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_FLASH_FIRE
     IfLoadedEqualTo AI_HAVE, TagStrategy_CheckPartnerFireAbsorption
 
@@ -7529,9 +7529,9 @@ TagStrategy_PartnerWillOWisp:
     GoTo ScorePlus5
 
 TagStrategy_PartnerThunderWave:
-    ; If our partner has a Ground typing or has an ability other than Motor Drive or Volt Absorb, score -30
-    ;
-    ; Otherwise, handle the move identically to other Electric moves
+    // If our partner has a Ground typing or has an ability other than Motor Drive or Volt Absorb, score -30
+    //
+    // Otherwise, handle the move identically to other Electric moves
     LoadTypeFrom LOAD_DEFENDER_TYPE_1
     IfLoadedEqualTo TYPE_GROUND, TagStrategy_PartnerScoreMinus30
     LoadTypeFrom LOAD_DEFENDER_TYPE_2
@@ -7546,15 +7546,15 @@ TagStrategy_PartnerThunderWave:
     GoTo TagStrategy_PartnerScoreMinus30
 
 TagStrategy_PartnerPoisonStatus:
-    ; If our partner meets all of the following conditions, score +5:
-    ;  - Has the Poison Heal ability
-    ;  - Is not currently statused
-    ;  - Is not holding a Toxic Orb
-    ;  - Is at 81% HP or greater
-    ;
-    ; Otherwise, score -30
-    ;
-    ; BUG: This routine should also consider if the partner has a Poison or Steel typing.
+    // If our partner meets all of the following conditions, score +5:
+    //  - Has the Poison Heal ability
+    //  - Is not currently statused
+    //  - Is not holding a Toxic Orb
+    //  - Is at 81% HP or greater
+    //
+    // Otherwise, score -30
+    //
+    // BUG: This routine should also consider if the partner has a Poison or Steel typing.
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_POISON_HEAL
     IfLoadedNotEqualTo AI_HAVE, TagStrategy_PartnerScoreMinus30
 
@@ -7567,12 +7567,12 @@ TagStrategy_PartnerPoisonStatus:
     GoTo ScorePlus5
 
 TagStrategy_PartnerUsingHelpingHand:
-    ; If we do not have a partner, score -30
-    ;
-    ; If our partner has more than 50% HP or would move first in the turn, 75% chance of score +2,
-    ; 25% chance of score -1
-    ;
-    ; Else, no score changes
+    // If we do not have a partner, score -30
+    //
+    // If our partner has more than 50% HP or would move first in the turn, 75% chance of score +2,
+    // 25% chance of score -1
+    //
+    // Else, no score changes
     IfHPPercentEqualTo AI_BATTLER_ATTACKER_PARTNER, 0, ScoreMinus30
     IfHPPercentGreaterThan AI_BATTLER_ATTACKER_PARTNER, 50, TagStrategy_PartnerUsingHelpingHand_TryScorePlus2
     LoadBattlerSpeedRank AI_BATTLER_ATTACKER_PARTNER
@@ -7587,13 +7587,13 @@ TagStrategy_PartnerUsingHelpingHand_End:
     PopOrEnd 
 
 TagStrategy_PartnerSwagger:
-    ; If our partner is holding neither a Persim Berry nor a Lum Berry, score -30
-    ;
-    ; If our partner is at less than +2 Attack, score +3
-    ;
-    ; Otherwise, no score changes
-    ;
-    ; Curiously, this does not consider if our partner's ability is Own Tempo.
+    // If our partner is holding neither a Persim Berry nor a Lum Berry, score -30
+    //
+    // If our partner is at less than +2 Attack, score +3
+    //
+    // Otherwise, no score changes
+    //
+    // Curiously, this does not consider if our partner's ability is Own Tempo.
     IfHeldItemEqualTo AI_BATTLER_DEFENDER, ITEM_PERSIM_BERRY, TagStrategy_PartnerSwagger_TryScorePlus3
     IfHeldItemEqualTo AI_BATTLER_DEFENDER, ITEM_LUM_BERRY, TagStrategy_PartnerSwagger_TryScorePlus3
     GoTo TagStrategy_PartnerScoreMinus30
@@ -7609,11 +7609,11 @@ TagStrategy_PartnerTrick:
     PopOrEnd 
 
 TagStrategy_PartnerGastroAcid:
-    ; If our partner's ability is already suppressed, score -30
-    ;
-    ; If our partner has Truant or Slow Start, score +5
-    ;
-    ; Otherwise, no score changes
+    // If our partner's ability is already suppressed, score -30
+    //
+    // If our partner has Truant or Slow Start, score +5
+    //
+    // Otherwise, no score changes
     IfMoveEffect AI_BATTLER_ATTACKER_PARTNER, MOVE_EFFECT_ABILITY_SUPPRESSED, TagStrategy_PartnerScoreMinus30
 
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_TRUANT
@@ -7631,15 +7631,15 @@ TagStrategy_PartnerGastroAcid_End:
     PopOrEnd 
 
 TagStrategy_PartnerAcupressure:
-    ; If our partner has Simple and any stat at +3 stages, score -10
-    ;
-    ; Else if our partner has any stat at +6 stages, score -30
-    ;
-    ; Else if our partner's HP is 50% or lower, score -1
-    ;
-    ; Else if our partner's HP is 91% or higher, 68.75% chance of score +2, 31.25% chance of no score change
-    ;
-    ; Else 31.25% chance of score +2, 68.75% chance of no score change
+    // If our partner has Simple and any stat at +3 stages, score -10
+    //
+    // Else if our partner has any stat at +6 stages, score -30
+    //
+    // Else if our partner's HP is 50% or lower, score -1
+    //
+    // Else if our partner's HP is 91% or higher, 68.75% chance of score +2, 31.25% chance of no score change
+    //
+    // Else 31.25% chance of score +2, 68.75% chance of no score change
     CheckBattlerAbility AI_BATTLER_ATTACKER_PARTNER, ABILITY_SIMPLE
     IfLoadedEqualTo AI_HAVE, TagStrategy_PartnerAcupressureSimple
     IfStatStageEqualTo AI_BATTLER_ATTACKER_PARTNER, BATTLE_STAT_ATTACK, 12, TagStrategy_PartnerScoreMinus30
@@ -7683,11 +7683,11 @@ TagStrategy_PartnerScoreMinus30:
 CheckHP_Main:
     IfTargetIsPartner TagStrategy_Partner
 
-    ; Which moves apply to the routine depends on the attacker's HP percentage
-    IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 70, CheckHP_GT70Percent ; >70%
-    IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 30, CheckHP_31To70Percent ; 31-70%
+    // Which moves apply to the routine depends on the attacker's HP percentage
+    IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 70, CheckHP_GT70Percent // >70%
+    IfHPPercentGreaterThan AI_BATTLER_ATTACKER, 30, CheckHP_31To70Percent // 31-70%
     LoadCurrentMoveEffect 
-    IfLoadedInTable CheckHP_DiscourageAtLowHP, CheckHP_TryScoreMinus2 ; 1-30%
+    IfLoadedInTable CheckHP_DiscourageAtLowHP, CheckHP_TryScoreMinus2 // 1-30%
     GoTo CheckHP_Target
 
 CheckHP_GT70Percent:
@@ -7701,13 +7701,13 @@ CheckHP_31To70Percent:
     GoTo CheckHP_Target
 
 CheckHP_TryScoreMinus2:
-    ; ~80.5% of the time, score -2
+    // ~80.5% of the time, score -2
     IfRandomLessThan 50, CheckHP_Target
     AddToMoveScore -2
 
 CheckHP_Target:
-    ; The second round is similar to the first, but looks at the target's HP instead of
-    ; the attacker's.
+    // The second round is similar to the first, but looks at the target's HP instead of
+    // the attacker's.
     IfHPPercentGreaterThan AI_BATTLER_DEFENDER, 70, CheckHP_Target_GT70Percent
     IfHPPercentGreaterThan AI_BATTLER_DEFENDER, 30, CheckHP_Target_31To70Percent
     LoadCurrentMoveEffect 
@@ -7725,7 +7725,7 @@ CheckHP_Target_31To70Percent:
     GoTo CheckHP_Terminate
 
 CheckHP_Target_TryScoreMinus2:
-    ; ~80.5% of the time, score -2
+    // ~80.5% of the time, score -2
     IfRandomLessThan 50, CheckHP_Terminate
     AddToMoveScore -2
 
@@ -7900,7 +7900,7 @@ CheckHP_Target_DiscourageAtMediumHP:
 
 CheckHP_Target_DiscourageAtLowHP:
     TableEntry BATTLE_EFFECT_STATUS_SLEEP
-    TableEntry BATTLE_EFFECT_HALVE_DEFENSE ; done
+    TableEntry BATTLE_EFFECT_HALVE_DEFENSE // done
     TableEntry BATTLE_EFFECT_ATK_UP
     TableEntry BATTLE_EFFECT_DEF_UP
     TableEntry BATTLE_EFFECT_SPEED_UP
@@ -7966,11 +7966,11 @@ CheckHP_Target_DiscourageAtLowHP:
 Weather_Main:
     IfTargetIsPartner Terminate
 
-    ; If it is not the first turn of the battle, break.
+    // If it is not the first turn of the battle, break.
     LoadTurnCount 
     IfLoadedNotEqualTo 0, Weather_Terminate
 
-    ; For each weather, don't try to set it if it's already active from the field.
+    // For each weather, don't try to set it if it's already active from the field.
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_WEATHER_SUN, Weather_Sun
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_WEATHER_RAIN, Weather_Rain
     IfCurrentMoveEffectEqualTo BATTLE_EFFECT_WEATHER_SANDSTORM, Weather_Sand
@@ -7997,7 +7997,7 @@ Weather_Hail:
     GoTo Weather_ScorePlus5
 
 Weather_ScorePlus5:
-    ; On the attacker's first turn only, score +5.
+    // On the attacker's first turn only, score +5.
     LoadIsFirstTurnInBattle AI_BATTLER_ATTACKER
     IfLoadedEqualTo FALSE, Weather_Terminate
     AddToMoveScore 5
@@ -8008,12 +8008,12 @@ Weather_Terminate:
 Harrassment_Main:
     IfTargetIsPartner Terminate
 
-    ; If the move is not judged to be a Harrassment move within the context
-    ; of this routine, break.
+    // If the move is not judged to be a Harrassment move within the context
+    // of this routine, break.
     LoadCurrentMoveEffect 
     IfLoadedNotInTable Harrassment_Effects, Harrassment_Terminate
 
-    ; 50% of the time, score +2.
+    // 50% of the time, score +2.
     IfRandomLessThan 128, Harrassment_Terminate
     AddToMoveScore 2
 
@@ -8058,8 +8058,8 @@ Harrassment_Effects:
     TableEntry TABLE_END
 
 RoamingPokemon_Main:
-    ; If the Roamer is trapped, break from this routine
-    ; Otherwise, override all other possible moves and Escape
+    // If the Roamer is trapped, break from this routine
+    // Otherwise, override all other possible moves and Escape
     IfVolatileStatus AI_BATTLER_ATTACKER, VOLATILE_CONDITION_BIND, RoamingPokemon_Trapped
     IfVolatileStatus AI_BATTLER_ATTACKER, VOLATILE_CONDITION_MEAN_LOOK, RoamingPokemon_Trapped
     LoadAbility AI_BATTLER_DEFENDER
@@ -8081,7 +8081,7 @@ Safari_Main:
     Escape 
 
 CatchTutorial_Main:
-    ; If the target is at 20% or less HP, flee from the battle
+    // If the target is at 20% or less HP, flee from the battle
     IfHPPercentEqualTo AI_BATTLER_DEFENDER, 20, CatchTutorial_Escape
     IfHPPercentLessThan AI_BATTLER_DEFENDER, 20, CatchTutorial_Escape
     PopOrEnd 


### PR DESCRIPTION
## Description

The Trainer AI script is currently built with `mwasmarm` (hereafter called `mwas`), which implements a different assembler dialect than `arm-none-eabi-gcc` (hereafter called `gas`). This creates a few pitfalls:

1. The implementation of [`.equ` in `gas`](https://sourceware.org/binutils/docs/as/Equ.html) allows for setting the definition of a symbol multiple times; this is not the case in `mwas`, which will throw an error like the [`.equiv` directive in `gas`](https://sourceware.org/binutils/docs/as/Equiv.html).
2. `gas` does not recognize `;` as a comment-prefix.
3. The [`.macro` directive in `gas`](https://sourceware.org/binutils/docs/as/Macro.html) supports the specification of required parameters, variadic arguments, and default values for unspecified parameters.
4. `mwas` supports far fewer preprocessor features and options. In particular, `gas`, as a `gcc`-derivative, will provide [standard pre-defined macros](https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html) on invocation.

It makes sense to unify how we compile bytecode scripts, so that the behavior is consistent throughout the project.

## Other Approaches

One way that I tried to do this was specifying `arm-none-eabi-gcc` as the `nasm` compiler in the Meson cross-files. That didn't seem to work, as `arm-none-eabi-gcc` is not directly recognized by Meson as a known compiler. I'm sure that there's a way to do this, but I didn't try much harder past the first hour or two of debugging.

## Clean-up Changes

- `asm/macros/aicmd.inc` - All macro parameters have been marked as required.
- `src/battle/trainer_ai/script.s` - All comment-strings have been updated to use `//` rather than `;` as a prefix.