### PR TITLE
build: Share a generator for all battle-animation scripts

### DIFF
--- a/res/battle/meson.build
+++ b/res/battle/meson.build
@@ -1,3 +1,35 @@
+# We must walk into this directory first; all other battle-scripts need access
+# to the index for the battle particles NARC.
 subdir('particles')
+
+# This generator is shared by both move-specific animations (in the `moves`
+# directory) and common animations (in the `scripts/common_anims` directory).
+battle_anim_script_bin_gen = generator(make_script_bin_sh,
+    arguments: [
+        '-i', relative_source_root / 'include',
+        '-i', relative_source_root / 'asm',
+        '-i', '.' / 'res' / 'text',
+        '-i', '.' / 'res',
+        '-i', '.',
+        '--depfile',
+        '--assembler', arm_none_eabi_gcc_exe.full_path(),
+        '--objcopy', arm_none_eabi_objcopy_exe.full_path(),
+        '@EXTRA_ARGS@',
+        '@INPUT@',
+    ],
+    depends: [
+        text_banks,
+        c_consts_generators,
+        h_headers,
+        battle_particles_narc[1],
+        anim_ncer_narc_files[1],
+        anim_nanr_narc_files[1],
+        anim_ncgr_narc_files[1],
+        anim_nclr_narc_files[1],
+    ],
+    output: '@BASENAME@',
+    depfile: '@BASENAME@.d',
+)
+
 subdir('moves')
 subdir('scripts')

--- a/res/battle/moves/meson.build
+++ b/res/battle/moves/meson.build
@@ -72,34 +72,6 @@ pl_waza_tbl_narc = custom_target('pl_waza_tbl.narc',
     ]
 )
 
-battle_anim_script_bin_gen = generator(make_script_bin_sh,
-    arguments: [
-        '-i', relative_source_root / 'include',
-        '-i', relative_source_root / 'asm',
-        '-i', '.' / 'res' / 'text',
-        '-i', '.' / 'res',
-        '-i', '.',
-        '--depfile',
-        '-P', # Preserve parent dir in output file name
-        '--assembler', arm_none_eabi_gcc_exe.full_path(),
-        '--objcopy', arm_none_eabi_objcopy_exe.full_path(),
-        '@EXTRA_ARGS@',
-        '@INPUT@',
-    ],
-    depends: [
-        text_banks,
-        c_consts_generators,
-        h_headers,
-        battle_particles_narc[1],
-        anim_ncer_narc_files[1],
-        anim_nanr_narc_files[1],
-        anim_ncgr_narc_files[1],
-        anim_nclr_narc_files[1],
-    ],
-    output: '@BASENAME@',
-    depfile: '@BASENAME@.d',
-)
-
 anim_script_srcs = []
 foreach subdir : anim_script_subdirs
     anim_script_srcs += subdir / 'anim.s'
@@ -127,7 +99,7 @@ anim_scripts_narc = custom_target(anim_scripts_narc_name,
     ],
     input: battle_anim_script_bin_gen.process(
         anim_script_srcs,
-        extra_args: ['--out-dir', anim_scripts_private_dir],
+        extra_args: ['--out-dir', anim_scripts_private_dir, '--parent-dir'],
         preserve_path_from: anim_scripts_root,
     ),
     command: [

--- a/res/battle/scripts/common_anims/meson.build
+++ b/res/battle/scripts/common_anims/meson.build
@@ -65,7 +65,7 @@ anim_subscripts_narc = custom_target(anim_subscripts_narc_name,
         anim_subscripts_narc_name,
         anim_subscripts_naix_name,
     ],
-    input: script_bin_gen.process(
+    input: battle_anim_script_bin_gen.process(
         anim_subscript_files,
         extra_args: [ '--out-dir', anim_subscripts_private_dir, ]
     ),


### PR DESCRIPTION
The generator used for `anim_subscripts.narc` did not declare its dependency on the `battle_particles.naix`. This could result in Ninja choosing to build those subscripts first, which results in an assembler error.