### PR TITLE
Document distortion world scripts

### DIFF
--- a/res/field/scripts/scripts_distortion_world_1f.s
+++ b/res/field/scripts/scripts_distortion_world_1f.s
@@ -1,6 +1,7 @@
 #include "macros/scrcmd.inc"
 #include "res/text/bank/distortion_world_1f.h"
 
+// NOTE: These constants must mirror those in ov9_02249960.c
 #define LOCALID_CYNTHIA 128
 
     ScriptEntry DistortionWorld1F_OnTransition

--- a/res/field/scripts/scripts_distortion_world_1f.s
+++ b/res/field/scripts/scripts_distortion_world_1f.s
@@ -1,31 +1,32 @@
 #include "macros/scrcmd.inc"
 #include "res/text/bank/distortion_world_1f.h"
 
+#define LOCALID_CYNTHIA 128
 
-    ScriptEntry _0016
-    ScriptEntry _001A
-    ScriptEntry _0070
-    ScriptEntry _011D
-    ScriptEntry _012A
+    ScriptEntry DistortionWorld1F_OnTransition
+    ScriptEntry DistortionWorld1F_Portal
+    ScriptEntry DistortionWorld1F_OnFrameFirstEntry
+    ScriptEntry DistortionWorld1F_TriggerCynthiaElevator
+    ScriptEntry DistortionWorld1F_CynthiaElevator
     ScriptEntryEnd
 
-_0016:
+DistortionWorld1F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-_001A:
+DistortionWorld1F_Portal:
     PlaySE SEQ_SE_CONFIRM
     LockAll
-    Message 7
+    Message DistortionWorld1F_Text_ReturnToSpearPillar
     ShowYesNoMenu VAR_RESULT
-    GoToIfEq VAR_RESULT, MENU_YES, _003A
+    GoToIfEq VAR_RESULT, MENU_YES, DistortionWorld1F_ReturnToSpearPillar
     CloseMessage
     ReleaseAll
     End
 
-_003A:
+DistortionWorld1F_ReturnToSpearPillar:
     BufferPlayerName 0
-    Message 8
+    Message DistortionWorld1F_Text_PlayerHeadedForSpearPillar
     CloseMessage
     PlaySE SEQ_SE_PL_SYUWA
     SetPartyGiratinaForm GIRATINA_FORM_ALTERED
@@ -36,80 +37,80 @@ _003A:
     WaitFadeScreen
     End
 
-_0070:
+DistortionWorld1F_OnFrameFirstEntry:
     LockAll
-    ApplyMovement LOCALID_PLAYER, _0140
+    ApplyMovement LOCALID_PLAYER, DistortionWorld1F_Movement_PlayerWalkWest
     WaitMovement
-    ApplyMovement LOCALID_PLAYER, _014C
+    ApplyMovement LOCALID_PLAYER, DistortionWorld1F_Movement_PlayerWalkOnSpotEast
     WaitMovement
-    AddDistortionWorldMapObject 128
-    ApplyMovement 128, _017C
+    AddDistortionWorldMapObject LOCALID_CYNTHIA
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorld1F_Movement_CynthiaLookAround
     WaitMovement
-    Message 0
+    Message DistortionWorld1F_Text_ThisPlace
     CloseMessageWithoutErasing
-    ApplyMovement 128, _0198
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorld1F_Movement_CynthiaWalkOnSpotSouth
     WaitMovement
-    Message 1
+    Message DistortionWorld1F_Text_SpaceCalledDistortionWorld
     CloseMessageWithoutErasing
-    ApplyMovement 128, _01A4
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorld1F_Movement_CynthiaWalkOnSpotWest
     WaitMovement
-    Message 2
+    Message DistortionWorld1F_Text_LetsFindGiratina
     CloseMessage
-    ApplyMovement LOCALID_PLAYER, _0154
-    ApplyMovement 128, _01AC
+    ApplyMovement LOCALID_PLAYER, DistortionWorld1F_Movement_PlayerWatchCynthiaWalkSouth
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorld1F_Movement_CynthiaWalkSouth
     WaitMovement
     StartDistortionWorldGiratinaShadowEvent 0
-    ApplyMovement LOCALID_PLAYER, _0160
-    ApplyMovement 128, _01B4
+    ApplyMovement LOCALID_PLAYER, DistortionWorld1F_Movement_PlayerNoticeGiratina
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorld1F_Movement_CynthiaNoticeGiratina
     WaitMovement
     WaitTime 30, VAR_RESULT
     FinishDistortionWorldGiratinaShadowEvent
-    Message 3
+    Message DistortionWorld1F_Text_ThatWasGiratina
     WaitButton
     CloseMessage
-    ApplyMovement LOCALID_PLAYER, _0174
-    ApplyMovement 128, _01C4
+    ApplyMovement LOCALID_PLAYER, DistortionWorld1F_Movement_PlayerWalkOnSpotSouth
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorld1F_Movement_CynthiaWalkOnSpotNorth
     WaitMovement
-    Message 4
+    Message DistortionWorld1F_Text_WeHaveToHurry
     CloseMessage
-    ApplyMovement 128, _01CC
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorld1F_Movement_CynthiaLeave
     WaitMovement
-    DeleteDistortionWorldMapObject 128
+    DeleteDistortionWorldMapObject LOCALID_CYNTHIA
     SetVar VAR_DISTORTION_WORLD_PROGRESS, 1
     ReleaseAll
     End
 
-_011D:
+DistortionWorld1F_TriggerCynthiaElevator:
     LockAll
-    Message 5
+    Message DistortionWorld1F_Text_SlabMovesIfYouStep
     WaitABPadPress
     CloseMessage
     ReleaseAll
     End
 
-_012A:
-    NPCMessage 6
+DistortionWorld1F_CynthiaElevator:
+    NPCMessage DistortionWorld1F_Text_WhyIsGroundColoredDifferently
     End
 
     .balign 4, 0
-_0140:
+DistortionWorld1F_Movement_PlayerWalkWest:
     WalkNormalWest
     Delay8
     EndMovement
 
     .balign 4, 0
-_014C:
+DistortionWorld1F_Movement_PlayerWalkOnSpotEast:
     WalkOnSpotNormalEast
     EndMovement
 
     .balign 4, 0
-_0154:
+DistortionWorld1F_Movement_PlayerWatchCynthiaWalkSouth:
     Delay8
     WalkOnSpotNormalSouth
     EndMovement
 
     .balign 4, 0
-_0160:
+DistortionWorld1F_Movement_PlayerNoticeGiratina:
     Delay4
     FaceWest
     EmoteExclamationMark
@@ -117,12 +118,12 @@ _0160:
     EndMovement
 
     .balign 4, 0
-_0174:
+DistortionWorld1F_Movement_PlayerWalkOnSpotSouth:
     WalkOnSpotNormalSouth
     EndMovement
 
     .balign 4, 0
-_017C:
+DistortionWorld1F_Movement_CynthiaLookAround:
     WalkOnSpotNormalSouth
     Delay16 2
     WalkOnSpotNormalEast
@@ -132,35 +133,35 @@ _017C:
     EndMovement
 
     .balign 4, 0
-_0198:
+DistortionWorld1F_Movement_CynthiaWalkOnSpotSouth:
     WalkOnSpotNormalSouth
     Delay8
     EndMovement
 
     .balign 4, 0
-_01A4:
+DistortionWorld1F_Movement_CynthiaWalkOnSpotWest:
     WalkOnSpotNormalWest
     EndMovement
 
     .balign 4, 0
-_01AC:
+DistortionWorld1F_Movement_CynthiaWalkSouth:
     WalkNormalSouth 2
     EndMovement
 
     .balign 4, 0
-_01B4:
+DistortionWorld1F_Movement_CynthiaNoticeGiratina:
     FaceWest
     EmoteExclamationMark
     FaceEast
     EndMovement
 
     .balign 4, 0
-_01C4:
+DistortionWorld1F_Movement_CynthiaWalkOnSpotNorth:
     WalkOnSpotNormalNorth
     EndMovement
 
     .balign 4, 0
-_01CC:
+DistortionWorld1F_Movement_CynthiaLeave:
     WalkNormalWest 3
     WalkNormalSouth 3
     WalkNormalWest 2

--- a/res/field/scripts/scripts_distortion_world_b1f.s
+++ b/res/field/scripts/scripts_distortion_world_b1f.s
@@ -1,59 +1,61 @@
 #include "macros/scrcmd.inc"
 #include "res/text/bank/distortion_world_b1f.h"
 
+#define LOCALID_CYNTHIA 128
+#define LOCALID_MESPRIT 129
 
-    ScriptEntry _000E
-    ScriptEntry _0012
-    ScriptEntry _004B
+    ScriptEntry DistortionWorldB1F_OnTransition
+    ScriptEntry DistortionWorldB1F_OnFrameFirstEntry
+    ScriptEntry DistortionWorldB1F_TriggerMesprit
     ScriptEntryEnd
 
-_000E:
+DistortionWorldB1F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-_0012:
+DistortionWorldB1F_OnFrameFirstEntry:
     LockAll
-    ApplyMovement LOCALID_PLAYER, _0078
-    ApplyMovement 128, _00A8
+    ApplyMovement LOCALID_PLAYER, DistortionWorldB1F_Movement_PlayerWalkOnSpotNorth
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB1F_Movement_CynthiaWalkOnSpotSouth
     WaitMovement
-    Message 0
+    Message DistortionWorldB1F_Text_WillWeSeeGiratina
     CloseMessage
