### PR TITLE
Rename overworld anim manager ID field

### DIFF
--- a/include/overlay005/dist_world_surf_mount_renderer.h
+++ b/include/overlay005/dist_world_surf_mount_renderer.h
@@ -34,7 +34,7 @@ enum DistWorldSurfMountRendererFlagMask {
 
 void *DistWorldSurfMountRenderer_New(FieldEffectManager *fieldEffMan);
 void DistWorldSurfMountRenderer_Free(void *context);
-OverworldAnimManager *DistWorldSurfMountRenderer_HandleSurfBegin(PlayerAvatar *playerAvatar, int mountTileX, int mountTileY, int mountTileZ, enum FaceDirection dir, BOOL reuseMapObjPos, enum AvatarDistortionState avatarDistortionState);
+OverworldAnimManager *DistWorldSurfMountRenderer_HandleSurfBegin(PlayerAvatar *playerAvatar, int mountTileX, int mountTileY, int mountTileZ, enum FaceDirection dir, BOOL syncPos, enum AvatarDistortionState avatarDistortionState);
 Simple3DRotationAngles *DistWorldSurfMountRenderer_GetSurfMountRotationAngles(OverworldAnimManager *animMan);
 void DistWorldSurfMountRenderer_SetFixedRotationAngles(OverworldAnimManager *animMan, enum FaceDirection dir, enum AvatarDistortionState avatarDistortionState);
 void DistWorldSurfMountRenderer_SetFlags(OverworldAnimManager *animMan, int mask);

--- a/include/overlay005/field_effect_manager.h
+++ b/include/overlay005/field_effect_manager.h
@@ -48,7 +48,7 @@ FieldEffectManager *MapObject_GetFieldEffectManager(const MapObject *mapObject);
 u32 FieldEffectManager_GetNARCMemberSize(FieldEffectManager *fieldEffMan, u32 memberIndex);
 void FieldEffectManager_ReadNARCWholeMember(FieldEffectManager *fieldEffMan, u32 memberIndex, void *dest);
 void *FieldEffectManager_AllocAndReadNARCWholeMember(FieldEffectManager *fieldEffMan, u32 memberIndex, BOOL allocAtEnd);
-OverworldAnimManager *FieldEffectManager_InitAnimManager(const FieldEffectManager *fieldEffMan, const OverworldAnimManagerFuncs *funcs, const VecFx32 *initialPos, int animId, const void *userData, int sysTaskPriority);
+OverworldAnimManager *FieldEffectManager_InitAnimManager(const FieldEffectManager *fieldEffMan, const OverworldAnimManagerFuncs *funcs, const VecFx32 *initialPos, int userInt, const void *userData, int sysTaskPriority);
 void FieldEffectManager_FinishAnimManager(OverworldAnimManager *animMan);
 Billboard *ov5_021DF7F8(FieldEffectManager *param0, const BillboardResources *param1, const VecFx32 *param2);
 Billboard *ov5_021DF84C(FieldEffectManager *param0, u32 param1, const VecFx32 *param2);

--- a/include/overlay005/surf_mount_renderer.h
+++ b/include/overlay005/surf_mount_renderer.h
@@ -9,7 +9,7 @@
 
 void *SurfMountRenderer_New(FieldEffectManager *fieldEffMan);
 void SurfMountRenderer_Free(void *context);
-OverworldAnimManager *SurfMountRenderer_HandleSurfBegin(MapObject *surfMountMapObj, int tileX, int tileZ, int dir, int reuseMapObjPos);
-void SurfMountRenderer_Reset(OverworldAnimManager *animMan, int animID);
+OverworldAnimManager *SurfMountRenderer_HandleSurfBegin(MapObject *surfMountMapObj, int tileX, int tileZ, int dir, BOOL syncPos);
+void SurfMountRenderer_SetSyncPos(OverworldAnimManager *animMan, BOOL syncPos);
 
 #endif // POKEPLATINUM_SURF_MOUNT_RENDERER_H

--- a/include/overworld_anim_manager.h
+++ b/include/overworld_anim_manager.h
@@ -47,7 +47,7 @@ enum OverworldAnimManagerFlags {
 
 struct OverworldAnimManager {
     u32 flags;
-    int id;
+    int userInt;
     int distWorldGhostPropKind;
     const void *userData;
     SysTask *tickSysTask;
@@ -68,8 +68,8 @@ struct OverworldAnimManager {
 OverworldAnimManagerList *OverworldAnimManagerList_New(enum HeapID heapID, int managerCount);
 void OverworldAnimManagerList_Free(OverworldAnimManagerList *managerList);
 void OverworldAnimManagerList_FinishAndFree(OverworldAnimManagerList *managerList);
-OverworldAnimManager *OverworldAnimManagerList_InitManagerEx(OverworldAnimManagerList *managerList, const OverworldAnimManagerExtendedFuncs *funcs, const VecFx32 *initialPos, int id, const void *userData, int sysTaskPriority);
-OverworldAnimManager *OverworldAnimManagerList_InitManager(OverworldAnimManagerList *managerList, const OverworldAnimManagerFuncs *funcs, const VecFx32 *initialPos, int id, const void *userData, int sysTaskPriority);
+OverworldAnimManager *OverworldAnimManagerList_InitManagerEx(OverworldAnimManagerList *managerList, const OverworldAnimManagerExtendedFuncs *funcs, const VecFx32 *initialPos, int userInt, const void *userData, int sysTaskPriority);
+OverworldAnimManager *OverworldAnimManagerList_InitManager(OverworldAnimManagerList *managerList, const OverworldAnimManagerFuncs *funcs, const VecFx32 *initialPos, int userInt, const void *userData, int sysTaskPriority);
 void OverworldAnimManager_Finish(OverworldAnimManager *manager);
 void OverworldAnimManagerList_Finish(OverworldAnimManagerList *managerList);
 void OverworldAnimManagerList_Render(OverworldAnimManagerList *managerList);
@@ -86,7 +86,7 @@ void OverworldAnimManager_SetUnused1Func(OverworldAnimManager *manager, Overworl
 void OverworldAnimManager_SetUnused2Func(OverworldAnimManager *manager, OverworldAnimManager_Unused2Func unused2Func);
 void *OverworldAnimManager_GetFuncsContext(OverworldAnimManager *manager);
 void OverworldAnimManager_ResetFuncsContext(OverworldAnimManager *manager, int ctxSize);
-int OverworldAnimManager_GetID(const OverworldAnimManager *manager);
+int OverworldAnimManager_GetUserInt(const OverworldAnimManager *manager);
 const void *OverworldAnimManager_GetUserData(const OverworldAnimManager *manager);
 void OverworldAnimManager_SetDistWorldGhostPropKind(OverworldAnimManager *manager, int kind);
 int OverworldAnimManager_GetDistWorldGhostPropKind(const OverworldAnimManager *manager);

--- a/src/overlay005/dist_world_surf_mount_renderer.c
+++ b/src/overlay005/dist_world_surf_mount_renderer.c
@@ -98,7 +98,7 @@ static void DistWorldSurfMountResources_Free(DistWorldSurfMountResources *resour
     Simple3D_FreeModel(&resources->surfMountModel);
 }
 
-OverworldAnimManager *DistWorldSurfMountRenderer_HandleSurfBegin(PlayerAvatar *playerAvatar, int mountTileX, int mountTileY, int mountTileZ, enum FaceDirection dir, BOOL reuseMapObjPos, enum AvatarDistortionState avatarDistortionState)
+OverworldAnimManager *DistWorldSurfMountRenderer_HandleSurfBegin(PlayerAvatar *playerAvatar, int mountTileX, int mountTileY, int mountTileZ, enum FaceDirection dir, BOOL syncPos, enum AvatarDistortionState avatarDistortionState)
 {
     VecFx32 mountPos = { 0, 0, 0 };
     DistWorldSurfMountUserData userData;
@@ -111,7 +111,7 @@ OverworldAnimManager *DistWorldSurfMountRenderer_HandleSurfBegin(PlayerAvatar *p
     userData.playerMapObj = playerMapObj;
     userData.playerAvatar = playerAvatar;
 
-    if (!reuseMapObjPos) {
+    if (!syncPos) {
         FieldSystem *fieldSystem = MapObject_FieldSystem(playerMapObj);
         const VecFx32 *mountPosFix = &sInitialMountPosFixes[avatarDistortionState];
 
@@ -126,7 +126,7 @@ OverworldAnimManager *DistWorldSurfMountRenderer_HandleSurfBegin(PlayerAvatar *p
     }
 
     int taskPriority = MapObject_CalculateTaskPriority(playerMapObj, 2);
-    OverworldAnimManager *animMan = FieldEffectManager_InitAnimManager(userData.fieldEffMan, &sDistWorldSurfMountRendererAnimFuncs, &mountPos, reuseMapObjPos, &userData, taskPriority);
+    OverworldAnimManager *animMan = FieldEffectManager_InitAnimManager(userData.fieldEffMan, &sDistWorldSurfMountRendererAnimFuncs, &mountPos, syncPos, &userData, taskPriority);
 
     return animMan;
 }
@@ -145,7 +145,7 @@ static BOOL DistWorldSurfMountRenderer_AnimInit(OverworldAnimManager *animMan, v
     renderer->orbitAngle = sOrbitAngles[renderer->avatarDistortionState];
     renderer->orbitDistance = MOUNT_ORBIT_DISTANCE;
 
-    if (OverworldAnimManager_GetID(animMan) == 1) {
+    if (OverworldAnimManager_GetUserInt(animMan) == TRUE) {
         renderer->flags |= DIST_WORLD_SURF_MOUNT_RENDERER_FLAG_MASK_TICK;
     }
 

--- a/src/overlay005/field_effect_manager.c
+++ b/src/overlay005/field_effect_manager.c
@@ -348,10 +348,10 @@ static void RenderFieldEffects(FieldEffectManager *fieldEffMan)
     }
 }
 
-OverworldAnimManager *FieldEffectManager_InitAnimManager(const FieldEffectManager *fieldEffMan, const OverworldAnimManagerFuncs *funcs, const VecFx32 *initialPos, int animId, const void *userData, int sysTaskPriority)
+OverworldAnimManager *FieldEffectManager_InitAnimManager(const FieldEffectManager *fieldEffMan, const OverworldAnimManagerFuncs *funcs, const VecFx32 *initialPos, int userInt, const void *userData, int sysTaskPriority)
 {
     OverworldAnimManagerList *animManList = fieldEffMan->animManList;
-    OverworldAnimManager *animMan = OverworldAnimManagerList_InitManager(animManList, funcs, initialPos, animId, userData, sysTaskPriority);
+    OverworldAnimManager *animMan = OverworldAnimManagerList_InitManager(animManList, funcs, initialPos, userInt, userData, sysTaskPriority);
 
     GF_ASSERT(animMan != NULL);
     return animMan;

--- a/src/overlay005/ov5_021DFB54.c
+++ b/src/overlay005/ov5_021DFB54.c
@@ -317,7 +317,7 @@ static void PlayerAvatar_RequestStateSurf(PlayerAvatar *playerAvatar)
     }
 
     if (distortionState == AVATAR_DISTORTION_STATE_NONE) {
-        v5 = SurfMountRenderer_HandleSurfBegin(mapObj, 0, 0, v1, 1);
+        v5 = SurfMountRenderer_HandleSurfBegin(mapObj, 0, 0, v1, TRUE);
         v0 = PLAYER_STATE_SURFING;
     } else {
         v5 = DistWorldSurfMountRenderer_HandleSurfBegin(playerAvatar, 0, 0, 0, v1, 1, distortionState);
@@ -681,7 +681,7 @@ static BOOL FieldTask_UseSurf(FieldTask *task)
         if (PlayerAvatar_MapDistortionState(taskEnv->playerAvatar) == AVATAR_DISTORTION_STATE_NONE) {
             int playerXPos = Player_GetXPos(taskEnv->playerAvatar) + MapObject_GetDxFromDir(taskEnv->direction);
             int playerZPos = Player_GetZPos(taskEnv->playerAvatar) + MapObject_GetDzFromDir(taskEnv->direction);
-            taskEnv->unk_28 = SurfMountRenderer_HandleSurfBegin(taskEnv->surfMount, playerXPos, playerZPos, taskEnv->direction, 0);
+            taskEnv->unk_28 = SurfMountRenderer_HandleSurfBegin(taskEnv->surfMount, playerXPos, playerZPos, taskEnv->direction, FALSE);
         } else {
             int mountXPos = MapObject_GetX(taskEnv->surfMount);
             int mountYPos = (MapObject_GetY(taskEnv->surfMount) / 2);
@@ -728,7 +728,7 @@ static BOOL FieldTask_UseSurf(FieldTask *task)
         if (PlayerAvatar_MapDistortionState(taskEnv->playerAvatar) == AVATAR_DISTORTION_STATE_NONE) {
             int moveState;
 
-            SurfMountRenderer_Reset(taskEnv->unk_28, 1);
+            SurfMountRenderer_SetSyncPos(taskEnv->unk_28, TRUE);
             moveState = Player_MoveStateFromGender(0x2, PlayerAvatar_Gender(taskEnv->playerAvatar));
             PlayerAvatar_Redraw(taskEnv->playerAvatar, moveState);
         } else {
@@ -805,7 +805,7 @@ static BOOL ov5_021E03C8(FieldTask *param0)
             enum AvatarDistortionState distortionState = PlayerAvatar_MapDistortionState(v0->playerAvatar);
 
             if (distortionState == AVATAR_DISTORTION_STATE_NONE) {
-                SurfMountRenderer_Reset(v0->unk_14, 0);
+                SurfMountRenderer_SetSyncPos(v0->unk_14, FALSE);
                 v1 = Player_MoveStateFromGender(0x0, PlayerAvatar_Gender(v0->playerAvatar));
             } else {
                 DistWorldSurfMountRenderer_ClearFlags(v0->unk_14, DIST_WORLD_SURF_MOUNT_RENDERER_FLAG_MASK_TICK);

--- a/src/overlay005/ov5_021F134C.c
+++ b/src/overlay005/ov5_021F134C.c
@@ -220,7 +220,7 @@ static int ov5_021F15B4(OverworldAnimManager *param0, void *param1)
     v1 = OverworldAnimManager_GetUserData(param0);
 
     v0->unk_14 = *v1;
-    v0->unk_10 = OverworldAnimManager_GetID(param0);
+    v0->unk_10 = OverworldAnimManager_GetUserInt(param0);
     v0->unk_00 = MapObject_GetGraphicsID(v0->unk_14.unk_08);
     v0->unk_04 = MapObject_GetLocalID(v0->unk_14.unk_08);
 
@@ -349,7 +349,7 @@ static void ov5_021F176C(OverworldAnimManager *param0, void *param1)
     }
 
     {
-        int v1 = OverworldAnimManager_GetID(param0);
+        int v1 = OverworldAnimManager_GetUserInt(param0);
         VecFx32 v2;
         Simple3DRenderObj *v3 = &v0->unk_14.unk_04->unk_64[v1];
 

--- a/src/overlay005/ov5_021F17B8.c
+++ b/src/overlay005/ov5_021F17B8.c
@@ -119,7 +119,7 @@ static int ov5_021F184C(OverworldAnimManager *param0, void *param1)
     v2 = OverworldAnimManager_GetUserData(param0);
 
     v1->unk_14 = *v2;
-    v1->unk_10 = OverworldAnimManager_GetID(param0);
+    v1->unk_10 = OverworldAnimManager_GetUserInt(param0);
     v1->unk_00 = MapObject_GetLocalID(v1->unk_14.unk_0C);
     v1->unk_04 = MapObject_GetMapID(v1->unk_14.unk_0C);
     v1->unk_08 = MapObject_GetGraphicsID(v1->unk_14.unk_0C);
@@ -374,7 +374,7 @@ static int ov5_021F1BEC(OverworldAnimManager *param0, void *param1)
     v2 = OverworldAnimManager_GetUserData(param0);
 
     v1->unk_04 = *v2;
-    v1->unk_00 = OverworldAnimManager_GetID(param0);
+    v1->unk_00 = OverworldAnimManager_GetUserInt(param0);
     v1->unk_40.x = FX32_ONE;
     v1->unk_40.y = FX32_ONE;
     v1->unk_40.z = FX32_ONE;

--- a/src/overlay005/ov5_021F1CC8.c
+++ b/src/overlay005/ov5_021F1CC8.c
@@ -234,7 +234,7 @@ static int ov5_021F1FB8(OverworldAnimManager *param0, void *param1)
     const UnkStruct_021F1FB8 *v2;
 
     v1 = param1;
-    v1->unk_10 = OverworldAnimManager_GetID(param0);
+    v1->unk_10 = OverworldAnimManager_GetUserInt(param0);
 
     v2 = OverworldAnimManager_GetUserData(param0);
     v1->unk_18 = v2->unk_08;

--- a/src/overlay005/ov5_021F2850.c
+++ b/src/overlay005/ov5_021F2850.c
@@ -150,7 +150,7 @@ static int ov5_021F2980(OverworldAnimManager *param0, void *param1)
 
     v0->unk_10 = *v1;
     v0->unk_04 = v1->unk_00;
-    v0->unk_0C = OverworldAnimManager_GetID(param0);
+    v0->unk_0C = OverworldAnimManager_GetUserInt(param0);
 
     ov5_021F28D4(v0->unk_10.unk_0C);
     ov5_021F2874(v0->unk_10.unk_0C);

--- a/src/overlay005/ov5_021F2D20.c
+++ b/src/overlay005/ov5_021F2D20.c
@@ -192,7 +192,7 @@ static int ov5_021F2F0C(OverworldAnimManager *param0, void *param1)
 
     v3->unk_34 = ov5_021DF84C(v3->unk_18.unk_10, 0, &v2);
 
-    if (OverworldAnimManager_GetID(param0) == 0) {
+    if (OverworldAnimManager_GetUserInt(param0) == 0) {
         v3->unk_00 = 1;
     }
 
@@ -415,7 +415,7 @@ static int ov5_021F31B4(OverworldAnimManager *param0, void *param1)
     v2 = param1;
     v3 = OverworldAnimManager_GetUserData(param0);
     v2->unk_10 = *v3;
-    v2->unk_0C = OverworldAnimManager_GetID(param0);
+    v2->unk_0C = OverworldAnimManager_GetUserInt(param0);
 
     v1.x = (((v2->unk_10.unk_00) << 4) * FX32_ONE) + ((16 * FX32_ONE) >> 1);
     v1.z = (((v2->unk_10.unk_04) << 4) * FX32_ONE) + ((((16 * FX32_ONE) >> 1) + (FX32_ONE * 6) + (FX32_ONE * 4)) / 2);

--- a/src/overlay005/ov5_021F3284.c
+++ b/src/overlay005/ov5_021F3284.c
@@ -130,7 +130,7 @@ static void ov5_021F33D0(OverworldAnimManager *param0, void *param1)
         return;
     }
 
-    v1 = OverworldAnimManager_GetID(param0);
+    v1 = OverworldAnimManager_GetUserInt(param0);
 
     if (v1 == 1) {
         if (sub_02062EC8(v3) == 0) {

--- a/src/overlay005/ov5_021F348C.c
+++ b/src/overlay005/ov5_021F348C.c
@@ -191,7 +191,7 @@ static int ov5_021F36F4(OverworldAnimManager *param0, void *param1)
 
     {
         u32 v4[4] = { 8, 14, 15, 16 };
-        int v5 = OverworldAnimManager_GetID(param0);
+        int v5 = OverworldAnimManager_GetUserInt(param0);
 
         v2->unk_20 = ov5_021DF84C(v2->unk_10.unk_04, v4[v5], &v1);
     }

--- a/src/overlay005/ov5_021F37A8.c
+++ b/src/overlay005/ov5_021F37A8.c
@@ -128,7 +128,7 @@ static int ov5_021F38AC(OverworldAnimManager *param0, void *param1)
     OverworldAnimManager_SetPosition(param0, &v2);
     v3->unk_34 = ov5_021DF84C(v3->unk_18.unk_10, 9, &v2);
 
-    if (OverworldAnimManager_GetID(param0) == 0) {
+    if (OverworldAnimManager_GetUserInt(param0) == 0) {
         v3->unk_00 = 1;
     }
 

--- a/src/overlay005/ov5_021F3A50.c
+++ b/src/overlay005/ov5_021F3A50.c
@@ -129,7 +129,7 @@ static int ov5_021F3B54(OverworldAnimManager *param0, void *param1)
 
     v3->unk_34 = ov5_021DF84C(v3->unk_18.unk_10, 10, &v2);
 
-    if (OverworldAnimManager_GetID(param0) == 0) {
+    if (OverworldAnimManager_GetUserInt(param0) == 0) {
         v3->unk_00 = 1;
     }
 

--- a/src/overlay005/ov5_021F47B0.c
+++ b/src/overlay005/ov5_021F47B0.c
@@ -380,7 +380,7 @@ static int ov5_021F4D50(OverworldAnimManager *param0, void *param1)
 {
     UnkStruct_021F4D50 *v0 = param1;
 
-    v0->unk_00 = OverworldAnimManager_GetID(param0);
+    v0->unk_00 = OverworldAnimManager_GetUserInt(param0);
     v0->unk_04 = (FieldEffectManager *)OverworldAnimManager_GetUserData(param0);
     v0->unk_08 = FieldEffectManager_GetRendererContext(v0->unk_04, 32);
 

--- a/src/overlay005/ov5_021F5A10.c
+++ b/src/overlay005/ov5_021F5A10.c
@@ -272,7 +272,7 @@ static int ov5_021F5C70(OverworldAnimManager *param0, void *param1)
     v1->unk_40 = ov5_021F5C18(v1->unk_30.unk_04, v1->unk_30.unk_00, &v0, v1->unk_30.unk_08->unk_06);
     ov5_021F5A7C(v1->unk_30.unk_08, v1->unk_30.unk_00);
 
-    if (OverworldAnimManager_GetID(param0) == 1) {
+    if (OverworldAnimManager_GetUserInt(param0) == 1) {
         Sound_PlayEffect(SEQ_SE_DP_DECIDE);
     }
 
@@ -390,7 +390,7 @@ static int ov5_021F5DE4(OverworldAnimManager *param0, void *param1)
     v1->unk_40 = ov5_021F5C18(v1->unk_30.unk_04, v1->unk_30.unk_00, &v0, v1->unk_30.unk_08->unk_06);
     ov5_021F5A7C(v1->unk_30.unk_08, v1->unk_30.unk_00);
 
-    if (OverworldAnimManager_GetID(param0) == 1) {
+    if (OverworldAnimManager_GetUserInt(param0) == 1) {
         Sound_PlayEffect(SEQ_SE_DP_DECIDE);
     }
 
@@ -489,7 +489,7 @@ static void ov5_021F5F24(OverworldAnimManager *param0, void *param1)
         Billboard_SetDrawFlag(v0->unk_40, 1);
         v0->unk_10 = 0;
 
-        if (OverworldAnimManager_GetID(param0) == 1) {
+        if (OverworldAnimManager_GetUserInt(param0) == 1) {
             Sound_PlayEffect(SEQ_SE_DP_DECIDE);
         }
 

--- a/src/overlay005/surf_mount_renderer.c
+++ b/src/overlay005/surf_mount_renderer.c
@@ -46,7 +46,7 @@ typedef struct SurfMountRenderer {
     int mapObjLocalID;
     int mapHeaderID;
     int counter;
-    int animID;
+    BOOL syncPos;
     fx32 yOffset;
     fx32 yDelta;
     SurfMountUserData userData;
@@ -85,7 +85,7 @@ static void SurfMountResources_Free(SurfMountResources *resources)
     Simple3D_FreeModel(&resources->surfMountModel);
 }
 
-OverworldAnimManager *SurfMountRenderer_HandleSurfBegin(MapObject *surfMountMapObj, int tileX, int tileZ, int dir, BOOL reuseMapObjPos)
+OverworldAnimManager *SurfMountRenderer_HandleSurfBegin(MapObject *surfMountMapObj, int tileX, int tileZ, int dir, BOOL syncPos)
 {
     SurfMountUserData userData;
     VecFx32 mapObjPos = { 0, 0, 0 };
@@ -95,7 +95,7 @@ OverworldAnimManager *SurfMountRenderer_HandleSurfBegin(MapObject *surfMountMapO
     userData.resources = FieldEffectManager_GetRendererContext(userData.fieldEffMan, FIELD_EFFECT_RENDERER_SURF_MOUNT);
     userData.surfMountMapObj = surfMountMapObj;
 
-    if (!reuseMapObjPos) {
+    if (!syncPos) {
         FieldSystem *fieldSystem = MapObject_FieldSystem(surfMountMapObj);
 
         mapObjPos.x = MAP_OBJECT_COORD_TO_FX32(tileX);
@@ -109,7 +109,7 @@ OverworldAnimManager *SurfMountRenderer_HandleSurfBegin(MapObject *surfMountMapO
     }
 
     int taskPriority = MapObject_CalculateTaskPriority(surfMountMapObj, 2);
-    return FieldEffectManager_InitAnimManager(userData.fieldEffMan, &sSurfMountRendererAnimFuncs, &mapObjPos, reuseMapObjPos, &userData, taskPriority);
+    return FieldEffectManager_InitAnimManager(userData.fieldEffMan, &sSurfMountRendererAnimFuncs, &mapObjPos, syncPos, &userData, taskPriority);
 }
 
 static BOOL SurfMountRenderer_AnimInit(OverworldAnimManager *animMan, void *context)
@@ -122,7 +122,7 @@ static BOOL SurfMountRenderer_AnimInit(OverworldAnimManager *animMan, void *cont
     renderer->mapObjLocalID = MapObject_GetLocalID(surfMountMapObj);
     renderer->mapHeaderID = MapObject_GetMapID(surfMountMapObj);
     renderer->dir = userData->dir;
-    renderer->animID = OverworldAnimManager_GetID(animMan);
+    renderer->syncPos = OverworldAnimManager_GetUserInt(animMan);
     renderer->yOffset = RENDERER_INITIAL_Y_OFFSET;
     renderer->yDelta = RENDERER_INITIAL_Y_DELTA;
 
@@ -156,7 +156,7 @@ static void SurfMountRenderer_AnimTick(OverworldAnimManager *animMan, void *cont
         return;
     }
 
-    if (renderer->animID == 0) {
+    if (!renderer->syncPos) {
         return;
     }
 
@@ -223,11 +223,11 @@ static void SurfMountRenderer_AnimRender(OverworldAnimManager *animMan, void *co
     Simple3D_DrawRenderObj(surfMountRenderObj, &pos, &scale, &rotation);
 }
 
-void SurfMountRenderer_Reset(OverworldAnimManager *animMan, int animID)
+void SurfMountRenderer_SetSyncPos(OverworldAnimManager *animMan, BOOL syncPos)
 {
     SurfMountRenderer *renderer = OverworldAnimManager_GetFuncsContext(animMan);
 
-    renderer->animID = animID;
+    renderer->syncPos = syncPos;
     renderer->yOffset = RENDERER_INITIAL_Y_OFFSET;
     renderer->yDelta = RENDERER_INITIAL_Y_DELTA;
 }

--- a/src/overlay006/hm_cut_in.c
+++ b/src/overlay006/hm_cut_in.c
@@ -2249,16 +2249,16 @@ static void WindParticle_RunAnimFuncs(HMCutIn *cutIn, const VecFx32 *initialPos,
     v0 = OverworldAnimManagerList_InitManager(cutIn->unk_244, &sWindParticleAnimFuncs, initialPos, param4, &animData, 132);
 }
 
-static int WindParticleAnim_SetUpSprite(OverworldAnimManager *param0, void *windParticleAnimEnv)
+static int WindParticleAnim_SetUpSprite(OverworldAnimManager *animMan, void *windParticleAnimEnv)
 {
     VecFx32 position;
     WindParticleAnimEnv *env = windParticleAnimEnv;
-    const WindParticleAnimData *animData = OverworldAnimManager_GetUserData(param0);
+    const WindParticleAnimData *animData = OverworldAnimManager_GetUserData(animMan);
 
     env->data = *animData;
-    env->animID = OverworldAnimManager_GetID(param0);
+    env->animID = OverworldAnimManager_GetUserInt(animMan);
 
-    OverworldAnimManager_GetPosition(param0, &position);
+    OverworldAnimManager_GetPosition(animMan, &position);
 
     env->sprite = WindParticle_CreateSprite(env->data.cutIn, &position, env->data.spriteListPriority, env->animID);
     Sprite_SetDrawFlag(env->sprite, FALSE);
@@ -2266,23 +2266,23 @@ static int WindParticleAnim_SetUpSprite(OverworldAnimManager *param0, void *wind
     return 1;
 }
 
-static void WindParticleAnim_DeleteSprite(OverworldAnimManager *param0, void *windParticleAnimEnv)
+static void WindParticleAnim_DeleteSprite(OverworldAnimManager *animMan, void *windParticleAnimEnv)
 {
     WindParticleAnimEnv *env = windParticleAnimEnv;
     Sprite_Delete(env->sprite);
 }
 
-static void WindParticleAnim_AnimateParticle(OverworldAnimManager *param0, void *windParticleAnimEnv)
+static void WindParticleAnim_AnimateParticle(OverworldAnimManager *animMan, void *windParticleAnimEnv)
 {
     VecFx32 newPos;
     WindParticleAnimEnv *env = windParticleAnimEnv;
 
-    OverworldAnimManager_GetPosition(param0, &newPos);
+    OverworldAnimManager_GetPosition(animMan, &newPos);
 
     newPos.x += env->data.movementDelta.x;
     newPos.x %= (FX32_ONE * 512);
 
-    OverworldAnimManager_SetPosition(param0, &newPos);
+    OverworldAnimManager_SetPosition(animMan, &newPos);
     Sprite_SetPosition(env->sprite, &newPos);
 
     if (env->data.allowWindParticles == TRUE) {
@@ -2306,7 +2306,7 @@ static void WindParticleAnim_AnimateParticle(OverworldAnimManager *param0, void 
     }
 }
 
-static void WindParticleAnim_DoNothing(OverworldAnimManager *param0, void *windParticleAnimEnv)
+static void WindParticleAnim_DoNothing(OverworldAnimManager *animMan, void *windParticleAnimEnv)
 {
     WindParticleAnimEnv *env = windParticleAnimEnv;
 }

--- a/src/overlay101/ov101_021D59AC.c
+++ b/src/overlay101/ov101_021D59AC.c
@@ -267,7 +267,7 @@ static int ov101_021D5B44(OverworldAnimManager *param0, void *param1)
     VecFx32 v0;
     UnkStruct_ov101_021D5B9C *v1 = param1;
 
-    v1->unk_04 = OverworldAnimManager_GetID(param0);
+    v1->unk_04 = OverworldAnimManager_GetUserInt(param0);
     v1->unk_08 = v1->unk_04 * 10;
     v1->unk_00 = (UnkStruct_ov101_021D13C8 *)OverworldAnimManager_GetUserData(param0);
 
@@ -340,7 +340,7 @@ static int ov101_021D5C7C(OverworldAnimManager *param0, void *param1)
     VecFx32 v0;
     UnkStruct_ov101_021D5CD4 *v1 = param1;
 
-    v1->unk_04 = OverworldAnimManager_GetID(param0);
+    v1->unk_04 = OverworldAnimManager_GetUserInt(param0);
     v1->unk_08 = v1->unk_04 * 10;
     v1->unk_00 = (UnkStruct_ov101_021D13C8 *)OverworldAnimManager_GetUserData(param0);
 
@@ -440,7 +440,7 @@ static int ov101_021D5DD0(OverworldAnimManager *param0, void *param1)
     UnkStruct_ov101_021D630C *v0 = param1;
 
     v0->unk_38 = (UnkStruct_ov101_021D13C8 *)OverworldAnimManager_GetUserData(param0);
-    v0->unk_10 = OverworldAnimManager_GetID(param0);
+    v0->unk_10 = OverworldAnimManager_GetUserInt(param0);
 
     return 1;
 }
@@ -1050,7 +1050,7 @@ static int ov101_021D67BC(OverworldAnimManager *param0, void *param1)
     UnkStruct_ov101_021D66D0 *v0 = param1;
 
     v0->unk_20 = (UnkStruct_ov101_021D13C8 *)OverworldAnimManager_GetUserData(param0);
-    v0->unk_18 = OverworldAnimManager_GetID(param0);
+    v0->unk_18 = OverworldAnimManager_GetUserInt(param0);
 
     ov101_021D66D0(v0);
 
@@ -2087,7 +2087,7 @@ static int ov101_021D7810(OverworldAnimManager *param0, void *param1)
     UnkStruct_ov101_021D7984 *v6 = param1;
     UnkStruct_ov101_021D13C8 *v7 = (UnkStruct_ov101_021D13C8 *)OverworldAnimManager_GetUserData(param0);
 
-    v6->unk_00 = OverworldAnimManager_GetID(param0);
+    v6->unk_00 = OverworldAnimManager_GetUserInt(param0);
     v6->unk_14 = v7;
 
     if (v6->unk_00 == UnkEnum_ov101_021D77E4_00) {
@@ -2201,7 +2201,7 @@ static int ov101_021D7A00(OverworldAnimManager *param0, void *param1)
     UnkStruct_ov101_021D7A00 *v5 = param1;
 
     v5->unk_08 = (UnkStruct_ov101_021D13C8 *)OverworldAnimManager_GetUserData(param0);
-    v1 = OverworldAnimManager_GetID(param0);
+    v1 = OverworldAnimManager_GetUserInt(param0);
 
     OverworldAnimManager_GetPosition(param0, &v4);
 

--- a/src/overworld_anim_manager.c
+++ b/src/overworld_anim_manager.c
@@ -19,7 +19,7 @@ static OverworldAnimManager *OverworldAnimManagerList_GetManagers(const Overworl
 static void OverworldAnimManager_SetActive(OverworldAnimManager *manager);
 static void OverworldAnimManager_SetFlags(OverworldAnimManager *manager, u32 mask);
 static u32 OverworldAnimManager_GetFlags(OverworldAnimManager *manager, u32 mask);
-static void OverworldAnimManager_SetID(OverworldAnimManager *manager, int id);
+static void OverworldAnimManager_SetUserInt(OverworldAnimManager *manager, int userInt);
 static void OverworldAnimManager_SetUserData(OverworldAnimManager *manager, const void *userData);
 static void OverworldAnimManager_SetTickSysTask(OverworldAnimManager *manager, SysTask *sysTask);
 static SysTask *OverworldAnimManager_GetTickSysTask(OverworldAnimManager *manager);
@@ -48,7 +48,7 @@ void OverworldAnimManagerList_FinishAndFree(OverworldAnimManagerList *managerLis
     OverworldAnimManagerList_Free(managerList);
 }
 
-OverworldAnimManager *OverworldAnimManagerList_InitManagerEx(OverworldAnimManagerList *managerList, const OverworldAnimManagerExtendedFuncs *funcs, const VecFx32 *initialPos, int id, const void *userData, int sysTaskPriority)
+OverworldAnimManager *OverworldAnimManagerList_InitManagerEx(OverworldAnimManagerList *managerList, const OverworldAnimManagerExtendedFuncs *funcs, const VecFx32 *initialPos, int userInt, const void *userData, int sysTaskPriority)
 {
     int i = 0;
     int count = OverworldAnimManagerList_GetManagerCount(managerList);
@@ -68,7 +68,7 @@ OverworldAnimManager *OverworldAnimManagerList_InitManagerEx(OverworldAnimManage
     }
 
     OverworldAnimManager_SetActive(iter);
-    OverworldAnimManager_SetID(iter, id);
+    OverworldAnimManager_SetUserInt(iter, userInt);
     OverworldAnimManager_SetUserData(iter, userData);
     OverworldAnimManager_SetList(iter, managerList);
 
@@ -108,14 +108,14 @@ OverworldAnimManager *OverworldAnimManagerList_InitManagerEx(OverworldAnimManage
     return iter;
 }
 
-OverworldAnimManager *OverworldAnimManagerList_InitManager(OverworldAnimManagerList *managerList, const OverworldAnimManagerFuncs *funcs, const VecFx32 *initialPos, int id, const void *userData, int sysTaskPriority)
+OverworldAnimManager *OverworldAnimManagerList_InitManager(OverworldAnimManagerList *managerList, const OverworldAnimManagerFuncs *funcs, const VecFx32 *initialPos, int userInt, const void *userData, int sysTaskPriority)
 {
     OverworldAnimManagerExtendedFuncs funcsEx;
     funcsEx.baseFuncs = *funcs;
     funcsEx.unused1Func = OverworldAnimManager_DummyUnused1Func;
     funcsEx.unused2Func = OverworldAnimManager_DummyUnused2Func;
 
-    return OverworldAnimManagerList_InitManagerEx(managerList, &funcsEx, initialPos, id, userData, sysTaskPriority);
+    return OverworldAnimManagerList_InitManagerEx(managerList, &funcsEx, initialPos, userInt, userData, sysTaskPriority);
 }
 
 void OverworldAnimManager_Finish(OverworldAnimManager *manager)
@@ -323,14 +323,14 @@ void OverworldAnimManager_ResetFuncsContext(OverworldAnimManager *manager, int c
     memset(ctx, 0, ctxSize);
 }
 
-static void OverworldAnimManager_SetID(OverworldAnimManager *manager, int id)
+static void OverworldAnimManager_SetUserInt(OverworldAnimManager *manager, int userInt)
 {
-    manager->id = id;
+    manager->userInt = userInt;
 }
 
-int OverworldAnimManager_GetID(const OverworldAnimManager *manager)
+int OverworldAnimManager_GetUserInt(const OverworldAnimManager *manager)
 {
-    return manager->id;
+    return manager->userInt;
 }
 
 static void OverworldAnimManager_SetUserData(OverworldAnimManager *manager, const void *userData)

--- a/src/player_avatar.c
+++ b/src/player_avatar.c
@@ -87,7 +87,7 @@ void PlayerAvatar_InitDraw(PlayerAvatar *playerAvatar, int dynamicMapFeaturesID)
             int x = Player_GetXPos(playerAvatar);
             int z = Player_GetZPos(playerAvatar);
             int dir = PlayerAvatar_GetDir(playerAvatar);
-            OverworldAnimManager *v7 = SurfMountRenderer_HandleSurfBegin(mapObj, x, z, dir, 1);
+            OverworldAnimManager *v7 = SurfMountRenderer_HandleSurfBegin(mapObj, x, z, dir, TRUE);
 
             PlayerAvatar_SetSurfMountAnimManager(playerAvatar, v7);
         }


### PR DESCRIPTION
This renames the `id` field of the overworld animation manager to `userInt`.

This field was initially documented as containing some sort of caller-defined identifier based on how it was being used in the HM cut-in file, but it's become more clear that the entire meaning of this field is caller-defined (see its use by the surf mount renderers as a boolean).

This also updates the surf mount renderer to correctly identify a flag that's used to control whether the surf mount position is synchronized with the player position on tick.

The same changes were ported to the distortion world surf mount renderer where applicable.