### PR TITLE
Fix inaccurate labels for blocks calling SetWarpEventPos

### DIFF
--- a/res/field/scripts/scripts_acuity_lakefront.s
+++ b/res/field/scripts/scripts_acuity_lakefront.s
@@ -9,25 +9,25 @@
     ScriptEntryEnd
 
 _0012:
-    GoToIfUnset FLAG_TEAM_GALACTIC_LEFT_LAKE_VERITY, AcuityLakefront_SetWarpsLakeAcuityNormal
-    GoToIfSet FLAG_TEAM_GALACTIC_LEFT_LAKE_VERITY, AcuityLakefront_SetWarpsLakeAcuityLowWater
+    GoToIfUnset FLAG_TEAM_GALACTIC_LEFT_LAKE_VERITY, AcuityLakefront_RemoveWarpsLakeAcuityNormal
+    GoToIfSet FLAG_TEAM_GALACTIC_LEFT_LAKE_VERITY, AcuityLakefront_RemoveWarpsLakeAcuityLowWater
     End
 
-AcuityLakefront_SetWarpsLakeAcuityNormal:
-    SetWarpEventPos 2, 0x131, 229
-    SetWarpEventPos 3, 0x132, 229
+AcuityLakefront_RemoveWarpsLakeAcuityNormal:
+    SetWarpEventPos 2, 305, 229
+    SetWarpEventPos 3, 306, 229
     End
 
-AcuityLakefront_SetWarpsLakeAcuityLowWater:
-    SetWarpEventPos 0, 0x131, 229
-    SetWarpEventPos 1, 0x132, 229
+AcuityLakefront_RemoveWarpsLakeAcuityLowWater:
+    SetWarpEventPos 0, 305, 229
+    SetWarpEventPos 1, 306, 229
     End
 
 _004E:
     CheckBadgeAcquired BADGE_ID_ICICLE, VAR_MAP_LOCAL_0
     CallIfEq VAR_MAP_LOCAL_0, TRUE, _0079
-    GoToIfUnset FLAG_TEAM_GALACTIC_LEFT_LAKE_VERITY, AcuityLakefront_SetWarpsLakeAcuityNormal
-    GoToIfSet FLAG_TEAM_GALACTIC_LEFT_LAKE_VERITY, AcuityLakefront_SetWarpsLakeAcuityLowWater
+    GoToIfUnset FLAG_TEAM_GALACTIC_LEFT_LAKE_VERITY, AcuityLakefront_RemoveWarpsLakeAcuityNormal
+    GoToIfSet FLAG_TEAM_GALACTIC_LEFT_LAKE_VERITY, AcuityLakefront_RemoveWarpsLakeAcuityLowWater
     End
 
 _0079:

--- a/res/field/scripts/scripts_mt_coronet_1f_north_room_2.s
+++ b/res/field/scripts/scripts_mt_coronet_1f_north_room_2.s
@@ -9,8 +9,8 @@
 MtCoronet1FNorthRoom2_OnTransition:
     CallIfNe VAR_ICEBERG_RUINS_STATE, RUINS_STATE_CAUGHT_REGI, MtCoronet1FNorthRoom2_ResetIcebergRuinsState
     CheckPartyHasFatefulEncounterRegigigas VAR_MAP_LOCAL_1
-    GoToIfEq VAR_MAP_LOCAL_1, FALSE, MtCoronet1FNorthRoom2_SetWarpEventIcebergRuins
-    GoToIfEq VAR_MAP_LOCAL_1, TRUE, MtCoronet1FNorthRoom2_SetWarpEventMtCoronetIcebergRuins
+    GoToIfEq VAR_MAP_LOCAL_1, FALSE, MtCoronet1FNorthRoom2_RemoveWarpIcebergRuinsWithRegice
+    GoToIfEq VAR_MAP_LOCAL_1, TRUE, MtCoronet1FNorthRoom2_RemoveWarpIcebergRuinsWithoutRegice
     End
 
 MtCoronet1FNorthRoom2_ResetIcebergRuinsState:
@@ -19,15 +19,15 @@ MtCoronet1FNorthRoom2_ResetIcebergRuinsState:
 
 MtCoronet1FNorthRoom2_OnLoad:
     CheckPartyHasFatefulEncounterRegigigas VAR_MAP_LOCAL_1