-    ApplyMovement 128, _00B4
-    ApplyMovement LOCALID_PLAYER, _0080
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB1F_Movement_CynthiaLeave
+    ApplyMovement LOCALID_PLAYER, DistortionWorldB1F_Movement_PlayerWatchCynthiaLeave
     WaitMovement
-    DeleteDistortionWorldMapObject 128
+    DeleteDistortionWorldMapObject LOCALID_CYNTHIA
     SetVar VAR_DISTORTION_WORLD_PROGRESS, 3
     ReleaseAll
     End
 
-_004B:
+DistortionWorldB1F_TriggerMesprit:
     LockAll
     PlayCry SPECIES_MESPRIT
-    Message 1
+    Message DistortionWorldB1F_Text_MespritCry
     CloseMessage
     WaitCry
-    AddDistortionWorldMapObject 129
-    ApplyMovement LOCALID_PLAYER, _0090
-    ApplyMovement 129, _00D8
+    AddDistortionWorldMapObject LOCALID_MESPRIT
+    ApplyMovement LOCALID_PLAYER, DistortionWorldB1F_Movement_PlayerWatchMesprit
+    ApplyMovement LOCALID_MESPRIT, DistortionWorldB1F_Movement_MespritMoveNorth
     WaitMovement
-    DeleteDistortionWorldMapObject 129
+    DeleteDistortionWorldMapObject LOCALID_MESPRIT
     ReleaseAll
     End
 
     .balign 4, 0
-_0078:
+DistortionWorldB1F_Movement_PlayerWalkOnSpotNorth:
     WalkOnSpotNormalNorth
     EndMovement
 
     .balign 4, 0
-_0080:
+DistortionWorldB1F_Movement_PlayerWatchCynthiaLeave:
     Delay16
     Delay8
     WalkOnSpotNormalWest
     EndMovement
 
     .balign 4, 0
-_0090:
+DistortionWorldB1F_Movement_PlayerWatchMesprit:
     FaceWest
     Delay1 8
     Delay32
@@ -62,13 +64,13 @@ _0090:
     EndMovement
 
     .balign 4, 0
-_00A8:
+DistortionWorldB1F_Movement_CynthiaWalkOnSpotSouth:
     Delay16 3
     WalkOnSpotNormalSouth
     EndMovement
 
     .balign 4, 0
-_00B4:
+DistortionWorldB1F_Movement_CynthiaLeave:
     WalkNormalWest
     WalkNormalSouth 2
     WalkOnSpotNormalWest
@@ -80,7 +82,7 @@ _00B4:
     EndMovement
 
     .balign 4, 0
-_00D8:
+DistortionWorldB1F_Movement_MespritMoveNorth:
     Delay16 3
     WalkSlowNorth
     WalkNormalNorth

--- a/res/field/scripts/scripts_distortion_world_b1f.s
+++ b/res/field/scripts/scripts_distortion_world_b1f.s
@@ -1,6 +1,7 @@
 #include "macros/scrcmd.inc"
 #include "res/text/bank/distortion_world_b1f.h"
 
+// NOTE: These constants must mirror those in ov9_02249960.c
 #define LOCALID_CYNTHIA 128
 #define LOCALID_MESPRIT 129
 

--- a/res/field/scripts/scripts_distortion_world_b2f.s
+++ b/res/field/scripts/scripts_distortion_world_b2f.s
@@ -1,68 +1,69 @@
 #include "macros/scrcmd.inc"
 #include "res/text/bank/distortion_world_b2f.h"
 
+#define LOCALID_CYNTHIA 128
 
-    ScriptEntry _000E
-    ScriptEntry _0012
-    ScriptEntry _0084
+    ScriptEntry DistortionWorldB2F_OnTransition
+    ScriptEntry DistortionWorldB2F_OnFrameFirstEntry
+    ScriptEntry DistortionWorldB2F_Cynthia
     ScriptEntryEnd
 
-_000E:
+DistortionWorldB2F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-_0012:
+DistortionWorldB2F_OnFrameFirstEntry:
     PlaySE SEQ_SE_CONFIRM
     LockAll
-    GoToIfEq VAR_DISTORTION_WORLD_PROGRESS, 5, _0084
+    GoToIfEq VAR_DISTORTION_WORLD_PROGRESS, 5, DistortionWorldB2F_Cynthia
     GetPlayer3DPos VAR_0x8004, VAR_0x8005, VAR_0x8006
-    GoToIfEq VAR_0x8005, 232, _0059
-    ApplyMovement 128, _00DC
+    GoToIfEq VAR_0x8005, 232, DistortionWorldB2F_LetsSplitUpY232
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB2F_Movement_CynthiaFaceSouth
     WaitMovement
-    Message 0
+    Message DistortionWorldB2F_Text_LetsSplitUp
     CloseMessage
-    ApplyMovement 128, _00E4
+    ApplyMovement LOCALID_CYNTHIA, _00E4
     WaitMovement
-    GoTo _007A
+    GoTo DistortionWorldB2F_IncreaseProgressVar
 
-_0059:
-    ApplyMovement 128, _00F0
+DistortionWorldB2F_LetsSplitUpY232:
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB2F_Movement_CynthiaFaceEast
     WaitMovement
-    Message 0
+    Message DistortionWorldB2F_Text_LetsSplitUp
     CloseMessage
-    ApplyMovement 128, _00F8
+    ApplyMovement LOCALID_CYNTHIA, _00F8
     ApplyMovement LOCALID_PLAYER, _011C
     WaitMovement
-_007A:
+DistortionWorldB2F_IncreaseProgressVar:
     SetVar VAR_DISTORTION_WORLD_PROGRESS, 5
     ReleaseAll
     End
 
-_0084:
+DistortionWorldB2F_Cynthia:
     GetPlayer3DPos VAR_0x8004, VAR_0x8005, VAR_0x8006
-    GoToIfEq VAR_0x8005, 231, _00B6
-    GoToIfEq VAR_0x8005, 232, _00C6
-    ApplyMovement 128, _0104
+    GoToIfEq VAR_0x8005, 231, DistortionWorldB2F_CynthiaFaceEast
+    GoToIfEq VAR_0x8005, 232, DistortionWorldB2F_CynthiaFaceSouth
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB2F_Movement_CynthiaFaceWest
     WaitMovement
-    GoTo _00D0
+    GoTo DistortionWorldB2F_DontNeedToGoTogether
 
-_00B6:
-    ApplyMovement 128, _010C
+DistortionWorldB2F_CynthiaFaceEast:
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB2F_Movement_CynthiaFaceEast2
     WaitMovement
-    GoTo _00D0
+    GoTo DistortionWorldB2F_DontNeedToGoTogether
 
-_00C6:
-    ApplyMovement 128, _0114
+DistortionWorldB2F_CynthiaFaceSouth:
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB2F_Movement_CynthiaFaceSouth2
     WaitMovement
-_00D0:
-    Message 1
+DistortionWorldB2F_DontNeedToGoTogether:
+    Message DistortionWorldB2F_Text_DontNeedToGoTogether
     WaitButton
     CloseMessage
     ReleaseAll
     End
 
     .balign 4, 0
-_00DC:
+DistortionWorldB2F_Movement_CynthiaFaceSouth:
     FaceSouth
     EndMovement
 
@@ -73,7 +74,7 @@ _00E4:
     EndMovement
 
     .balign 4, 0
-_00F0:
+DistortionWorldB2F_Movement_CynthiaFaceEast:
     FaceEast
     EndMovement
 
@@ -84,17 +85,17 @@ _00F8:
     EndMovement
 
     .balign 4, 0
-_0104:
+DistortionWorldB2F_Movement_CynthiaFaceWest:
     FaceWest
     EndMovement
 
     .balign 4, 0
-_010C:
+DistortionWorldB2F_Movement_CynthiaFaceEast2:
     FaceEast
     EndMovement
 
     .balign 4, 0
-_0114:
+DistortionWorldB2F_Movement_CynthiaFaceSouth2:
     FaceSouth
     EndMovement
 

--- a/res/field/scripts/scripts_distortion_world_b2f.s
+++ b/res/field/scripts/scripts_distortion_world_b2f.s
@@ -1,6 +1,7 @@
 #include "macros/scrcmd.inc"
 #include "res/text/bank/distortion_world_b2f.h"
 
+// NOTE: These constants must mirror those in ov9_02249960.c
 #define LOCALID_CYNTHIA 128
 
     ScriptEntry DistortionWorldB2F_OnTransition

--- a/res/field/scripts/scripts_distortion_world_b3f.s
+++ b/res/field/scripts/scripts_distortion_world_b3f.s
@@ -1,45 +1,46 @@
 #include "macros/scrcmd.inc"
 #include "res/text/bank/distortion_world_b3f.h"
 
+#define LOCALID_CYRUS 128
 
-    ScriptEntry _000A
-    ScriptEntry _000E
+    ScriptEntry DistortionWorldB3F_OnTransition
+    ScriptEntry DistortionWorldB3F_TriggerCyrus
     ScriptEntryEnd
 
-_000A:
+DistortionWorldB3F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-_000E:
+DistortionWorldB3F_TriggerCyrus:
     LockAll
-    AddDistortionWorldMapObject 128
-    ApplyMovement 128, _0060
+    AddDistortionWorldMapObject LOCALID_CYRUS
+    ApplyMovement LOCALID_CYRUS, DistortionWorldB3F_Movement_CyrusEnter
     WaitMovement
-    Message 0
+    Message DistortionWorldB3F_Text_DoYouUnderstandGenes
     ShowYesNoMenu VAR_RESULT
