### PR TITLE
Remove VoidMatrix server link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ This repository builds the following ROMs:
 * [**pokeplatinum.us.nds**](https://datomatic.no-intro.org/index.php?page=show_record&s=28&n=4997) (Rev 1): `sha1: 0862ec35b24de5c7e2dcb88c9eea0873110d755c`
 * [**pokeplatinum.us.nds**](https://datomatic.no-intro.org/index.php?page=show_record&s=28&n=3541) (Rev 0): `sha1: ce81046eda7d232513069519cb2085349896dec7`
 
-For contacts and other pret projects, see [pret.github.io](https://pret.github.io/). In addition to the pret Discord, also see the [VoidMatrix Discord (#decomp)](https://discord.gg/prUAgd5).
+For contacts and other pret projects, see [pret.github.io](https://pret.github.io/).


### PR DESCRIPTION
This removes the link to the VoidMatrix discord we've had in the README since the repo's inception. They seem like lovely folks, but currently the only decomp-related channel in the discord is a webhook for pokediamond. In the interest of not confusing new contributors or sending them to the wrong place, we should probably remove this link.