-    GoToIfEq VAR_MAP_LOCAL_1, FALSE, MtCoronet1FNorthRoom2_SetWarpEventIcebergRuins
-    GoToIfEq VAR_MAP_LOCAL_1, TRUE, MtCoronet1FNorthRoom2_SetWarpEventMtCoronetIcebergRuins
+    GoToIfEq VAR_MAP_LOCAL_1, FALSE, MtCoronet1FNorthRoom2_RemoveWarpIcebergRuinsWithRegice
+    GoToIfEq VAR_MAP_LOCAL_1, TRUE, MtCoronet1FNorthRoom2_RemoveWarpIcebergRuinsWithoutRegice
     End
 
-MtCoronet1FNorthRoom2_SetWarpEventIcebergRuins:
+MtCoronet1FNorthRoom2_RemoveWarpIcebergRuinsWithRegice:
     SetWarpEventPos 3, 17, 16
     End
 
-MtCoronet1FNorthRoom2_SetWarpEventMtCoronetIcebergRuins:
+MtCoronet1FNorthRoom2_RemoveWarpIcebergRuinsWithoutRegice:
     SetWarpEventPos 2, 17, 16
     End
 

--- a/res/field/scripts/scripts_mt_coronet_6f.s
+++ b/res/field/scripts/scripts_mt_coronet_6f.s
@@ -6,59 +6,59 @@
     ScriptEntryEnd
 
 MtCoronet6F_OnTransition:
-    GoToIfSet FLAG_SPEAR_PILLAR_IS_DISTORTED, MtCoronet6F_SetWarpEventSpearPillarDistorted
-    GoToIfUnset FLAG_SPEAR_PILLAR_IS_DISTORTED, MtCoronet6F_TrySetWarpEventSpearPillarDialgaPalkia
+    GoToIfSet FLAG_SPEAR_PILLAR_IS_DISTORTED, MtCoronet6F_SetWarpSpearPillarDistorted
+    GoToIfUnset FLAG_SPEAR_PILLAR_IS_DISTORTED, MtCoronet6F_TrySetWarpSpearPillarDialgaPalkia
     End
 
 MtCoronet6F_OnLoad:
-    Call MtCoronet6F_SetDefaultWarpEvents
-    GoToIfSet FLAG_SPEAR_PILLAR_IS_DISTORTED, MtCoronet6F_SetWarpEventSpearPillarDistorted
-    GoToIfUnset FLAG_SPEAR_PILLAR_IS_DISTORTED, MtCoronet6F_TrySetWarpEventSpearPillarDialgaPalkia
+    Call MtCoronet6F_RemoveSpearPillarWarps
+    GoToIfSet FLAG_SPEAR_PILLAR_IS_DISTORTED, MtCoronet6F_SetWarpSpearPillarDistorted
+    GoToIfUnset FLAG_SPEAR_PILLAR_IS_DISTORTED, MtCoronet6F_TrySetWarpSpearPillarDialgaPalkia
     End
 
-MtCoronet6F_SetWarpEventSpearPillarDistorted:
+MtCoronet6F_SetWarpSpearPillarDistorted:
     SetWarpEventPos 2, 7, 5
     End
 
-MtCoronet6F_TrySetWarpEventSpearPillarDialgaPalkia:
-    GoToIfGe VAR_EXITED_DISTORTION_WORLD_STATE, 2, MtCoronet6F_TrySetWarpEventSpearPillarDialga
-    GoTo MtCoronet6F_SetWarpEventSpearPillar
+MtCoronet6F_TrySetWarpSpearPillarDialgaPalkia:
+    GoToIfGe VAR_EXITED_DISTORTION_WORLD_STATE, 2, MtCoronet6F_TrySetWarpSpearPillarDialga
+    GoTo MtCoronet6F_SetWarpSpearPillarNormal
     End
 
-MtCoronet6F_SetWarpEventSpearPillar:
+MtCoronet6F_SetWarpSpearPillarNormal:
     SetWarpEventPos 1, 7, 5
     End
 