-    GoToIfEq VAR_RESULT, MENU_NO, _003B
-    Message 1
-    GoTo _003E
+    GoToIfEq VAR_RESULT, MENU_NO, DistortionWorldB3F_OfCourseYouWouldnt
+    Message DistortionWorldB3F_Text_YouveImpressedMe
+    GoTo DistortionWorldB3F_TwoWorldsMustBalance
 
-_003B:
-    Message 2
-_003E:
-    Message 3
-    Message 4
+DistortionWorldB3F_OfCourseYouWouldnt:
+    Message DistortionWorldB3F_Text_OfCourseYouWouldnt
+DistortionWorldB3F_TwoWorldsMustBalance:
+    Message DistortionWorldB3F_Text_TwoWorldsMustBalance
+    Message DistortionWorldB3F_Text_DefeatingThatPokemonMatters
     CloseMessage
-    ApplyMovement 128, _0068
+    ApplyMovement LOCALID_CYRUS, DistortionWorldB3F_Movement_CyrusLeave
     WaitMovement
-    DeleteDistortionWorldMapObject 128
+    DeleteDistortionWorldMapObject LOCALID_CYRUS
     SetVar VAR_DISTORTION_WORLD_PROGRESS, 6
     ReleaseAll
     End
 
     .balign 4, 0
-_0060:
+DistortionWorldB3F_Movement_CyrusEnter:
     WalkNormalNorth 7
     EndMovement
 
     .balign 4, 0
-_0068:
+DistortionWorldB3F_Movement_CyrusLeave:
     WalkNormalSouth 7
     EndMovement

--- a/res/field/scripts/scripts_distortion_world_b3f.s
+++ b/res/field/scripts/scripts_distortion_world_b3f.s
@@ -1,6 +1,7 @@
 #include "macros/scrcmd.inc"
 #include "res/text/bank/distortion_world_b3f.h"
 
+// NOTE: These constants must mirror those in ov9_02249960.c
 #define LOCALID_CYRUS 128
 
     ScriptEntry DistortionWorldB3F_OnTransition

--- a/res/field/scripts/scripts_distortion_world_b4f.s
+++ b/res/field/scripts/scripts_distortion_world_b4f.s
@@ -1,11 +1,11 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry _000A
+    ScriptEntry DistortionWorldB4F_OnTransition
     ScriptEntry _000E
     ScriptEntryEnd
 
-_000A:
+DistortionWorldB4F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 

--- a/res/field/scripts/scripts_distortion_world_b5f.s
+++ b/res/field/scripts/scripts_distortion_world_b5f.s
@@ -1,11 +1,11 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry _000A
+    ScriptEntry DistortionWorldB5F_OnTransition
     ScriptEntry _000E
     ScriptEntryEnd
 
-_000A:
+DistortionWorldB5F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 

--- a/res/field/scripts/scripts_distortion_world_b6f.s
+++ b/res/field/scripts/scripts_distortion_world_b6f.s
@@ -1,6 +1,7 @@
 #include "macros/scrcmd.inc"
 #include "res/text/bank/distortion_world_b6f.h"
 
+// NOTE: These constants must mirror those in ov9_02249960.c
 #define LOCALID_MESPRIT 131
 #define LOCALID_UXIE    132
 #define LOCALID_AZELF   133

--- a/res/field/scripts/scripts_distortion_world_b6f.s
+++ b/res/field/scripts/scripts_distortion_world_b6f.s
@@ -1,88 +1,92 @@
 #include "macros/scrcmd.inc"
 #include "res/text/bank/distortion_world_b6f.h"
 
+#define LOCALID_MESPRIT 131
+#define LOCALID_UXIE    132
+#define LOCALID_AZELF   133
+#define LOCALID_CYNTHIA 134
 
-    ScriptEntry _0022
-    ScriptEntry _0026
-    ScriptEntry _0051
-    ScriptEntry _0080
-    ScriptEntry _0093
-    ScriptEntry _00B4
-    ScriptEntry _00D5
-    ScriptEntry _00F6
+    ScriptEntry DistortionWorldB6F_OnTransition
+    ScriptEntry DistortionWorldB6F_Cynthia
+    ScriptEntry DistortionWorldB6F_CynthiaPuzzleFinished
+    ScriptEntry DistortionWorldB6F_WereGettingClose
+    ScriptEntry DistortionWorldB6F_TriggerMespritBoulderInPit
+    ScriptEntry DistortionWorldB6F_TriggerUxieBoulderInPit
+    ScriptEntry DistortionWorldB6F_TriggerAzelfBoulderInPit
+    ScriptEntry DistortionWorldB6F_BoulderPit
     ScriptEntryEnd
 
-_0022:
+DistortionWorldB6F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-_0026:
-    GoToIfEq VAR_DISTORTION_WORLD_PROGRESS, 7, _0080
-    GoToIfSet FLAG_DISTORTION_WORLD_PUZZLE_FINISHED, _0051
-    NPCMessage 3
+DistortionWorldB6F_Cynthia:
+    GoToIfEq VAR_DISTORTION_WORLD_PROGRESS, 7, DistortionWorldB6F_WereGettingClose
+    GoToIfSet FLAG_DISTORTION_WORLD_PUZZLE_FINISHED, DistortionWorldB6F_CynthiaPuzzleFinished
+    NPCMessage DistortionWorldB6F_Text_ThisPlaceGiantPuzzle
     End
 
-_0051:
+DistortionWorldB6F_CynthiaPuzzleFinished:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     FacePlayer
-    Message 4
+    Message DistortionWorldB6F_Text_LakePokemonWentHome
     CloseMessage
     SetFlag FLAG_DISTORTION_WORLD_STEPPING_STONES
-    ApplyMovement 134, _0108
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB6F_Movement_CynthiaNoticePlatform
     WaitMovement
-    ApplyMovement 134, _011C
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB6F_Movement_CynthiaJumpOnPlatform
     WaitMovement
     SetVar VAR_DISTORTION_WORLD_PROGRESS, 7
     ReleaseAll
     End
 
-_0080:
-    NPCMessage 5
+DistortionWorldB6F_WereGettingClose:
+    NPCMessage DistortionWorldB6F_Text_WereGettingClose
     End
 
-_0093:
+DistortionWorldB6F_TriggerMespritBoulderInPit:
     LockAll
     PlayCry SPECIES_MESPRIT
-    Message 0
+    Message DistortionWorldB6F_Text_MespritCry
     CloseMessage
     WaitCry
-    ApplyMovement 131, _0130
+    ApplyMovement LOCALID_MESPRIT, DistortionWorldB6F_Movement_LakeGuardianWarpOut
     WaitMovement
-    DeleteDistortionWorldMapObject 131
+    DeleteDistortionWorldMapObject LOCALID_MESPRIT
     ReleaseAll
     End
 
-_00B4:
+DistortionWorldB6F_TriggerUxieBoulderInPit:
     LockAll
     PlayCry SPECIES_UXIE
-    Message 1
+    Message DistortionWorldB6F_Text_UxieCry
     CloseMessage
     WaitCry
-    ApplyMovement 132, _0130
+    ApplyMovement LOCALID_UXIE, DistortionWorldB6F_Movement_LakeGuardianWarpOut
     WaitMovement
-    DeleteDistortionWorldMapObject 132
+    DeleteDistortionWorldMapObject LOCALID_UXIE
     ReleaseAll
     End
 
-_00D5:
+DistortionWorldB6F_TriggerAzelfBoulderInPit:
     LockAll
     PlayCry SPECIES_AZELF
-    Message 2
+    Message DistortionWorldB6F_Text_AzelfCry
     CloseMessage
     WaitCry
-    ApplyMovement 133, _0130
+    ApplyMovement LOCALID_AZELF, DistortionWorldB6F_Movement_LakeGuardianWarpOut
     WaitMovement
-    DeleteDistortionWorldMapObject 133
+    DeleteDistortionWorldMapObject LOCALID_AZELF
     ReleaseAll
     End
 
-_00F6:
-    EventMessage 6
+DistortionWorldB6F_BoulderPit:
+    EventMessage DistortionWorldB6F_Text_BoulderMightFit
     End
 
     .balign 4, 0
-_0108:
+DistortionWorldB6F_Movement_CynthiaNoticePlatform:
     Delay32
     WalkOnSpotNormalSouth
     EmoteExclamationMark
@@ -90,7 +94,7 @@ _0108:
     EndMovement
 
     .balign 4, 0
-_011C:
+DistortionWorldB6F_Movement_CynthiaJumpOnPlatform:
     WalkNormalSouth
     JumpDistortionWorldSouth
     WalkNormalWest
@@ -98,6 +102,6 @@ _011C:
     EndMovement
 
     .balign 4, 0
-_0130:
+DistortionWorldB6F_Movement_LakeGuardianWarpOut:
     WarpOut
     EndMovement

--- a/res/field/scripts/scripts_distortion_world_b7f.s
+++ b/res/field/scripts/scripts_distortion_world_b7f.s
@@ -1,20 +1,22 @@
 #include "macros/scrcmd.inc"
 #include "res/text/bank/distortion_world_b7f.h"
 
+#define LOCALID_CYNTHIA 128
+#define LOCALID_CYRUS   129
 
-    ScriptEntry _001A
-    ScriptEntry _001E
-    ScriptEntry _0044
-    ScriptEntry _006F
-    ScriptEntry _0096
-    ScriptEntry _01DA
+    ScriptEntry DistortionWorldB7F_OnTransition
+    ScriptEntry DistortionWorldB7F_TriggerWarpToGiratinaRoom
+    ScriptEntry DistortionWorldB7F_OnFrameFirstEntry
+    ScriptEntry DistortionWorldB7F_TriggerCynthiaCyrus
+    ScriptEntry DistortionWorldB7F_Cyrus
+    ScriptEntry DistortionWorldB7F_Cynthia
     ScriptEntryEnd
 