-MtCoronet6F_TrySetWarpEventSpearPillarDialga:
-    GoToIfUnset FLAG_UNK_0x0145, MtCoronet6F_SetWarpEventSpearPillar
-    GoToIfSet FLAG_CAUGHT_DIALGA, MtCoronet6F_TrySetWarpEventSpearPillarPalkia
-    GoToIfGe VAR_SPEAR_PILLAR_DIALGA_STATE, 1, MtCoronet6F_TrySetWarpEventSpearPillarPalkia
+MtCoronet6F_TrySetWarpSpearPillarDialga:
+    GoToIfUnset FLAG_UNK_0x0145, MtCoronet6F_SetWarpSpearPillarNormal
+    GoToIfSet FLAG_CAUGHT_DIALGA, MtCoronet6F_TrySetWarpSpearPillarPalkia
+    GoToIfGe VAR_SPEAR_PILLAR_DIALGA_STATE, 1, MtCoronet6F_TrySetWarpSpearPillarPalkia
     CheckItem ITEM_ADAMANT_ORB, 1, VAR_MAP_LOCAL_1
-    GoToIfEq VAR_MAP_LOCAL_1, 1, MtCoronet6F_SetWarpEventSpearPillarDialga
+    GoToIfEq VAR_MAP_LOCAL_1, TRUE, MtCoronet6F_SetWarpSpearPillarDialga
     CheckPartyHasHeldItem ITEM_ADAMANT_ORB, VAR_MAP_LOCAL_1
-    GoToIfEq VAR_MAP_LOCAL_1, 1, MtCoronet6F_SetWarpEventSpearPillarDialga
-    GoTo MtCoronet6F_TrySetWarpEventSpearPillarPalkia
+    GoToIfEq VAR_MAP_LOCAL_1, TRUE, MtCoronet6F_SetWarpSpearPillarDialga
+    GoTo MtCoronet6F_TrySetWarpSpearPillarPalkia
     End
 
-MtCoronet6F_TrySetWarpEventSpearPillarPalkia:
-    GoToIfSet FLAG_CAUGHT_PALKIA, MtCoronet6F_SetWarpEventSpearPillar
-    GoToIfGe VAR_SPEAR_PILLAR_PALKIA_STATE, 1, MtCoronet6F_SetWarpEventSpearPillar
+MtCoronet6F_TrySetWarpSpearPillarPalkia:
+    GoToIfSet FLAG_CAUGHT_PALKIA, MtCoronet6F_SetWarpSpearPillarNormal
+    GoToIfGe VAR_SPEAR_PILLAR_PALKIA_STATE, 1, MtCoronet6F_SetWarpSpearPillarNormal
     CheckItem ITEM_LUSTROUS_ORB, 1, VAR_MAP_LOCAL_1
-    GoToIfEq VAR_MAP_LOCAL_1, 1, MtCoronet6F_SetWarpEventSpearPillarPalkia
+    GoToIfEq VAR_MAP_LOCAL_1, TRUE, MtCoronet6F_SetWarpSpearPillarPalkia
     CheckPartyHasHeldItem ITEM_LUSTROUS_ORB, VAR_MAP_LOCAL_1
-    GoToIfEq VAR_MAP_LOCAL_1, 1, MtCoronet6F_SetWarpEventSpearPillarPalkia
-    GoTo MtCoronet6F_SetWarpEventSpearPillar
+    GoToIfEq VAR_MAP_LOCAL_1, TRUE, MtCoronet6F_SetWarpSpearPillarPalkia
+    GoTo MtCoronet6F_SetWarpSpearPillarNormal
     End
 
-MtCoronet6F_SetWarpEventSpearPillarDialga:
+MtCoronet6F_SetWarpSpearPillarDialga:
     SetWarpEventPos 3, 7, 5
     End
 
-MtCoronet6F_SetWarpEventSpearPillarPalkia:
+MtCoronet6F_SetWarpSpearPillarPalkia:
     SetWarpEventPos 4, 7, 5
     End
 
-MtCoronet6F_SetDefaultWarpEvents:
+MtCoronet6F_RemoveSpearPillarWarps:
     SetWarpEventPos 1, 1, 5
     SetWarpEventPos 2, 1, 5
     SetWarpEventPos 3, 1, 5

--- a/res/field/scripts/scripts_route_214.s
+++ b/res/field/scripts/scripts_route_214.s
@@ -10,31 +10,31 @@
 
 Route214_OnLoad:
     GetUnownFormsSeenCount VAR_MAP_LOCAL_0