-_001A:
+DistortionWorldB7F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-_001E:
+DistortionWorldB7F_TriggerWarpToGiratinaRoom:
     FadeScreenOut
     WaitFadeScreen
     Warp MAP_HEADER_DISTORTION_WORLD_GIRATINA_ROOM, 0, 15, 25, 0
@@ -22,140 +24,140 @@ _001E:
     WaitFadeScreen
     End
 
-_0044:
+DistortionWorldB7F_OnFrameFirstEntry:
     LockAll
-    ApplyMovement 128, _028C
-    ApplyMovement LOCALID_PLAYER, _0204
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB7F_Movement_CynthiaWalkOnSpotNorth
+    ApplyMovement LOCALID_PLAYER, DistortionWorldB7F_Movement_PlayerWalkOnSpotNorth
     WaitMovement
-    Message 0
+    Message DistortionWorldB7F_Text_GiratinaIsUpAhead
     CloseMessage
-    ApplyMovement 128, _029C
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB7F_Movement_CynthiaWalkNorth
     WaitMovement
     SetVar VAR_DISTORTION_WORLD_PROGRESS, 8
     End
 
-_006F:
+DistortionWorldB7F_TriggerCynthiaCyrus:
     LockAll
-    Message 1
+    Message DistortionWorldB7F_Text_YouWereAlreadyHere
     CloseMessage
-    ApplyMovement 129, _0308
-    ApplyMovement 128, _02AC
+    ApplyMovement LOCALID_CYRUS, DistortionWorldB7F_Movement_CyrusWalkToCynthia
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB7F_Movement_CynthiaMoveAside
     WaitMovement
-    Message 2
-    Message 4
+    Message DistortionWorldB7F_Text_WhyChangeTheWorld
+    Message DistortionWorldB7F_Text_ThatIsMyJustice
     WaitABPadPress
     CloseMessage
     ReleaseAll
     End
 
-_0096:
+DistortionWorldB7F_Cyrus:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     FacePlayer
-    Message 5
+    Message DistortionWorldB7F_Text_IWontLose
     CloseMessage
     StartTrainerBattle TRAINER_GALACTIC_BOSS_CYRUS_DISTORTION_WORLD
     CheckWonBattle VAR_RESULT
-    GoToIfEq VAR_RESULT, FALSE, _01CE
+    GoToIfEq VAR_RESULT, FALSE, DistortionWorldB7F_LostBattle
     SetVar VAR_DISTORTION_WORLD_PROGRESS, 10
-    Message 6
+    Message DistortionWorldB7F_Text_YoullDestroyThisWorld
     CloseMessage
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
-    GoToIfEq VAR_0x8004, 86, _00E6
-    ApplyMovement LOCALID_PLAYER, _0210
-    GoTo _00EE
+    GoToIfEq VAR_0x8004, 86, DistortionWorldB7F_PlayerWatchCyrusLeave
+    ApplyMovement LOCALID_PLAYER, DistortionWorldB7F_Movement_PlayerMoveAside
+    GoTo DistortionWorldB7F_CyrusLeave
 
-_00E6:
-    ApplyMovement LOCALID_PLAYER, _0248
-_00EE:
-    ApplyMovement 129, _0314
-    ApplyMovement 128, _02DC
+DistortionWorldB7F_PlayerWatchCyrusLeave:
+    ApplyMovement LOCALID_PLAYER, DistortionWorldB7F_Movement_PlayerWatchCyrusLeave
+DistortionWorldB7F_CyrusLeave:
+    ApplyMovement LOCALID_CYRUS, DistortionWorldB7F_Movement_CyrusLeave
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB7F_Movement_CynthiaWatchCyrusLeave
     WaitMovement
-    DeleteDistortionWorldMapObject 129
-    ApplyMovement 128, _02BC
-    WaitMovement
-    GetPlayerMapPos VAR_0x8004, VAR_0x8005
-    GoToIfEq VAR_0x8005, 74, _012F
-    ApplyMovement LOCALID_PLAYER, _0254
-    GoTo _013F
-
-_012F:
-    ApplyMovement 128, _02E8
-    ApplyMovement LOCALID_PLAYER, _0264
-_013F:
-    Message 7
+    DeleteDistortionWorldMapObject LOCALID_CYRUS
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB7F_Movement_CynthiaWalkToPlayer
     WaitMovement
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
-    GoToIfEq VAR_0x8005, 74, _016D
-    ApplyMovement 128, _02F8
-    ApplyMovement LOCALID_PLAYER, _0274
-    GoTo _017D
+    GoToIfEq VAR_0x8005, 74, DistortionWorldB7F_CynthiaPlayerFaceEachOtherAfterDelay
+    ApplyMovement LOCALID_PLAYER, DistortionWorldB7F_Movement_PlayerFaceCynthiaNorthAfterDelay
+    GoTo DistortionWorldB7F_DontBelieveHisLies
 
-_016D:
-    ApplyMovement 128, _0300
-    ApplyMovement LOCALID_PLAYER, _0280
-_017D:
+DistortionWorldB7F_CynthiaPlayerFaceEachOtherAfterDelay:
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB7F_Movement_CynthiaFaceCynthiaEastAfterDelay
+    ApplyMovement LOCALID_PLAYER, DistortionWorldB7F_Movement_PlayerFaceCynthiaWestAfterDelay
+DistortionWorldB7F_DontBelieveHisLies:
+    Message DistortionWorldB7F_Text_DontBelieveHisLies
+    WaitMovement
+    GetPlayerMapPos VAR_0x8004, VAR_0x8005
+    GoToIfEq VAR_0x8005, 74, DistortionWorldB7F_CynthiaPlayerWalkOnSpotEastWest
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB7F_Movement_CynthiaWalkOnSpotSouth
+    ApplyMovement LOCALID_PLAYER, DistortionWorldB7F_Movement_PlayerWalkOnSpotNorthAfterDelay
+    GoTo DistortionWorldB7F_MeetGiratina
+
+DistortionWorldB7F_CynthiaPlayerWalkOnSpotEastWest:
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB7F_Movement_CynthiaWalkOnSpotEast
+    ApplyMovement LOCALID_PLAYER, DistortionWorldB7F_Movement_PlayerWalkOnSpotWestAfterDelay
+DistortionWorldB7F_MeetGiratina:
     BufferPlayerName 0
-    Message 8
+    Message DistortionWorldB7F_Text_CynthiaFullyHealedPokemon
     PlayFanfare SEQ_ASA
     WaitFanfare
     HealParty
     WaitMovement
-    Message 9
+    Message DistortionWorldB7F_Text_LetsGoMeetGiratina
     CloseMessage
-    ApplyMovement 128, _02C8
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldB7F_Movement_CynthiaWalkToGiratina
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
-    GoToIfEq VAR_0x8005, 74, _01BB
-    ApplyMovement LOCALID_PLAYER, _0220
-    GoTo _01C3
+    GoToIfEq VAR_0x8005, 74, DistortionWorldB7F_PlayerFollowCynthiaToGiratinaY74
+    ApplyMovement LOCALID_PLAYER, DistortionWorldB7F_Movement_PlayerFollowCynthiaToGiratinaY75
+    GoTo DistortionWorldB7F_GiratinaIsEnraged
 
-_01BB:
-    ApplyMovement LOCALID_PLAYER, _0234
-_01C3:
+DistortionWorldB7F_PlayerFollowCynthiaToGiratinaY74:
+    ApplyMovement LOCALID_PLAYER, DistortionWorldB7F_Movement_PlayerFollowCynthiaToGiratinaY74
+DistortionWorldB7F_GiratinaIsEnraged:
     WaitMovement
-    Message 10
+    Message DistortionWorldB7F_Text_GiratinaIsEnraged
     WaitButton
     CloseMessage
     End
 
-_01CE:
+DistortionWorldB7F_LostBattle:
     SetVar VAR_DISTORTION_WORLD_PROGRESS, 9
     BlackOutFromBattle
     ReleaseAll
     End
 
-_01DA:
+DistortionWorldB7F_Cynthia:
     PlaySE SEQ_SE_CONFIRM
     LockAll
-    GoToIfGe VAR_DISTORTION_WORLD_PROGRESS, 10, _01F8
-    Message 3
+    GoToIfGe VAR_DISTORTION_WORLD_PROGRESS, 10, DistortionWorldB7F_YourBondIsStrong
+    Message DistortionWorldB7F_Text_ThatsNoJustice
     WaitButton
     CloseMessage
     ReleaseAll
     End
 
-_01F8:
-    Message 11
+DistortionWorldB7F_YourBondIsStrong:
+    Message DistortionWorldB7F_Text_YourBondIsStrong
     WaitButton
     CloseMessage
     ReleaseAll
     End
 
     .balign 4, 0
-_0204:
+DistortionWorldB7F_Movement_PlayerWalkOnSpotNorth:
     Delay16 2
     WalkOnSpotNormalNorth
     EndMovement
 
     .balign 4, 0
-_0210:
+DistortionWorldB7F_Movement_PlayerMoveAside:
     WalkNormalEast
     WalkOnSpotNormalWest
     WalkOnSpotNormalSouth
     EndMovement
 
     .balign 4, 0
-_0220:
+DistortionWorldB7F_Movement_PlayerFollowCynthiaToGiratinaY75:
     WalkNormalWest
     WalkNormalNorth 7
     WalkNormalEast 4
@@ -163,7 +165,7 @@ _0220:
     EndMovement
 
     .balign 4, 0
-_0234:
+DistortionWorldB7F_Movement_PlayerFollowCynthiaToGiratinaY74:
     WalkNormalWest
     WalkNormalNorth 6
     WalkNormalEast 4
@@ -171,66 +173,66 @@ _0234:
     EndMovement
 
     .balign 4, 0
-_0248:
+DistortionWorldB7F_Movement_PlayerWatchCyrusLeave:
     Delay8
     WalkOnSpotNormalSouth
     EndMovement
 
     .balign 4, 0
-_0254:
+DistortionWorldB7F_Movement_PlayerFaceCynthiaNorthAfterDelay:
     Delay32 2
     Delay16
     WalkOnSpotNormalNorth
     EndMovement
 
     .balign 4, 0
-_0264:
+DistortionWorldB7F_Movement_PlayerFaceCynthiaWestAfterDelay:
     Delay32 2
     Delay16
     WalkOnSpotNormalWest
     EndMovement
 
     .balign 4, 0
-_0274:
+DistortionWorldB7F_Movement_PlayerWalkOnSpotNorthAfterDelay:
     Delay4
     WalkOnSpotNormalNorth
     EndMovement
 
     .balign 4, 0
-_0280:
+DistortionWorldB7F_Movement_PlayerWalkOnSpotWestAfterDelay:
     Delay4
     WalkOnSpotNormalWest
     EndMovement
 
     .balign 4, 0
-_028C:
+DistortionWorldB7F_Movement_CynthiaWalkOnSpotNorth:
     Delay16 2
     WalkOnSpotNormalNorth
     Delay16 2
     EndMovement
 
     .balign 4, 0
-_029C:
+DistortionWorldB7F_Movement_CynthiaWalkNorth:
     WalkNormalEast
     JumpDistortionWorldNorth
     WalkNormalNorth 7
     EndMovement
 
     .balign 4, 0
-_02AC:
+DistortionWorldB7F_Movement_CynthiaMoveAside:
     Delay8 3
     WalkNormalWest
     WalkOnSpotNormalEast
     EndMovement
 
     .balign 4, 0
-_02BC:
+DistortionWorldB7F_Movement_CynthiaWalkToPlayer:
     WalkNormalEast
     WalkOnSpotNormalSouth
     EndMovement
 
     .balign 4, 0
-_02C8:
+DistortionWorldB7F_Movement_CynthiaWalkToGiratina:
     WalkNormalNorth 6
     WalkNormalEast 4
     WalkNormalSouth
@@ -238,36 +240,36 @@ _02C8:
     EndMovement
 
     .balign 4, 0
-_02DC:
+DistortionWorldB7F_Movement_CynthiaWatchCyrusLeave:
     Delay16
     WalkOnSpotNormalSouth
     EndMovement
 
     .balign 4, 0
-_02E8:
+DistortionWorldB7F_Movement_CynthiaFaceCynthiaEastAfterDelay:
     Delay32 2
     Delay8
     WalkOnSpotNormalEast
     EndMovement
 
     .balign 4, 0
-_02F8:
+DistortionWorldB7F_Movement_CynthiaWalkOnSpotSouth:
     WalkOnSpotNormalSouth
     EndMovement
 
     .balign 4, 0
-_0300:
+DistortionWorldB7F_Movement_CynthiaWalkOnSpotEast:
     WalkOnSpotNormalEast
     EndMovement
 
     .balign 4, 0
-_0308:
+DistortionWorldB7F_Movement_CyrusWalkToCynthia:
     WalkNormalSouth 4
     WalkOnSpotNormalWest
     EndMovement
 
     .balign 4, 0
-_0314:
+DistortionWorldB7F_Movement_CyrusLeave:
     WalkNormalSouth 7
     JumpDistortionWorldSouth
     Delay16

--- a/res/field/scripts/scripts_distortion_world_b7f.s
+++ b/res/field/scripts/scripts_distortion_world_b7f.s
@@ -1,6 +1,7 @@
 #include "macros/scrcmd.inc"
 #include "res/text/bank/distortion_world_b7f.h"
 
+// NOTE: These constants must mirror those in ov9_02249960.c
 #define LOCALID_CYNTHIA 128
 #define LOCALID_CYRUS   129
 

--- a/res/field/scripts/scripts_distortion_world_giratina_room.s
+++ b/res/field/scripts/scripts_distortion_world_giratina_room.s
@@ -2,6 +2,7 @@
 #include "generated/hidden_locations.h"
 #include "res/text/bank/distortion_world_giratina_room.h"
 
+// NOTE: These constants must mirror those in ov9_02249960.c
 #define LOCALID_GIRATINA 128
 #define LOCALID_CYNTHIA  129
 #define LOCALID_CYRUS    130

--- a/res/field/scripts/scripts_distortion_world_giratina_room.s
+++ b/res/field/scripts/scripts_distortion_world_giratina_room.s
@@ -2,44 +2,47 @@
 #include "generated/hidden_locations.h"
 #include "res/text/bank/distortion_world_giratina_room.h"
 
+#define LOCALID_GIRATINA 128
+#define LOCALID_CYNTHIA  129
+#define LOCALID_CYRUS    130
 
-    ScriptEntry _0022
-    ScriptEntry _0026
-    ScriptEntry _0041
-    ScriptEntry _009E
-    ScriptEntry _00C4
-    ScriptEntry _020A
-    ScriptEntry _021D
-    ScriptEntry _0232
+    ScriptEntry DistortionWorldGiratinaRoom_OnTransition
+    ScriptEntry DistortionWorldGiratinaRoom_OnLoad
+    ScriptEntry DistortionWorldGiratinaRoom_Portal
+    ScriptEntry DistortionWorldGiratinaRoom_TriggerWarpToB7F
+    ScriptEntry DistortionWorldGiratinaRoom_Giratina
+    ScriptEntry DistortionWorldGiratinaRoom_Cynthia
+    ScriptEntry DistortionWorldGiratinaRoom_TriggerFirstShadow
+    ScriptEntry DistortionWorldGiratinaRoom_TriggerGiratinaArrival
     ScriptEntryEnd
 
-_0022:
+DistortionWorldGiratinaRoom_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-_0026:
-    GoToIfSet FLAG_MAP_LOCAL, _0033
+DistortionWorldGiratinaRoom_OnLoad:
+    GoToIfSet FLAG_MAP_LOCAL, DistortionWorldGiratinaRoom_RemoveGiratina
     End
 
-_0033:
+DistortionWorldGiratinaRoom_RemoveGiratina:
     ResetDistortionWorldPersistedCameraAngles
     SetVar VAR_DISTORTION_WORLD_PROGRESS, 14
-    RemoveObject 128
+    RemoveObject LOCALID_GIRATINA
     End
 
-_0041:
+DistortionWorldGiratinaRoom_Portal:
     PlaySE SEQ_SE_CONFIRM
     LockAll
-    Message 13
+    Message DistortionWorldGiratinaRoom_Text_LeapIntoPortal
     ShowYesNoMenu VAR_RESULT
-    GoToIfEq VAR_RESULT, MENU_YES, _0061
+    GoToIfEq VAR_RESULT, MENU_YES, DistortionWorldGiratinaRoom_GoToSendoffSpring
     CloseMessage
     ReleaseAll
     End
 
-_0061:
+DistortionWorldGiratinaRoom_GoToSendoffSpring:
     BufferPlayerName 0
-    Message 14
+    Message DistortionWorldGiratinaRoom_Text_PlayerLeaptIntoPortal
     CloseMessage
     EnableHiddenLocation HIDDEN_LOCATION_SPRING_PATH
     SetVar VAR_EXITED_DISTORTION_WORLD_STATE, 1
@@ -51,7 +54,7 @@ _0061:
     WaitFadeScreen
     End
 
-_009E:
+DistortionWorldGiratinaRoom_TriggerWarpToB7F:
     FadeScreenOut
     WaitFadeScreen
     Warp MAP_HEADER_DISTORTION_WORLD_B7F, 0, 89, 57, 1
@@ -59,11 +62,11 @@ _009E:
     WaitFadeScreen
     End
 
-_00C4:
+DistortionWorldGiratinaRoom_Giratina:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     PlayCry SPECIES_GIRATINA
-    Message 2
+    Message DistortionWorldGiratinaRoom_Text_GiratinaCryGiygogagohgwooh
     WaitCry
     CloseMessage
     SetFlag FLAG_MAP_LOCAL
@@ -71,137 +74,137 @@ _00C4:
     ClearFlag FLAG_MAP_LOCAL
     CheckWonBattle VAR_RESULT
     GetBattleResult VAR_RESULT
-    GoToIfEq VAR_RESULT, BATTLE_RESULT_LOSE, _0204
-    GoToIfEq VAR_RESULT, BATTLE_RESULT_DRAW, _0204
-    GoToIfEq VAR_RESULT, BATTLE_RESULT_PLAYER_FLED, _014E
-    GoToIfEq VAR_RESULT, BATTLE_RESULT_ENEMY_FLED, _014E
-    GoToIfEq VAR_RESULT, BATTLE_RESULT_CAPTURED_MON, _016E
-    AddDistortionWorldMapObject 130
-    AddDistortionWorldMapObject 129
-    ApplyMovement 129, _0250
+    GoToIfEq VAR_RESULT, BATTLE_RESULT_LOSE, DistortionWorldGiratinaRoom_BlackOut
+    GoToIfEq VAR_RESULT, BATTLE_RESULT_DRAW, DistortionWorldGiratinaRoom_BlackOut
+    GoToIfEq VAR_RESULT, BATTLE_RESULT_PLAYER_FLED, DistortionWorldGiratinaRoom_PlayerRan
+    GoToIfEq VAR_RESULT, BATTLE_RESULT_ENEMY_FLED, DistortionWorldGiratinaRoom_PlayerRan
+    GoToIfEq VAR_RESULT, BATTLE_RESULT_CAPTURED_MON, DistortionWorldGiratinaRoom_CaughtGiratina
+    AddDistortionWorldMapObject LOCALID_CYRUS
+    AddDistortionWorldMapObject LOCALID_CYNTHIA
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldGiratinaRoom_Movement_CynthiaJumpNorth
     WaitMovement