-    GoToIfGe VAR_MAP_LOCAL_0, 26, Route214_SetWarpEventManiacTunnel
-    GoToIfGe VAR_MAP_LOCAL_0, 10, Route214_SetWarpEventRuinManiacCaveLong
-    GoToIfLt VAR_MAP_LOCAL_0, 10, Route214_SetWarpEventRuinManiacCaveShort
+    GoToIfGe VAR_MAP_LOCAL_0, 26, Route214_RemoveWarpsManiacCaveShortAndLong
+    GoToIfGe VAR_MAP_LOCAL_0, 10, Route214_RemoveWarpsManiacCaveShortAndTunnel
+    GoToIfLt VAR_MAP_LOCAL_0, 10, Route214_RemoveWarpsManiacCaveLongAndTunnel
     End
 
-Route214_SetWarpEventManiacTunnel:
+Route214_RemoveWarpsManiacCaveShortAndLong:
     SetWarpEventPos 2, 710, 670
     SetWarpEventPos 3, 710, 670
     End
 
-Route214_SetWarpEventRuinManiacCaveLong:
+Route214_RemoveWarpsManiacCaveShortAndTunnel:
     SetWarpEventPos 2, 710, 670
     SetWarpEventPos 4, 710, 670
     End
 
-Route214_SetWarpEventRuinManiacCaveShort:
+Route214_RemoveWarpsManiacCaveLongAndTunnel:
     SetWarpEventPos 3, 710, 670
     SetWarpEventPos 4, 710, 670
     End
 
 Route214_OnTransition:
     GetUnownFormsSeenCount VAR_MAP_LOCAL_0
-    GoToIfGe VAR_MAP_LOCAL_0, 26, Route214_SetWarpEventManiacTunnel
-    GoToIfGe VAR_MAP_LOCAL_0, 10, Route214_SetWarpEventRuinManiacCaveLong
-    GoToIfLt VAR_MAP_LOCAL_0, 10, Route214_SetWarpEventRuinManiacCaveShort
+    GoToIfGe VAR_MAP_LOCAL_0, 26, Route214_RemoveWarpsManiacCaveShortAndLong
+    GoToIfGe VAR_MAP_LOCAL_0, 10, Route214_RemoveWarpsManiacCaveShortAndTunnel
+    GoToIfLt VAR_MAP_LOCAL_0, 10, Route214_RemoveWarpsManiacCaveLongAndTunnel
     End
 
 Route214_ArrowSignVeilstoneCity:

--- a/res/field/scripts/scripts_valley_windworks_outside.s
+++ b/res/field/scripts/scripts_valley_windworks_outside.s
@@ -18,8 +18,8 @@ ValleyWindworksOutside_OnResume:
 
 ValleyWindworksOutside_OnTransition:
     CallIfEq VAR_VALLEY_WINDWORKS_TEAM_GALACTIC_STATE, 2, ValleyWindworksOutside_IncreaseTeamGalacticValleyWindworksState
-    CallIfSet FLAG_UNLOCKED_VALLEY_WINDWORKS_DOOR, ValleyWindworksOutside_SetDoorBgEvent
-    CallIfUnset FLAG_UNLOCKED_VALLEY_WINDWORKS_DOOR, ValleyWindworksOutside_SetDoorWarpEvent
+    CallIfSet FLAG_UNLOCKED_VALLEY_WINDWORKS_DOOR, ValleyWindworksOutside_RemoveBgEventDoor
+    CallIfUnset FLAG_UNLOCKED_VALLEY_WINDWORKS_DOOR, ValleyWindworksOutside_RemoveWarpValleyWindworksBuilding
     GoToIfLt VAR_VALLEY_WINDWORKS_STATE, 2, ValleyWindworksOutside_HideDrifloon
     GoToIfSet FLAG_WON_AGAINST_VALLEY_WINDWORKS_OUTSIDE_DRIFLOON, ValleyWindworksOutside_HideDrifloon
     GetDayOfWeek VAR_MAP_LOCAL_0
@@ -39,8 +39,8 @@ ValleyWindworksOutside_IncreaseTeamGalacticValleyWindworksState:
     Return
 
 ValleyWindworksOutside_OnLoad:
-    CallIfSet FLAG_UNLOCKED_VALLEY_WINDWORKS_DOOR, ValleyWindworksOutside_SetDoorBgEvent
-    CallIfUnset FLAG_UNLOCKED_VALLEY_WINDWORKS_DOOR, ValleyWindworksOutside_SetDoorWarpEvent
+    CallIfSet FLAG_UNLOCKED_VALLEY_WINDWORKS_DOOR, ValleyWindworksOutside_RemoveBgEventDoor
+    CallIfUnset FLAG_UNLOCKED_VALLEY_WINDWORKS_DOOR, ValleyWindworksOutside_RemoveWarpValleyWindworksBuilding
     GoToIfSet FLAG_MAP_LOCAL, ValleyWindworksOutside_RemoveDrifloon
     End
 
@@ -50,11 +50,11 @@ ValleyWindworksOutside_RemoveDrifloon:
     ClearFlag FLAG_MAP_LOCAL
     End
 
-ValleyWindworksOutside_SetDoorBgEvent:
+ValleyWindworksOutside_RemoveBgEventDoor:
     SetBgEventPos 1, 243, 650
     Return
 
-ValleyWindworksOutside_SetDoorWarpEvent:
+ValleyWindworksOutside_RemoveWarpValleyWindworksBuilding:
     SetWarpEventPos 0, 243, 650
     Return
 
@@ -117,7 +117,7 @@ ValleyWindworksOutside_AskOpenDoor:
     ShowYesNoMenu VAR_RESULT
     GoToIfEq VAR_RESULT, MENU_NO, ValleyWindworksOutside_AskOpenDoorEnd
     SetFlag FLAG_UNLOCKED_VALLEY_WINDWORKS_DOOR
-    Call ValleyWindworksOutside_SetDoorBgEvent
+    Call ValleyWindworksOutside_RemoveBgEventDoor
     SetWarpEventPos 0, 243, 654
     Message ValleyWindworksOutside_Text_KerchunkTheDoorToValleyWindworksOpened
     WaitButton

--- a/res/field/scripts/scripts_valor_cavern.s
+++ b/res/field/scripts/scripts_valor_cavern.s
@@ -11,23 +11,23 @@
 
 ValorCavern_OnTransition:
     SetFlag FLAG_FIRST_ARRIVAL_VALOR_CAVERN
-    GoToIfUnset FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorCavern_SetWarpEventLakeValorDrained
-    GoToIfSet FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorCavern_SetWarpEventLakeValor
+    GoToIfUnset FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorCavern_RemoveWarpLakeValorNormal
+    GoToIfSet FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorCavern_RemoveWarpLakeValorDrained
     End
 
-ValorCavern_SetWarpEventLakeValorDrained:
+ValorCavern_RemoveWarpLakeValorNormal:
     SetWarpEventPos 1, 10, 29
     End
 
-ValorCavern_SetWarpEventLakeValor:
+ValorCavern_RemoveWarpLakeValorDrained:
     SetWarpEventPos 0, 10, 29
     End
 
 ValorCavern_OnLoad:
     SetFlag FLAG_FIRST_ARRIVAL_VALOR_CAVERN
     CallIfSet FLAG_MAP_LOCAL, ValorCavern_RemoveAzelf
-    GoToIfUnset FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorCavern_SetWarpEventLakeValorDrained
-    GoToIfSet FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorCavern_SetWarpEventLakeValor
+    GoToIfUnset FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorCavern_RemoveWarpLakeValorNormal
+    GoToIfSet FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorCavern_RemoveWarpLakeValorDrained
     End
 
 ValorCavern_RemoveAzelf:

--- a/res/field/scripts/scripts_valor_lakefront.s
+++ b/res/field/scripts/scripts_valor_lakefront.s
@@ -16,8 +16,8 @@
 
 ValorLakefront_OnTransition:
     CallIfSet FLAG_TALKED_TO_VALOR_LAKEFRONT_GRUNT_M, ValorLakefront_SetGruntMPositionNorth