-    Message 3
+    Message DistortionWorldGiratinaRoom_Text_GiratinaUnderstoodUs
     CloseMessage
-    Message 4
-    GoTo _0194
+    Message DistortionWorldGiratinaRoom_Text_ThatPokemonWasDefeated
+    GoTo DistortionWorldGiratinaRoom_PostBattle
 
-_014E:
-    AddDistortionWorldMapObject 130
-    AddDistortionWorldMapObject 129
-    ApplyMovement 129, _0250
+DistortionWorldGiratinaRoom_PlayerRan:
+    AddDistortionWorldMapObject LOCALID_CYRUS
+    AddDistortionWorldMapObject LOCALID_CYNTHIA
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldGiratinaRoom_Movement_CynthiaJumpNorth
     WaitMovement
-    Message 3
+    Message DistortionWorldGiratinaRoom_Text_GiratinaUnderstoodUs
     CloseMessage
-    Message 6
-    GoTo _0194
+    Message DistortionWorldGiratinaRoom_Text_YouRefusedToBattle
+    GoTo DistortionWorldGiratinaRoom_PostBattle
 
-_016E:
+DistortionWorldGiratinaRoom_CaughtGiratina:
     SetFlag FLAG_CAUGHT_GIRATINA
     SetFlag FLAG_HIDE_TURNBACK_CAVE_GIRATINA_ROOM_GIRATINA
     ClearFlag FLAG_HIDE_TURNBACK_CAVE_GIRATINA_ROOM_ITEM
-    AddDistortionWorldMapObject 130
-    AddDistortionWorldMapObject 129
-    ApplyMovement 129, _0250
+    AddDistortionWorldMapObject LOCALID_CYRUS
+    AddDistortionWorldMapObject LOCALID_CYNTHIA
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldGiratinaRoom_Movement_CynthiaJumpNorth
     WaitMovement
-    Message 3
+    Message DistortionWorldGiratinaRoom_Text_GiratinaUnderstoodUs
     CloseMessage
-    Message 5
-_0194:
+    Message DistortionWorldGiratinaRoom_Text_ThatPokemonWasCaptured
+DistortionWorldGiratinaRoom_PostBattle:
     CloseMessage
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     AddFreeCamera VAR_0x8004, VAR_0x8005
-    ApplyFreeCameraMovement _0280
-    ApplyMovement 130, _026C
-    ApplyMovement 129, _0258
-    ApplyMovement LOCALID_PLAYER, _0244
+    ApplyFreeCameraMovement DistortionWorldGiratinaRoom_Movement_CameraMoveSouth
+    ApplyMovement LOCALID_CYRUS, DistortionWorldGiratinaRoom_Movement_CyrusEnter
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldGiratinaRoom_Movement_CynthiaNoticeCyrus
+    ApplyMovement LOCALID_PLAYER, DistortionWorldGiratinaRoom_Movement_PlayerNoticeCyrus
     WaitMovement
-    Message 7
-    Message 8
-    Message 9
-    Message 10
+    Message DistortionWorldGiratinaRoom_Text_NewWorldCantBeMade
+    Message DistortionWorldGiratinaRoom_Text_PokemonUniteUs
+    Message DistortionWorldGiratinaRoom_Text_BigSilence
+    Message DistortionWorldGiratinaRoom_Text_EnoughBlathering
     CloseMessage
-    ApplyMovement 130, _0274
+    ApplyMovement LOCALID_CYRUS, DistortionWorldGiratinaRoom_Movement_CyrusLeave
     WaitMovement
-    DeleteDistortionWorldMapObject 130
-    ApplyFreeCameraMovement _0288
+    DeleteDistortionWorldMapObject LOCALID_CYRUS
+    ApplyFreeCameraMovement DistortionWorldGiratinaRoom_Movement_CameraMoveNorth
     WaitMovement
     RestoreCamera
-    Message 11
-    ApplyMovement 129, _0264
+    Message DistortionWorldGiratinaRoom_Text_WeCanFeelJoy
+    ApplyMovement LOCALID_CYNTHIA, DistortionWorldGiratinaRoom_Movement_CynthiaWalkOnSpotNorth
     WaitMovement
-    Message 12
+    Message DistortionWorldGiratinaRoom_Text_LetsGoBackHome
     WaitButton
     CloseMessage
     ReleaseAll
     End
 
-_0204:
+DistortionWorldGiratinaRoom_BlackOut:
     BlackOutFromBattle
     ReleaseAll
     End
 
-_020A:
-    NPCMessage 12
+DistortionWorldGiratinaRoom_Cynthia:
+    NPCMessage DistortionWorldGiratinaRoom_Text_LetsGoBackHome
     End
 
-_021D:
+DistortionWorldGiratinaRoom_TriggerFirstShadow:
     LockAll
     PlayCry SPECIES_GIRATINA
-    Message 0
+    Message DistortionWorldGiratinaRoom_Text_GiratinaCryGiygogagogwoh
     WaitCry
     WaitABPadPress
     CloseMessage
     ReleaseAll
     End
 
-_0232:
+DistortionWorldGiratinaRoom_TriggerGiratinaArrival:
     LockAll
     BufferPlayerName 0
-    Message 1
+    Message DistortionWorldGiratinaRoom_Text_GiratinaIsEyeingPlayer
     WaitABPadPress
     CloseMessage
     ReleaseAll
     End
 
     .balign 4, 0
-_0244:
+DistortionWorldGiratinaRoom_Movement_PlayerNoticeCyrus:
     WalkOnSpotNormalSouth
     EmoteExclamationMark
     EndMovement
 
     .balign 4, 0
-_0250:
+DistortionWorldGiratinaRoom_Movement_CynthiaJumpNorth:
     JumpDistortionWorldNorth 2
     EndMovement
 
     .balign 4, 0
-_0258:
+DistortionWorldGiratinaRoom_Movement_CynthiaNoticeCyrus:
     WalkOnSpotNormalSouth
     EmoteExclamationMark
     EndMovement
 
     .balign 4, 0
-_0264:
+DistortionWorldGiratinaRoom_Movement_CynthiaWalkOnSpotNorth:
     WalkOnSpotNormalNorth
     EndMovement
 
     .balign 4, 0
-_026C:
+DistortionWorldGiratinaRoom_Movement_CyrusEnter:
     JumpDistortionWorldNorth
     EndMovement
 
     .balign 4, 0
-_0274:
+DistortionWorldGiratinaRoom_Movement_CyrusLeave:
     JumpDistortionWorldSouth
     WalkNormalSouth 5
     EndMovement
 
     .balign 4, 0
-_0280:
+DistortionWorldGiratinaRoom_Movement_CameraMoveSouth:
     WalkNormalSouth 5
     EndMovement
 
     .balign 4, 0
-_0288:
+DistortionWorldGiratinaRoom_Movement_CameraMoveNorth:
     WalkNormalNorth 5
     EndMovement

--- a/res/field/scripts/scripts_distortion_world_turnback_cave_room.s
+++ b/res/field/scripts/scripts_distortion_world_turnback_cave_room.s
@@ -2,27 +2,27 @@
 #include "res/text/bank/distortion_world_turnback_cave_room.h"
 
 
-    ScriptEntry _000A
-    ScriptEntry _000E
+    ScriptEntry DistortionWorldTurnbackCaveRoom_OnTransition
+    ScriptEntry DistortionWorldTurnbackCaveRoom_Portal
     ScriptEntryEnd
 
-_000A:
+DistortionWorldTurnbackCaveRoom_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-_000E:
+DistortionWorldTurnbackCaveRoom_Portal:
     PlaySE SEQ_SE_CONFIRM
     LockAll
-    Message 0
+    Message DistortionWorldTurnbackCaveRoom_Text_LeapIntoPortal
     ShowYesNoMenu VAR_RESULT
-    GoToIfEq VAR_RESULT, MENU_YES, _002E
+    GoToIfEq VAR_RESULT, MENU_YES, DistortionWorldTurnbackCaveRoom_GoToTurnbackCave
     CloseMessage
     ReleaseAll
     End
 
-_002E:
+DistortionWorldTurnbackCaveRoom_GoToTurnbackCave:
     BufferPlayerName 0
-    Message 1
+    Message DistortionWorldTurnbackCaveRoom_Text_PlayerLeaptIntoPortal
     CloseMessage
     PlaySE SEQ_SE_PL_SYUWA
     SetPartyGiratinaForm GIRATINA_FORM_ALTERED

--- a/res/text/distortion_world_1f.json
+++ b/res/text/distortion_world_1f.json
@@ -2,11 +2,11 @@
   "key": 29794,
   "messages": [
     {
-      "id": "pl_msg_00000314_00000",
+      "id": "DistortionWorld1F_Text_ThisPlace",
       "en_US": "Cynthia: This place...\r"
     },
     {
-      "id": "pl_msg_00000314_00001",
+      "id": "DistortionWorld1F_Text_SpaceCalledDistortionWorld",
       "en_US": [
         "Can you feel it?\n",
         "There are no Pokémon here at all.\r",
@@ -18,7 +18,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000314_00002",
+      "id": "DistortionWorld1F_Text_LetsFindGiratina",
       "en_US": [
         "Let’s find GIRATINA.\r",
         "We need it to stop the spreading\n",
@@ -26,14 +26,14 @@
       ]
     },
     {
-      "id": "pl_msg_00000314_00003",
+      "id": "DistortionWorld1F_Text_ThatWasGiratina",
       "en_US": [
         "Cynthia: That was...\r",
         "GIRATINA...!"
       ]
     },
     {
-      "id": "pl_msg_00000314_00004",
+      "id": "DistortionWorld1F_Text_WeHaveToHurry",
       "en_US": [
         "We have to hurry!\r",
         "If something’s not done, the distortion\n",
@@ -42,7 +42,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000314_00005",
+      "id": "DistortionWorld1F_Text_SlabMovesIfYouStep",
       "en_US": [
         "Cynthia: This rock slab...\r",
         "It appears to move if you step on a\n",
@@ -50,14 +50,14 @@
       ]
     },
     {
-      "id": "pl_msg_00000314_00006",
+      "id": "DistortionWorld1F_Text_WhyIsGroundColoredDifferently",
       "en_US": [
         "Cynthia: On the ground here...\n",
         "Why is it colored differently?"
       ]
     },
     {
-      "id": "pl_msg_00000314_00007",
+      "id": "DistortionWorld1F_Text_ReturnToSpearPillar",
       "en_US": [
         "There is the portal leading back to\n",
         "the Spear Pillar.\r",
@@ -66,7 +66,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000314_00008",
+      "id": "DistortionWorld1F_Text_PlayerHeadedForSpearPillar",
       "en_US": [
         "{STRVAR_1 3, 0, 0} headed for the Spear\n",
         "Pillar!\r"

--- a/res/text/distortion_world_b1f.json
+++ b/res/text/distortion_world_b1f.json
@@ -2,7 +2,7 @@
   "key": 29806,
   "messages": [
     {
-      "id": "pl_msg_00000315_00000",
+      "id": "DistortionWorldB1F_Text_WillWeSeeGiratina",
       "en_US": [
         "Cynthia: Will we get to see GIRATINA if\n",
         "we keep going down?\r",
@@ -11,7 +11,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000315_00001",
+      "id": "DistortionWorldB1F_Text_MespritCry",
       "en_US": "MESPRIT: Piih!\r"
     }
   ]

--- a/res/text/distortion_world_b2f.json
+++ b/res/text/distortion_world_b2f.json
@@ -2,7 +2,7 @@
   "key": 29802,
   "messages": [
     {
-      "id": "pl_msg_00000316_00000",
+      "id": "DistortionWorldB2F_Text_LetsSplitUp",
       "en_US": [
         "Cynthia: The legend of GIRATINA has\n",
         "been all but forgotten but to a few...\r",
@@ -17,7 +17,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000316_00001",
+      "id": "DistortionWorldB2F_Text_DontNeedToGoTogether",
       "en_US": [
         "We don’t need to go together now.\n",
         "Let’s keep looking for the way down."

--- a/res/text/distortion_world_b3f.json
+++ b/res/text/distortion_world_b3f.json
@@ -2,7 +2,7 @@
   "key": 29814,
   "messages": [
     {
-      "id": "pl_msg_00000317_00000",
+      "id": "DistortionWorldB3F_Text_DoYouUnderstandGenes",
       "en_US": [
         "Cyrus: ...The shadowy Pokémon isn’t\n",
         "here.\r",
@@ -15,15 +15,15 @@
       ]
     },
     {
-      "id": "pl_msg_00000317_00001",
+      "id": "DistortionWorldB3F_Text_YouveImpressedMe",
       "en_US": "...If it’s true, you’ve impressed me.\r"
     },
     {
-      "id": "pl_msg_00000317_00002",
+      "id": "DistortionWorldB3F_Text_OfCourseYouWouldnt",
       "en_US": "...No, of course, you wouldn’t.\r"
     },
     {
-      "id": "pl_msg_00000317_00003",
+      "id": "DistortionWorldB3F_Text_TwoWorldsMustBalance",
       "en_US": [
         "Genes can be considered the blueprints\n",
         "of all life-forms.\r",
@@ -57,7 +57,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000317_00004",
+      "id": "DistortionWorldB3F_Text_DefeatingThatPokemonMatters",
       "en_US": [
         "The shadowy Pokémon must have made\n",
         "this bizarre world.\r",

--- a/res/text/distortion_world_b6f.json
+++ b/res/text/distortion_world_b6f.json
@@ -2,19 +2,19 @@
   "key": 29766,
   "messages": [
     {
-      "id": "pl_msg_00000318_00000",
+      "id": "DistortionWorldB6F_Text_MespritCry",
       "en_US": "MESPRIT: Piih!\r"
     },
     {
-      "id": "pl_msg_00000318_00001",
+      "id": "DistortionWorldB6F_Text_UxieCry",
       "en_US": "UXIE: Piih!\r"
     },
     {
-      "id": "pl_msg_00000318_00002",
+      "id": "DistortionWorldB6F_Text_AzelfCry",
       "en_US": "AZELF: Piiuw!\r"
     },
     {
-      "id": "pl_msg_00000318_00003",
+      "id": "DistortionWorldB6F_Text_ThisPlaceGiantPuzzle",
       "en_US": [
         "Cynthia: This place...\n",
         "It seems to be a giant puzzle.\r",
@@ -31,7 +31,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000318_00004",
+      "id": "DistortionWorldB6F_Text_LakePokemonWentHome",
       "en_US": [
         "Cynthia: I guess the Pokémon of the\n",
         "lakes must have gone home.\r",
@@ -44,7 +44,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000318_00005",
+      "id": "DistortionWorldB6F_Text_WereGettingClose",
       "en_US": [
         "Cynthia: Call it a Trainer’s intuition,\n",
         "but we’re getting close.\r",
@@ -52,7 +52,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000318_00006",
+      "id": "DistortionWorldB6F_Text_BoulderMightFit",
       "en_US": [
         "At the bottom of the pit is a space\n",
         "that a boulder might fit into..."

--- a/res/text/distortion_world_b7f.json
+++ b/res/text/distortion_world_b7f.json
@@ -2,18 +2,18 @@
   "key": 29762,
   "messages": [
     {
-      "id": "pl_msg_00000319_00000",
+      "id": "DistortionWorldB7F_Text_GiratinaIsUpAhead",
       "en_US": [
         "Cynthia: This is it...\n",
         "GIRATINA is up ahead.\r"
       ]
     },
     {
-      "id": "pl_msg_00000319_00001",
+      "id": "DistortionWorldB7F_Text_YouWereAlreadyHere",
       "en_US": "Cynthia: ...So, you were already here.\r"
     },
     {
-      "id": "pl_msg_00000319_00002",
+      "id": "DistortionWorldB7F_Text_WhyChangeTheWorld",
       "en_US": [
         "Cynthia: Why do you seek to change the\n",
         "world?\r",
@@ -24,14 +24,14 @@
       ]
     },
     {
-      "id": "pl_msg_00000319_00003",
+      "id": "DistortionWorldB7F_Text_ThatsNoJustice",
       "en_US": [
         "Cynthia: But...\n",
         "That’s no justice at all!"
       ]
     },
     {
-      "id": "pl_msg_00000319_00004",
+      "id": "DistortionWorldB7F_Text_ThatIsMyJustice",
       "en_US": [
         "Cyrus: Why should I run and hide from\n",
         "the world and have to wait quietly?\r",
@@ -44,7 +44,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000319_00005",
+      "id": "DistortionWorldB7F_Text_IWontLose",
       "en_US": [
         "Cyrus: I won’t lose!\r",
         "Not to that shadowy Pokémon!\n",
@@ -52,7 +52,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000319_00006",
+      "id": "DistortionWorldB7F_Text_YoullDestroyThisWorld",
       "en_US": [
         "Cyrus: ...Don’t think that you can\n",
         "defeat or capture that Pokémon.\r",
@@ -69,7 +69,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000319_00007",
+      "id": "DistortionWorldB7F_Text_DontBelieveHisLies",
       "en_US": [
         "Cynthia: Don’t believe his lies.\r",
         "It’s not possible that a Pokémon can\n",
@@ -90,18 +90,18 @@
       ]
     },
     {
-      "id": "pl_msg_00000319_00008",
+      "id": "DistortionWorldB7F_Text_CynthiaFullyHealedPokemon",
       "en_US": [
         "Cynthia fully healed {STRVAR_1 3, 0, 0}’s\n",
         "Pokémon.\r"
       ]
     },
     {
-      "id": "pl_msg_00000319_00009",
+      "id": "DistortionWorldB7F_Text_LetsGoMeetGiratina",
       "en_US": "Cynthia: Now let’s go meet GIRATINA!\r"
     },
     {
-      "id": "pl_msg_00000319_00010",
+      "id": "DistortionWorldB7F_Text_GiratinaIsEnraged",
       "en_US": [
         "Cynthia: GIRATINA is enraged because\n",
         "the two worlds are endangered.\r",
@@ -121,14 +121,14 @@
       ]
     },
     {
-      "id": "pl_msg_00000319_00011",
+      "id": "DistortionWorldB7F_Text_YourBondIsStrong",
       "en_US": [
         "Cynthia: I know that the bond you\n",
         "share with your Pokémon is strong!"
       ]
     },
     {
-      "id": "pl_msg_00000319_00012",
+      "id": "DistortionWorldB7F_Text_Dummy12",
       "garbage": 7
     }
   ]

--- a/res/text/distortion_world_giratina_room.json
+++ b/res/text/distortion_world_giratina_room.json
@@ -2,43 +2,43 @@
   "key": 28774,
   "messages": [
     {
-      "id": "pl_msg_00000320_00000",
+      "id": "DistortionWorldGiratinaRoom_Text_GiratinaCryGiygogagogwoh",
       "en_US": "Giygogagogwoh!"
     },
     {
-      "id": "pl_msg_00000320_00001",
+      "id": "DistortionWorldGiratinaRoom_Text_GiratinaIsEyeingPlayer",
       "en_US": [
         "GIRATINA is quietly eyeing\n",
         "{STRVAR_1 3, 0, 0}..."
       ]
     },
     {
-      "id": "pl_msg_00000320_00002",
+      "id": "DistortionWorldGiratinaRoom_Text_GiratinaCryGiygogagohgwooh",
       "en_US": "Giygogagohgwooh!\r"
     },
     {
-      "id": "pl_msg_00000320_00003",
+      "id": "DistortionWorldGiratinaRoom_Text_GiratinaUnderstoodUs",
       "en_US": [
         "Cynthia: GIRATINA seems to have\n",
         "understood us!\r"
       ]
     },
     {
-      "id": "pl_msg_00000320_00004",
+      "id": "DistortionWorldGiratinaRoom_Text_ThatPokemonWasDefeated",
       "en_US": [
         "Cyrus: That Pokémon...\r",
         "That shadowy Pokémon was defeated?!\r"
       ]
     },
     {
-      "id": "pl_msg_00000320_00005",
+      "id": "DistortionWorldGiratinaRoom_Text_ThatPokemonWasCaptured",
       "en_US": [
         "Cyrus: That Pokémon...\r",
         "That shadowy Pokémon was captured?!\r"
       ]
     },
     {
-      "id": "pl_msg_00000320_00006",
+      "id": "DistortionWorldGiratinaRoom_Text_YouRefusedToBattle",
       "en_US": [
         "Cyrus: That shadowy Pokémon...\r",
         "You quelled its rage by refusing to\n",
@@ -46,7 +46,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000320_00007",
+      "id": "DistortionWorldGiratinaRoom_Text_NewWorldCantBeMade",
       "en_US": [
         "Your doing so means this irrational\n",
         "world will remain in existence!\r",
@@ -61,7 +61,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000320_00008",
+      "id": "DistortionWorldGiratinaRoom_Text_PokemonUniteUs",
       "en_US": [
         "Cynthia: ...The places we are born.\r",
         "The time we spend living...\r",
@@ -76,11 +76,11 @@
       ]
     },
     {
-      "id": "pl_msg_00000320_00009",
+      "id": "DistortionWorldGiratinaRoom_Text_BigSilence",
       "en_US": "{SIZE 200}Silence!{SIZE 100}\r"
     },
     {
-      "id": "pl_msg_00000320_00010",
+      "id": "DistortionWorldGiratinaRoom_Text_EnoughBlathering",
       "en_US": [
         "Cyrus: Enough of your blathering!\r",
         "That’s how you justify spirit as\n",
@@ -104,7 +104,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000320_00011",
+      "id": "DistortionWorldGiratinaRoom_Text_WeCanFeelJoy",
       "en_US": [
         "Cynthia: ...\n",
         "...\r",
@@ -115,7 +115,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000320_00012",
+      "id": "DistortionWorldGiratinaRoom_Text_LetsGoBackHome",
       "en_US": [
         "Let’s go back home.\r",
         "The portal where GIRATINA was should\n",
@@ -127,14 +127,14 @@
       ]
     },
     {
-      "id": "pl_msg_00000320_00013",
+      "id": "DistortionWorldGiratinaRoom_Text_LeapIntoPortal",
       "en_US": [
         "There is a portal where GIRATINA was.\n",
         "Will you leap into the portal?"
       ]
     },
     {
-      "id": "pl_msg_00000320_00014",
+      "id": "DistortionWorldGiratinaRoom_Text_PlayerLeaptIntoPortal",
       "en_US": "{STRVAR_1 3, 0, 0} leapt into the portal.\r"
     }
   ]

--- a/res/text/distortion_world_turnback_cave_room.json
+++ b/res/text/distortion_world_turnback_cave_room.json
@@ -2,7 +2,7 @@
   "key": 28770,
   "messages": [
     {
-      "id": "pl_msg_00000321_00000",
+      "id": "DistortionWorldTurnbackCaveRoom_Text_LeapIntoPortal",
       "en_US": [
         "There is the portal leading back to\n",
         "the Turnback Cave.\r",
@@ -11,7 +11,7 @@
       ]
     },
     {
-      "id": "pl_msg_00000321_00001",
+      "id": "DistortionWorldTurnbackCaveRoom_Text_PlayerLeaptIntoPortal",
       "en_US": "{STRVAR_1 3, 0, 0} leapt into the portal.\r"
     }
   ]

--- a/src/overlay009/ov9_02249960.c
+++ b/src/overlay009/ov9_02249960.c
@@ -314,21 +314,25 @@ enum EventCmdHandlerResult {
     EVENT_CMD_HANDLER_RES_FINISH,
 };
 
+// NOTE: These constants must mirror those in res/field/scripts/scripts_distortion_world_1f.s
 enum MapObjectEvent1FLocalID {
     MAP_OBJECT_1F_CYNTHIA_PORTAL = MAP_OBJECT_BASE_LOCAL_ID,
     MAP_OBJECT_1F_CYNTHIA_ELEVATOR,
 };
 
+// NOTE: These constants must mirror those in res/field/scripts/scripts_distortion_world_b1f.s
 enum MapObjectEventB1FLocalID {
     MAP_OBJECT_B1F_CYNTHIA_ELEVATOR = MAP_OBJECT_BASE_LOCAL_ID,
     MAP_OBJECT_B1F_MESPRIT,
 };
 
+// NOTE: These constants must mirror those in res/field/scripts/scripts_distortion_world_b2f.s
 enum MapObjectEventB2FLocalID {
     MAP_OBJECT_B2F_CYNTHIA_1 = MAP_OBJECT_BASE_LOCAL_ID,
     MAP_OBJECT_B2F_CYNTHIA_2 = MAP_OBJECT_B2F_CYNTHIA_1,
 };
 
+// NOTE: These constants must mirror those in res/field/scripts/scripts_distortion_world_b3f.s
 enum MapObjectEventB3FLocalID {
     MAP_OBJECT_B3F_CYRUS = MAP_OBJECT_BASE_LOCAL_ID,
 };
@@ -346,6 +350,7 @@ enum MapObjectEventB5FLocalID {
     MAP_OBJECT_B5F_MESPRIT,
 };
 
+// NOTE: These constants must mirror those in res/field/scripts/scripts_distortion_world_b6f.s
 enum MapObjectEventB6FLocalID {
     MAP_OBJECT_B6F_MESPRIT_BOULDER_OUTSIDE = MAP_OBJECT_BASE_LOCAL_ID,
     MAP_OBJECT_B6F_AZELF_BOULDER_OUTSIDE,
@@ -369,6 +374,7 @@ enum MapObjectEventB6FLocalID {
     MAP_OBJECT_B6F_UXIE_BOULDER_IN_PIT,
 };
 
+// NOTE: These constants must mirror those in res/field/scripts/scripts_distortion_world_b7f.s
 enum MapObjectEventB7FLocalID {
     MAP_OBJECT_B7F_CYNTHIA_INITIAL = MAP_OBJECT_BASE_LOCAL_ID,
     MAP_OBJECT_B7F_CYNTHIA_TALKING = MAP_OBJECT_B7F_CYNTHIA_INITIAL,
@@ -377,6 +383,7 @@ enum MapObjectEventB7FLocalID {
     MAP_OBJECT_B7F_CYRUS_TALKING = MAP_OBJECT_B7F_CYRUS_INITIAL,
 };
 
+// NOTE: These constants must mirror those in res/field/scripts/scripts_distortion_world_giratina_room.s
 enum MapObjectEventGiratinaRoomLocalID {
     MAP_OBJECT_GIRATINA_ROOM_GIRATINA = MAP_OBJECT_BASE_LOCAL_ID,
     MAP_OBJECT_GIRATINA_ROOM_CYNTHIA,


### PR DESCRIPTION
This PR documents the script and text files for the distortion world. All the events are handled in `ov9_02249960.c`. This is also where the object event ids are defined as enums. From what I know and tested, I cannot simply import those enums and use them for the scripts. Because of that, I have currently hardcoded the local ids in each script file. The one proposed solution is replacing the `MapObjectEvent...LocalID` enums in `ov9_02249960.c` with `#define`d constants so these can be used in both `ov9_02249960.c` and in the script files. This works, but the downside is that it's ugly, especially for maps with a lot of object_events:
```
#define DIST_WORLD_B6F_LOCALID_MESPRIT_BOULDER_OUTSIDE    DIST_WORLD_BASE_LOCALID
#define DIST_WORLD_B6F_LOCALID_AZELF_BOULDER_OUTSIDE      DIST_WORLD_B6F_LOCALID_MESPRIT_BOULDER_OUTSIDE + 1
#define DIST_WORLD_B6F_LOCALID_UXIE_BOULDER_OUTSIDE       DIST_WORLD_B6F_LOCALID_AZELF_BOULDER_OUTSIDE + 1
#define DIST_WORLD_B6F_LOCALID_MESPRIT                    DIST_WORLD_B6F_LOCALID_UXIE_BOULDER_OUTSIDE + 1
#define DIST_WORLD_B6F_LOCALID_UXIE                       DIST_WORLD_B6F_LOCALID_MESPRIT + 1
...
```
I have a stash for this solution that I could apply, but I'm interested to hear if there are potantially better solutions.