-    GoToIfUnset FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorLakefront_SetWarpEventsLakeValorDrained
-    GoToIfSet FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorLakefront_SetWarpEventsLakeValor
+    GoToIfUnset FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorLakefront_RemoveWarpsLakeValorNormal
+    GoToIfSet FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorLakefront_RemoveWarpsLakeValorDrained
     End
     End
 
@@ -28,16 +28,16 @@ ValorLakefront_SetGruntMPositionNorth:
     Return
 
 ValorLakefront_OnLoad:
-    GoToIfUnset FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorLakefront_SetWarpEventsLakeValorDrained
-    GoToIfSet FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorLakefront_SetWarpEventsLakeValor
+    GoToIfUnset FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorLakefront_RemoveWarpsLakeValorNormal
+    GoToIfSet FLAG_GALACTIC_LEFT_LAKE_VALOR, ValorLakefront_RemoveWarpsLakeValorDrained
     End
 
-ValorLakefront_SetWarpEventsLakeValorDrained:
+ValorLakefront_RemoveWarpsLakeValorNormal:
     SetWarpEventPos 5, 713, 760
     SetWarpEventPos 6, 713, 761
     End
 
-ValorLakefront_SetWarpEventsLakeValor:
+ValorLakefront_RemoveWarpsLakeValorDrained:
     SetWarpEventPos 3, 713, 760
     SetWarpEventPos 4, 713, 761
     End

--- a/res/field/scripts/scripts_verity_lakefront.s
+++ b/res/field/scripts/scripts_verity_lakefront.s
@@ -9,23 +9,23 @@
     ScriptEntryEnd
 
 VerityLakefront_OnLoad:
-    GoToIfUnset FLAG_DEFEATED_COMMANDER_SATURN_VALOR_CAVERN, VerityLakefront_SetWarpsLakeVerityNormal
-    GoToIfSet FLAG_DEFEATED_COMMANDER_SATURN_VALOR_CAVERN, VerityLakefront_SetWarpsLakeVerityLowWater
+    GoToIfUnset FLAG_DEFEATED_COMMANDER_SATURN_VALOR_CAVERN, VerityLakefront_RemoveWarpsLakeVerityNormal
+    GoToIfSet FLAG_DEFEATED_COMMANDER_SATURN_VALOR_CAVERN, VerityLakefront_RemoveWarpsLakeVerityLowWater
     End
 
-VerityLakefront_SetWarpsLakeVerityNormal:
-    SetWarpEventPos 2, 80, 0x348
-    SetWarpEventPos 3, 81, 0x348
+VerityLakefront_RemoveWarpsLakeVerityNormal:
+    SetWarpEventPos 2, 80, 840
+    SetWarpEventPos 3, 81, 840
     End
 
-VerityLakefront_SetWarpsLakeVerityLowWater:
-    SetWarpEventPos 1, 80, 0x348
-    SetWarpEventPos 0, 81, 0x348
+VerityLakefront_RemoveWarpsLakeVerityLowWater:
+    SetWarpEventPos 1, 80, 840
+    SetWarpEventPos 0, 81, 840
     End
 
 VerityLakefront_OnTransition:
-    GoToIfUnset FLAG_DEFEATED_COMMANDER_SATURN_VALOR_CAVERN, VerityLakefront_SetWarpsLakeVerityNormal
-    GoToIfSet FLAG_DEFEATED_COMMANDER_SATURN_VALOR_CAVERN, VerityLakefront_SetWarpsLakeVerityLowWater
+    GoToIfUnset FLAG_DEFEATED_COMMANDER_SATURN_VALOR_CAVERN, VerityLakefront_RemoveWarpsLakeVerityNormal
+    GoToIfSet FLAG_DEFEATED_COMMANDER_SATURN_VALOR_CAVERN, VerityLakefront_RemoveWarpsLakeVerityLowWater
     End
 
 VerityLakefront_TriggerWereAtTheLake:


### PR DESCRIPTION
`SetWarpEventPos` is mostly used to "remove" warp events by moving them away from the correct position while leaving the intended warp event at that position. So far, blocks with `SetWarpEventPos` calls were not labeled to reflect that, so this PR fixes that.

Spear pillar works differently, first all the warp events get "removed" (moved away) in `MtCoronet6F_RemoveSpearPillarWarps`, and then only one warp event gets moved back (for example in `MtCoronet6F_SetWarpSpearPillarDistorted`).