### PR TITLE
Clean-up dataproc implementations + document various project file formats

### DIFF
--- a/docs/datafiles/ingame_trades.md
+++ b/docs/datafiles/ingame_trades.md
@@ -1,0 +1,63 @@
+# In-Game Trade Data File Format
+
+This document describes the file format for in-game trade data consumed by the
+`npctradeproc` build tool. Each NPC trade in the ROM is represented by a JSON
+file `res/npc_trades/<name>.json`, which contains metadata for the in-game trade
+event and the received Pokémon. The fields from each of these files are mapped
+onto the `NPCTradeMon` struct from `include/overlay006/npc_trade.h`.
+
+## Schema
+
+| Field                | Type                      | Description                                                     |
+| -------------------- | ------------------------- | --------------------------------------------------------------- |
+| `name`               | `string`                  | The Pokémon's nickname after the trade.                         |
+| `otName`             | `string`                  | The Original Trainer's name (max 7 characters).                 |
+| `species`            | `enum Species`            | The species of the Pokémon being offered.                       |
+| `hpIV`               | `u8` (0–31)               | HP Individual Value (stored in 5 bits).                         |
+| `atkIV`              | `u8` (0–31)               | Attack Individual Value (stored in 5 bits).                     |
+| `defIV`              | `u8` (0–31)               | Defense Individual Value (stored in 5 bits).                    |
+| `speedIV`            | `u8` (0–31)               | Speed Individual Value (stored in 5 bits).                      |
+| `spAtkIV`            | `u8` (0–31)               | Special Attack Individual Value (stored in 5 bits).             |
+| `spDefIV`            | `u8` (0–31)               | Special Defense Individual Value (stored in 5 bits).            |
+| `unused1`            | `u32`                     | Unused field. Present in the retail ROM.                        |
+| `otID`               | `u32`                     | The Original Trainer's ID number.                               |
+| `cool`               | `u32`                     | Cool contest condition value.                                   |
+| `beauty`             | `u32`                     | Beauty contest condition value.                                 |
+| `cute`               | `u32`                     | Cute contest condition value.                                   |
+| `smart`              | `u32`                     | Smart contest condition value.                                  |
+| `tough`              | `u32`                     | Tough contest condition value.                                  |
+| `personality`        | `u32`                     | Personality value, which determines gender, ability, and nature.|
+| `heldItem`           | `enum Item`               | The item held by the Pokémon.                                   |
+| `otGender`           | `enum Gender`             | The gender of the Original Trainer.                             |
+| `unused2`            | `u32`                     | Unused field. Present in the retail ROM.                        |
+| `language`           | `enum Language`           | The language of the Original Trainer.                           |
+| `requestedSpecies`   | `enum Species`            | The species required in exchange for the trade.                 |
+
+## Example
+
+```json
+{
+    "name": "Kazza",
+    "otName": "Hilary",
+    "species": "SPECIES_ABRA",
+    "hpIV": 15,
+    "atkIV": 15,
+    "defIV": 15,
+    "speedIV": 20,
+    "spAtkIV": 25,
+    "spDefIV": 25,
+    "unused1": 28,
+    "otID": 25643,
+    "cool": 0,
+    "beauty": 0,
+    "cute": 0,
+    "smart": 0,
+    "tough": 0,
+    "personality": 142,
+    "heldItem": "ITEM_ORAN_BERRY",
+    "otGender": "GENDER_FEMALE",
+    "unused2": 0,
+    "language": "LANGUAGE_ENGLISH",
+    "requestedSpecies": "SPECIES_MACHOP"
+}
+```

--- a/docs/datafiles/items.md
+++ b/docs/datafiles/items.md
@@ -1,0 +1,166 @@
+# Item Data File Format
+
+This document describes the file format for item data consumed by the `itemproc`
+build tool. Each item in the ROM is represented by a JSON file
+`res/items/data/<name>.json`. Fields from each of these files are mapped onto
+the `ItemData` struct from `include/item.h` and the `BerryData` struct from
+`include/berry_data.h`.
+
+Bogus items in the retail ROM—those with the `ITEM_UNUSED_` prefix—do not have
+corresponding JSON files. They are assigned placeholder text in the output, but
+they do not produce a data entry.
+
+## Schema
+
+| Field                | Type                           | Description                                                                                    |
+| -------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `name`               | `string`                       | The item's display name (singular).                                                            |
+| `plural`             | `string`                       | The item's display name (plural).                                                              |
+| `article`            | `string`                       | Indefinite article (e.g. "a", "an") for in-game text.                                          |
+| `description`        | `string[]`                     | The item's description, as an array of lines.                                                  |
+| `icon`               | `object`                       | References to the item's icon graphics. See below.                                             |
+| `gbaID`              | `string`                       | The corresponding Gen-III item identifier, or `GBA_ITEM_NONE` for Gen-IV items.                |
+| `price`              | `u16`                          | Base price in Pokédollars paid when purchasing from a shop. `0` means the item cannot be sold. |
+| `effectParam`        | `u8`                           | Generic parameter; semantics vary by item type (e.g., heal amount).                            |
+| `holdEffect`         | `enum ItemHoldEffect`          | Effect when held by a Pokémon.                                                                 |
+| `pluckEffect`        | `define PLUCK_EFFECT`          | Effect when consumed by Bug Bite / Pluck.                                                      |
+| `flingEffect`        | `define FLING_EFFECT`          | Effect when used with Fling.                                                                   |
+| `flingPower`         | `u8`                           | Base power of Fling when this item is flung.                                                   |
+| `naturalGiftPower`   | `u8`                           | Base power of Natural Gift when this item is held. 0 if not a berry.                           |
+| `naturalGiftType`    | `enum PokemonType` or `null`   | Type of Natural Gift when this item is held. `null` if not a berry.                            |
+| `preventToss`        | `bool`                         | If `true`, then the item cannot be tossed or sold.                                             |
+| `canRegister`        | `bool`                         | If `true`, then the item can be registered to the `Y` button.                                  |
+| `fieldPocket`        | `define POCKET`                | The Bag pocket the item belongs to (Items, Medicine, etc.).                                    |
+| `battlePocket`       | `define BATTLE_POCKET_MASK`    | The battle pocket mask for use during battle.                                                  |
+| `fieldUseFunc`       | `define ITEM_USE_FUNC`         | The field-use function invoked from the overworld.                                             |
+| `battleUseFunc`      | `u8`                           | The battle-use function invoked from the battle menu.                                          |
+| `itemUseParams`      | `object` or `null`             | Detailed usage parameters. See below.                                                          |
+| `teachesMove`        | `enum Move`                    | The move taught by this TM or HM (only for TMs/HMs).                                           |
+| `berryData`          | `object`                       | Berry growth and flavor data (only for berries). See below.                                    |
+
+### The `icon` Object
+
+| Field     | Type     | Description                                          |
+| --------- | -------- | ---------------------------------------------------- |
+| `sprite`  | `string` | Name of the NCGR sprite resource for the item icon.  |
+| `palette` | `string` | Name of the NCLR palette resource for the item icon. |
+
+These fields map to the in-game files produced from the inputs in
+`res/items/icons`.
+
+### The `itemUseParams` Object
+
+This object defines the parameters for items that act on a Pokémon in the party
+or in battle. All fields are optional and default to `0` or `false`.
+
+| Field               | Type    | Description                                                      |
+| ------------------- | ------- | ---------------------------------------------------------------- |
+| `healSleep`         | `bool`  | Cures sleep.                                                     |
+| `healPoison`        | `bool`  | Cures poison.                                                    |
+| `healBurn`          | `bool`  | Cures burn.                                                      |
+| `healFreeze`        | `bool`  | Cures freeze.                                                    |
+| `healParalysis`     | `bool`  | Cures paralysis.                                                 |
+| `healConfusion`     | `bool`  | Cures confusion.                                                 |
+| `healAttract`       | `bool`  | Cures infatuation.                                               |
+| `guardSpec`         | `bool`  | Temporarily protects from stat reduction.                        |
+| `revive`            | `bool`  | Revives a fainted Pokémon.                                       |
+| `reviveAll`         | `bool`  | Revives all fainted Pokémon.                                     |
+| `levelUp`           | `bool`  | Increases the Pokémon's level by one.                            |
+| `ppUp`              | `bool`  | Increases a move's PP.                                           |
+| `ppMax`             | `bool`  | Maximizes a move's PP.                                           |
+| `restorePPAllMoves` | `bool`  | Restores PP to all moves.                                        |
+| `atkStages`         | `u8`    | Attack stage change (0–4).                                       |
+| `defStages`         | `u8`    | Defense stage change (0–4).                                      |
+| `spatkStages`       | `u8`    | Special Attack stage change (0–4).                               |
+| `spdefStages`       | `u8`    | Special Defense stage change (0–4).                              |
+| `speedStages`       | `u8`    | Speed stage change (0–4).                                        |
+| `accStages`         | `u8`    | Accuracy stage change (0–4).                                     |
+| `critStages`        | `u8`    | Critical-hit ratio stage change (0–2).                           |
+| `hpRestored`        | `s8`    | HP restored. Use `-1` for 100%, `-2` for 50%, or `-3` for 25%.   |
+| `ppRestored`        | `s8`    | PP restored. Use `-1` for 100%.                                  |
+| `hpEVs`             | `s8`    | HP EVs gained.                                                   |
+| `atkEVs`            | `s8`    | Attack EVs gained.                                               |
+| `defEVs`            | `s8`    | Defense EVs gained.                                              |
+| `speedEVs`          | `s8`    | Speed EVs gained.                                                |
+| `spatkEVs`          | `s8`    | Special Attack EVs gained.                                       |
+| `spdefEVs`          | `s8`    | Special Defense EVs gained.                                      |
+| `friendshipLow`     | `s8`    | Friendship change when friendship < 100.                         |
+| `friendshipMed`     | `s8`    | Friendship change when 100 ≤ friendship < 200.                   |
+| `friendshipHigh`    | `s8`    | Friendship change when friendship ≥ 200.                         |
+
+When `fieldUseFunc` is set to `ITEM_USE_FUNC_BERRY`, `ITEM_USE_FUNC_EVO_STONE`,
+`ITEM_USE_FUNC_HEALING`, or any other use function that acts on a party Pokémon,
+this object is optional but will be used if present.
+
+### The `berryData` Object
+
+| Field               | Type                   | Description                                            |
+| ------------------- | ---------------------- | ------------------------------------------------------ |
+| `size`              | `u16`                  | Size of the berry in millimeters.                      |
+| `firmness`          | `define FIRMNESS`      | Firmness category (Very Soft through Super Hard).      |
+| `baseYield`         | `u8`                   | Base yield per plant.                                  |
+| `stageDuration`     | `u8`                   | Number of stages to grow.                              |
+| `moistureDrainRate` | `u8`                   | How quickly moisture drains.                           |
+| `spiciness`         | `u8`                   | Spicy flavor value.                                    |
+| `dryness`           | `u8`                   | Dry flavor value.                                      |
+| `sweetness`         | `u8`                   | Sweet flavor value.                                    |
+| `bitterness`        | `u8`                   | Bitter flavor value.                                   |
+| `sourness`          | `u8`                   | Sour flavor value.                                     |
+| `smoothness`        | `u8`                   | Smoothness for Poffin cooking.                         |
+
+This field is only recognized when `fieldUseFunc` is `ITEM_USE_FUNC_BERRY`.
+
+## Outputs
+
+The tool produces the following outputs:
+
+| Output                          | Description                                                          |
+| ------------------------------- | -------------------------------------------------------------------- |
+| `pl_item_data.narc`             | `ItemData` entries for every item, packed by index ID.               |
+| `item_id_map.h`                 | Maps item IDs to data index, icon resource, palette, and Gen-III ID. |
+| `item_tm_move_map.h`            | Maps TM indices to the move they teach.                              |
+| `item_berry_list.h`             | Lists all berry items by their berry index.                          |
+| `item_mail_list.h`              | Lists all mail items by their mail type index.                       |
+| `item_names.json`               | Text bank for singular item names.                                   |
+| `item_names_plural.json`        | Text bank for plural item names.                                     |
+| `item_names_with_articles.json` | Text bank for item names with their indefinite article.              |
+| `item_descriptions.json`        | Text bank for item descriptions.                                     |
+| `hidden_item_scripts.h`         | Generated header mapping hidden item script IDs to script entries.   |
+| `nuts_data.narc`                | `BerryData` entries for each in-game berry.                          |
+
+## Example
+
+```json
+{
+    "name": "Potion",
+    "plural": "Potions",
+    "article": "a",
+    "description": [
+        "A spray-type medicine for wounds.\n",
+        "It restores the HP of one Pokémon by\n",
+        "just 20 points."
+    ],
+    "icon": {
+        "sprite": "potion_NCGR",
+        "palette": "potion_NCLR"
+    },
+    "gbaID": "GBA_ITEM_POTION",
+    "price": 300,
+    "effectParam": 20,
+    "holdEffect": "HOLD_EFFECT_NONE",
+    "pluckEffect": "PLUCK_EFFECT_NONE",
+    "flingEffect": "FLING_EFFECT_NONE",
+    "flingPower": 30,
+    "naturalGiftPower": 0,
+    "naturalGiftType": null,
+    "preventToss": false,
+    "canRegister": false,
+    "fieldPocket": "POCKET_MEDICINE",
+    "battlePocket": "BATTLE_POCKET_MASK_RECOVER_HP",
+    "fieldUseFunc": "ITEM_USE_FUNC_HEALING",
+    "battleUseFunc": 2,
+    "itemUseParams": {
+        "hpRestored": 20
+    }
+}
+```

--- a/docs/datafiles/pokemon.md
+++ b/docs/datafiles/pokemon.md
@@ -1,0 +1,361 @@
+# Pokémon Data File Format
+
+This document describes the file format for Pokémon species data consumed by the
+`speciesproc` build tool. Each species in the ROM is represented by a directory
+`res/pokemon/<species>` which must contain the following files:
+
+| File               | Purpose                                                        |
+| ------------------ | -------------------------------------------------------------- |
+| `data.json`        | Internal metadata (stats, types, learnsets, evolutions, etc.)  |
+| `sprite_data.json` | Sprite offset, shadow, and animation data (National Dex only)  |
+
+Some alternate forms have their own input data due to differing base stats,
+types, or abilities. In the retail ROM, this includes forms for:
+
+1. Deoxys
+2. Wormadam
+3. Shaymin
+4. Giratina
+5. Rotom
+
+Each such form has a corresponding subdirectory under their species parent, e.g.
+`giratina/forms/origin`. These forms have a similar `data.json` file, but they
+do not have a `sprite_data.json` file.
+
+## `data.json` — Internal Metadata
+
+The JSON fields from this file map onto the `SpeciesData`, `SpeciesEvolution`,
+`SpeciesLearnset`, and `SpeciesPalPark` structs from
+`include/struct_defs/species.h`.
+
+### Schema
+
+| Field               | Type                 | Description                                                                                     |
+| ------------------- | -------------------- | ----------------------------------------------------------------------------------------------- |
+| `base_stats`        | `object`             | Base stat values (HP, Attack, Defense, Speed, Sp. Atk, Sp. Def).                                |
+| `types`             | `enum PokemonType[]` | The species' primary and secondary types (2 elements).                                          |
+| `catch_rate`        | `u8`                 | Catch rate (0–255).                                                                             |
+| `base_exp_reward`   | `u8`                 | Base experience yield on defeat.                                                                |
+| `ev_yields`         | `object`             | EV yield values (2-bit each) for each stat.                                                     |
+| `held_items.common` | `enum Item`          | The common wild held item (20%).                                                                |
+| `held_items.rare`   | `enum Item`          | The rare wild held item (5%).                                                                   |
+| `gender_ratio`      | `enum GenderRatio`   | Gender ratio of the species.                                                                    |
+| `hatch_cycles`      | `u8`                 | Number of hatch cycles (255 x cycle length).                                                    |
+| `base_friendship`   | `u8`                 | Base friendship level.                                                                          |
+| `exp_rate`          | `enum ExpRate`       | Level-up experience curve.                                                                      |
+| `egg_groups`        | `enum EggGroup[]`    | Egg groups for breeding (2 elements).                                                           |
+| `abilities`         | `enum Ability[]`     | Slot 1 and slot 2 abilities (2 elements).                                                       |
+| `safari_flee_rate`  | `u8`                 | Safari Zone flee rate.                                                                          |
+| `body_color`        | `enum PokemonColor`  | Pokédex body color.                                                                             |
+| `flip_sprite`       | `bool`               | Whether the in-battle sprite should be flipped horizontally in menus (like the summary screen). |
+| `icon_palette`      | `u8` or `array`      | Icon palette index; array of `[form_name, index]` tuples for species with per-form palettes.    |
+| `learnset`          | `object`             | Learnset data (level-up, TM/HM, tutor, egg moves). See below.                                   |
+| `evolutions`        | `array`              | Evolution methods and targets.                                                                  |
+| `offspring`         | `enum Species`       | The species produced when breeding (usually self).                                              |
+| `footprint`         | `object`             | Footprint data for the Pokédex.                                                                 |
+| `pokedex_data`      | `object`             | Pokédex entry text, height, weight, body shape, and sprite scales/positions.                    |
+| `catching_show`     | `object`             | Pal Park encounter data.                                                                        |
+
+#### The `learnset` Object
+
+| Field      | Type          | Description                                                               |
+| ---------- | ------------- | ------------------------------------------------------------------------- |
+| `by_level` | `array`       | Level-up learnset: array of `[level, move]` tuples.                       |
+| `by_tm`    | `string[]`    | TM/HM compatibility: array of TM or HM markers (e.g. `"TM01"`, `"HM04"`). |
+| `by_tutor` | `enum Move[]` | Moves teachable by move tutors.                                           |
+| `egg_moves`| `enum Move[]` | Moves available as egg moves (optional).                                  |
+
+If a move listed in the `by_tutor` array is not teachable by any move tutor in
+the game, then a warning will be emitted, and that move will be skipped.
+
+No validation is performed against `egg_moves` due to the potential cost of
+analyzing every other member of each egg group.
+
+#### The `evolutions` Array
+
+Each element is a tuple describing one evolution path:
+
+| Index | Type                   | Description                                                            |
+| ----- | ---------------------- | ---------------------------------------------------------------------- |
+| 0     | `enum EvolutionMethod` | The evolution method (level, trade, item, etc.)                        |
+| 1     | varies                 | The parameter for the method (level, item, move, species, or nothing). |
+| 2     | `enum Species`         | The target species to evolve into.                                     |
+
+The parameter type depends on the method:
+
+- For `EVO_LEVEL`, `EVO_LEVEL_ATK_GT_DEF`, etc., it is the level at which the
+  evolution should trigger.
+- For `EVO_USE_ITEM`, `EVO_TRADE_WITH_HELD_ITEM`, etc., it is the `enum Item`
+  required to be held or used to trigger the evolution.
+- For `EVO_LEVEL_KNOW_MOVE`, it is an `enum Move` which must be known for the
+  next level-up to trigger the evolution.
+- For `EVO_LEVEL_SPECIES_IN_PARTY`, it is an `enum Species` which must be
+  present in the party for the next level-up to trigger the evolution.
+- For `EVO_NONE`, `EVO_LEVEL_HAPPINESS`, `EVO_TRADE`, there is no listed
+  parameter, and the evolution only has two elements: `[method, species]`.
+
+#### The `footprint` Object
+
+| Field  | Type                    | Description                                         |
+| ------ | ----------------------- | --------------------------------------------------- |
+| `has`  | `bool`                  | Whether the species has a footprint in the Pokédex. |
+| `size` | `enum FootprintSize`    | The relative size of the footprint.                 |
+| `type` | `define FOOTPRINT_TYPE` | The footprint type (e.g. Cute, Scary, etc.).        |
+
+#### The `pokedex_data` Object
+
+Height and weight may be specified in either metric or imperial units, but not
+both.
+
+| Field              | Type                    | Description                                              |
+| ------------------ | ----------------------- | -------------------------------------------------------- |
+| `height_meters`    | `float`                 | Height in meters (alternative to `height_inches`).       |
+| `height_inches`    | `u32`                   | Height in inches (alternative to `height_meters`).       |
+| `weight_kilograms` | `float`                 | Weight in kilograms (alternative to `weight_pounds`).    |
+| `weight_pounds`    | `float`                 | Weight in pounds (alternative to `weight_kilograms`).    |
+| `body_shape`       | `enum PokemonBodyShape` | Pokédex body shape category.                             |
+| `trainer_scale_f`  | `u16`                   | Trainer back-sprite scale (female).                      |
+| `pokemon_scale_f`  | `u16`                   | Pokémon front-sprite scale (female).                     |
+| `trainer_scale_m`  | `u16`                   | Trainer back-sprite scale (male).                        |
+| `pokemon_scale_m`  | `u16`                   | Pokémon front-sprite scale (male).                       |
+| `trainer_pos_f`    | `u16`                   | Trainer back-sprite Y-position offset (female).          |
+| `pokemon_pos_f`    | `u16`                   | Pokémon front-sprite Y-position offset (female).         |
+| `trainer_pos_m`    | `u16`                   | Trainer back-sprite Y-position offset (male).            |
+| `pokemon_pos_m`    | `u16`                   | Pokémon front-sprite Y-position offset (male).           |
+| `origin_forme`     | `object`                | Alternate-forme Pokédex data (Giratina only). See below. |
+| `en`, `fr`, `etc.` | `object`                | Localized Pokédex data. See below.                       |
+
+The `origin_forme` sub-object uses the same schema as the top-level
+`pokedex_data` (height, weight, body shape, scales, and positions) and is only
+present for Giratina to support its Origin Forme.
+
+Each language sub-object has the following fields:
+
+| Field        | Type       | Description                                   |
+| ------------ | ---------- | --------------------------------------------- |
+| `name`       | `string`   | The species name in that language.            |
+| `category`   | `string`   | The species category (e.g. "Lizard Pokémon"). |
+| `entry_text` | `string[]` | The Pokédex entry text, as an array of lines. |
+
+#### The `catching_show` Object
+
+| Field                 | Type                    | Description                              |
+| --------------------- | ----------------------- | ---------------------------------------- |
+| `pal_park_land_area`  | `enum PalParkLandArea`  | Pal Park land area assignment.           |
+| `pal_park_water_area` | `enum PalParkWaterArea` | Pal Park water area assignment.          |
+| `catching_points`     | `u8`                    | Catching show points awarded.            |
+| `rarity`              | `u8`                    | Rarity score for the catching show.      |
+| `unused`              | `u16`                   | Unused field. Present in the retail ROM. |
+
+## `sprite_data.json` — Sprite Offsets and Animation Data
+
+This file is only processed for species present in the National Pokédex (that
+is, those with an ID less than `SPECIES_EGG`) and defines the battle sprite
+layout and some animation parameters.
+
+| Field    | Type     | Description                                    |
+| -------- | -------- | ---------------------------------------------- |
+| `front`  | `object` | Front-face sprite animation and Y-offset data. |
+| `back`   | `object` | Back-face sprite animation and Y-offset data.  |
+| `shadow` | `object` | Shadow sprite position and size.               |
+
+### The `front` and `back` Objects
+
+| Field           | Type       | Description                                              |
+| --------------- | ---------- | -------------------------------------------------------- |
+| `y_offset`      | `object`   | Per-gender Y-offsets for the sprite (`male` / `female`). |
+| `addl_y_offset` | `s8`       | Additional Y-offset (front only).                        |
+| `animation`     | `u8`       | Pre-programmed animation sequence ID.                    |
+| `cry_delay`     | `u8`       | Frames to wait before playing the cry.                   |
+| `start_delay`   | `u8`       | Frames to wait before starting the animation.            |
+| `frames`        | `object[]` | Array of animation frame definitions (up to 10 frames).  |
+
+#### The `frame` Objects
+
+| Field          | Type | Description                           |
+| -------------- | ---- | ------------------------------------- |
+| `sprite_frame` | `s8` | Sprite frame index (`-1` = no frame). |
+| `frame_delay`  | `u8` | Duration of this frame in ticks.      |
+| `x_shift`      | `s8` | Horizontal shift for this frame.      |
+| `y_shift`      | `s8` | Vertical shift for this frame.        |
+
+### The `shadow` Object
+
+| Field      | Type              | Description                             |
+| ---------- | ----------------- | --------------------------------------- |
+| `x_offset` | `s8`              | Horizontal offset of the shadow sprite. |
+| `size`     | `enum ShadowSize` | Size category of the shadow sprite.     |
+
+### Outputs
+
+The tool produces the following outputs:
+
+| Output                                   | Description                                                       |
+| ---------------------------------------- | ----------------------------------------------------------------- |
+| `pl_personal.narc`                       | `SpeciesData` entries for every species and alternate form.       |
+| `evo.narc`                               | `SpeciesEvolution` entries.                                       |
+| `wotbl.narc`                             | Level-up learnset entries for every species.                      |
+| `height.narc`                            | Per-gender sprite Y-offsets (4 files per National Dex species).   |
+| `pl_poke_data.narc`                      | `SpeciesSpriteData` for all National Dex species.                 |
+| `ppark.narc`                             | `SpeciesPalPark` data for all National Dex species.               |
+| `pms.narc`                               | Offspring species map (breeding species resolution).              |
+| `zukan_data(_gira).narc`                 | Data for the sorted Pokédex indices (by height, by weight, etc.). |
+| `tutorable_moves.h`                      | Move tutor definitions and costs.                                 |
+| `species_learnsets_by_tutor.h`           | Bitmask of tutorable moves per species.                           |
+| `species_egg_moves.h`                    | Egg move lists per species.                                       |
+| `species_footprint_sizes.h`              | Footprint size per species.                                       |
+| `species_footprint_types.h`              | Footprint type per species.                                       |
+| `species_icon_palettes.h`                | Icon palette index per species.                                   |
+| `species_name.json`                      | Text bank for species names.                                      |
+| `species_name_with_articles.json`        | Text bank for species names with indefinite articles.             |
+| `species_pokedex_entry_*.json`           | Text banks for Pokédex entries in 6 languages.                    |
+| `species_name_with_natdex_number_*.json` | Text banks for species names with National Dex numbers.           |
+| `species_category*.json`                 | Text banks for species categories.                                |
+| `species_weight*.json`                   | Text banks for Pokédex weight display.                            |
+| `species_height*.json`                   | Text banks for Pokédex height display.                            |
+
+### Example
+
+```json
+{
+    "base_stats": {
+        "hp": 39,
+        "attack": 52,
+        "defense": 43,
+        "speed": 65,
+        "special_attack": 60,
+        "special_defense": 50
+    },
+    "types": [ "TYPE_FIRE", "TYPE_FIRE" ],
+    "catch_rate": 45,
+    "base_exp_reward": 65,
+    "ev_yields": {
+        "hp": 0,
+        "attack": 0,
+        "defense": 0,
+        "speed": 1,
+        "special_attack": 0,
+        "special_defense": 0
+    },
+    "held_items": {
+        "common": "ITEM_NONE",
+        "rare": "ITEM_NONE"
+    },
+    "gender_ratio": "GENDER_RATIO_FEMALE_12_5",
+    "hatch_cycles": 20,
+    "base_friendship": 70,
+    "exp_rate": "EXP_RATE_MEDIUM_SLOW",
+    "egg_groups": [ "EGG_GROUP_MONSTER", "EGG_GROUP_DRAGON" ],
+    "abilities": [ "ABILITY_BLAZE", "ABILITY_NONE" ],
+    "safari_flee_rate": 0,
+    "body_color": "MON_COLOR_RED",
+    "flip_sprite": false,
+    "icon_palette": 0,
+    "learnset": {
+        "by_level": [
+            [ 1, "MOVE_SCRATCH" ],
+            [ 1, "MOVE_GROWL" ],
+            [ 7, "MOVE_EMBER" ],
+            [ 10, "MOVE_SMOKE_SCREEN" ],
+            [ 16, "MOVE_DRAGON_RAGE" ]
+        ],
+        "by_tm": [
+            "TM01", "TM02", "TM06", "TM10",
+            "HM01", "HM04", "HM06"
+        ],
+        "by_tutor": [
+            "MOVE_MUD_SLAP",
+            "MOVE_FIRE_PUNCH",
+            "MOVE_SNORE"
+        ],
+        "egg_moves": [
+            "MOVE_BELLY_DRUM",
+            "MOVE_OUTRAGE",
+            "MOVE_DRAGON_DANCE"
+        ]
+    },
+    "evolutions": [
+        [ "EVO_LEVEL", 16, "SPECIES_CHARMELEON" ]
+    ],
+    "offspring": "SPECIES_CHARMANDER",
+    "footprint": {
+        "has": true,
+        "size": "FOOTPRINT_MEDIUM",
+        "type": "FOOTPRINT_TYPE_CUTE"
+    },
+    "pokedex_data": {
+        "height_inches": 24,
+        "weight_pounds": 18.7,
+        "body_shape": "SHAPE_BIPEDAL_TAILED",
+        "trainer_scale_f": 272,
+        "pokemon_scale_f": 384,
+        "trainer_scale_m": 256,
+        "pokemon_scale_m": 384,
+        "trainer_pos_f": 8,
+        "pokemon_pos_f": 23,
+        "trainer_pos_m": 9,
+        "pokemon_pos_m": 23,
+        "en": {
+            "name": "CHARMANDER",
+            "category": "Lizard Pokémon",
+            "entry_text": [
+                "The fire on the tip of its tail is a\n",
+                "measure of its life. If healthy,\n",
+                "its tail burns intensely."
+            ]
+        },
+        "fr": {
+            "name": "SALAMECHE",
+            "category": "Pokémon Lézard",
+            "entry_text": [
+                "La flamme de sa queue symbolise sa\n",
+                "vitalité. Elle est intense quand il\n",
+                "est en bonne santé."
+            ]
+        },
+        "de": {
+            "name": "GLUMANDA",
+            "category": "Echse",
+            "entry_text": [
+                "Lodert die Flamme auf seiner\n",
+                "Schweifspitze hell, ist GLUMANDA\n",
+                "gesund."
+            ]
+        },
+        "it": {
+            "name": "CHARMANDER",
+            "category": "Pokémon Lucertola",
+            "entry_text": [
+                "La fiamma sulla punta della coda\n",
+                "indica la sua vitalità. Se sta bene,\n",
+                "la fiamma è più ardente."
+            ]
+        },
+        "es": {
+            "name": "CHARMANDER",
+            "category": "Pokémon Lagartija",
+            "entry_text": [
+                "La llama de la punta de su cola\n",
+                "indica su salud. Si CHARMANDER\n",
+                "está sano, arderá con más fuerza."
+            ]
+        },
+        "jp": {
+            "name": "ヒトカゲ",
+            "category": "とかげポケモン",
+            "entry_text": [
+                "ヒトカゲの　しっぽの　ほのおは\n",
+                "いのちの　ともしび。げんきな　ときは\n",
+                "ほのおも　ちからづよく　もえあがる。"
+            ]
+        }
+    },
+    "catching_show": {
+        "pal_park_land_area": "PAL_PARK_AREA_LAND_SOUTH_WEST",
+        "pal_park_water_area": "PAL_PARK_AREA_WATER_NONE",
+        "catching_points": 50,
+        "rarity": 30,
+        "unused": 514
+    }
+}
+```

--- a/docs/datafiles/trainers.md
+++ b/docs/datafiles/trainers.md
@@ -1,0 +1,231 @@
+# Trainer Data File Format
+
+This document describes the file format for trainer data consumed by the
+`trainerproc` build tool. Each trainer in the ROM is represented by a JSON file
+`res/trainers/data/<name>.json`, which contains metadata for the trainer and
+their party. The fields from each of these files are mapped onto the structs
+defined in `include/struct_defs/trainer_data.h`.
+
+## Top-Level Schema
+
+| Field           | Type                          | Description                                                      |
+| --------------- | ----------------------------- | ---------------------------------------------------------------- |
+| `name`          | `string`                      | The trainer's display name.                                      |
+| `class`         | `enum TrainerClass`           | The trainer class, e.g. Youngster, Ace Trainer, Gym Leader.      |
+| `items`         | `enum Item[]`                 | Items usable by the trainer in battle (up to 4). May be empty.   |
+| `ai_flags`      | `enum AIFlag[]`               | AI behavior flags for battle scripts. May be empty.              |
+| `double_battle` | `bool`                        | Whether this is a double battle.                                 |
+| `party`         | `object[]`                    | The trainer's party of Pokémon. See below for the member schema. |
+| `messages`      | `object[]`                    | Dialogue messages. See the Messages section below.               |
+
+## Party Member Schema
+
+Each element of the `party` array represents a Pokémon owned by the trainer.
+
+| Field        | Type                    | Description                                                       |
+| ------------ | ----------------------- | ----------------------------------------------------------------- |
+| `species`    | `enum Species`          | The species of the Pokémon.                                       |
+| `form`       | `u8`                    | Form index, packed into the high bits of the species field.       |
+| `level`      | `u16`                   | The level of the Pokémon.                                         |
+| `item`       | `enum Item` or `null`   | The held item, or `null` for none.                                |
+| `moves`      | `enum Move[]` or `null` | Known moves (up to 4), or `null` for default level-up moves.      |
+| `iv_scale`   | `u16`                   | IV scaling factor (0–255).                                        |
+| `ball_seal`  | `u16`                   | Ball seal / capsule decoration index.                             |
+
+The presence of the `item` and `moves` fields determines the exact structure of
+the output data, which affects the trainer's party in-game. If any Pokémon in
+the party specifies that it can have a held item or a custom move-set, then all
+other Pokémon in the party must *also* specify as much.
+
+To illustrate, this party is valid:
+
+```json
+{
+    "party": [
+        {
+            "species": "SPECIES_STARLY",
+            "form": 0,
+            "level": 7,
+            "item": null,
+            "moves": [
+                "MOVE_QUICK_ATTACK",
+                "MOVE_GROWL"
+            ],
+            "iv_scale": 30,
+            "ball_seal": 0
+        },
+        {
+            "species": "SPECIES_CHIMCHAR",
+            "form": 0,
+            "level": 9,
+            "item": null,
+            "moves": [
+                "MOVE_SCRATCH",
+                "MOVE_LEER"
+            ],
+            "iv_scale": 30,
+            "ball_seal": 0
+        }
+    ]
+}
+```
+
+However, this party is *not* valid, as Chimchar specifies that it has data for
+its held-item, while Starly does not:
+
+```json
+{
+    "party": [
+        {
+            "species": "SPECIES_STARLY",
+            "form": 0,
+            "level": 7,
+            "item": null,
+            "moves": [
+                "MOVE_QUICK_ATTACK",
+                "MOVE_GROWL"
+            ],
+            "iv_scale": 30,
+            "ball_seal": 0
+        },
+        {
+            "species": "SPECIES_CHIMCHAR",
+            "form": 0,
+            "level": 9,
+            "item": "ITEM_ORAN_BERRY",
+            "moves": [
+                "MOVE_SCRATCH",
+                "MOVE_LEER"
+            ],
+            "iv_scale": 30,
+            "ball_seal": 0
+        }
+    ],
+}
+```
+
+Similarly, this party would also be invalid, as Starly declares that it should
+derive its move-set from the moves that it learns by level-up, while Chimchar
+declares that it has a custom move-set:
+
+```json
+{
+    "party": [
+        {
+            "species": "SPECIES_STARLY",
+            "form": 0,
+            "level": 7,
+            "item": null,
+            "moves": null,
+            "iv_scale": 30,
+            "ball_seal": 0
+        },
+        {
+            "species": "SPECIES_CHIMCHAR",
+            "form": 0,
+            "level": 9,
+            "item": null,
+            "moves": [
+                "MOVE_SCRATCH",
+                "MOVE_LEER"
+            ],
+            "iv_scale": 30,
+            "ball_seal": 0
+        }
+    ],
+}
+```
+
+## Messages
+
+The `messages` array defines dialogue that the trainer may speak at various
+points during a battle. Each entry has a `type` field drawn from
+`enum TrainerMessageType` (e.g. `TRMSG_PRE_BATTLE`, `TRMSG_DEFEAT`,
+`TRMSG_POST_BATTLE`, `TRMSG_REMATCH`) and an `en_US` field containing the
+message text. As with the text-files stored in `res/text`, the content may be
+a single string or an array of strings as a convenience for multi-line messages.
+Entries with the `garbage` key in place of `en_US` represent padding present in
+the retail ROM.
+
+## Outputs
+
+The tool produces the following outputs:
+
+| Output                      | Description                                                    |
+| --------------------------- | -------------------------------------------------------------- |
+| `trdata.narc`               | `TrainerHeader` entries for every trainer, packed by index ID. |
+| `trpoke.narc`               | Party data for every trainer, packed by index ID.              |
+| `trainer_scripts.h`         | Generated header mapping trainer IDs to `ScriptEntry` macros.  |
+| `npc_trainer_names.json`    | Text bank for trainer display names.                           |
+| `npc_trainer_messages.json` | Text bank for in-battle trainer dialogue.                      |
+| `trtbl.narc`                | Message lookup table mapping `(trainerID, messageType)` pairs. |
+| `trtblofs.narc`             | Offset table into `trtbl.narc` for each trainer index.         |
+
+## Example
+
+```json
+{
+    "name": "Catherine",
+    "class": "TRAINER_CLASS_ACE_TRAINER_FEMALE",
+    "items": [],
+    "ai_flags": [
+        "AI_FLAG_BASIC",
+        "AI_FLAG_EVAL_ATTACK",
+        "AI_FLAG_EXPERT"
+    ],
+    "double_battle": false,
+    "party": [
+        {
+            "species": "SPECIES_HAUNTER",
+            "form": 0,
+            "level": 23,
+            "item": null,
+            "moves": [
+                "MOVE_NIGHT_SHADE",
+                "MOVE_CONFUSE_RAY",
+                "MOVE_SUCKER_PUNCH",
+                "MOVE_CURSE"
+            ],
+            "iv_scale": 60,
+            "ball_seal": 0
+        },
+        {
+            "species": "SPECIES_MISDREAVUS",
+            "form": 0,
+            "level": 24,
+            "item": null,
+            "moves": [
+                "MOVE_PSYBEAM",
+                "MOVE_PAIN_SPLIT",
+                "MOVE_CONFUSE_RAY",
+                "MOVE_SPITE"
+            ],
+            "iv_scale": 60,
+            "ball_seal": 0
+        }
+    ],
+    "messages": [
+        {
+            "type": "TRMSG_PRE_BATTLE",
+            "en_US": [
+                "What does it feel like, taking one step\n",
+                "after another into darkness?\r"
+            ]
+        },
+        {
+            "type": "TRMSG_DEFEAT",
+            "en_US": [
+                "You’re the kind of person who can keep\n",
+                "going forward even into the unknown.\n"
+            ]
+        },
+        {
+            "type": "TRMSG_POST_BATTLE",
+            "en_US": [
+                "I think, sometimes, one has to make\n",
+                "mistakes to learn what is right.\n"
+            ]
+        }
+    ]
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,10 @@ For more detailed information about the project as a whole, please refer to its
 ## Working with Files for Various Data Types
 
 - [Overview of the Processing Tools](datafiles/overview.md)
+- [Pokémon Species](datafiles/pokemon.md)
+- [In-Game Trainers](datafiles/trainers.md)
+- [In-Game Trades](datafiles/trainers.md)
+- [Items](datafiles/items.md)
 - [Moves](datafiles/moves.md)
 
 ## Subsystems

--- a/res/trainers/meson.build
+++ b/res/trainers/meson.build
@@ -6,26 +6,6 @@
 #       AI behavior flags, and items on-hand.
 #     - trpoke - party information for individual trainers in-game
 
-trainer_data_dir = meson.current_source_dir() / 'data'
-
-# 1. Build the list of trainer stems, which define the files to be scanned
-# by the batch processor below. While building this list, assert that each
-# stem must have a corresponding data file.
-trainer_consts = fs.read(trainers_txt).splitlines()
-trainer_stems = []
-trainer_data_files = []
-foreach trainer : trainer_consts
-    # `substring` here strips the `TRAINER_` prefix
-    trainer_stem = trainer.substring(8).to_lower()
-    trainer_stems += trainer_stem
-    trainer_data_files += files(trainer_data_dir / (trainer_stem + '.json'))
-endforeach
-
-# 2. Build the environment of trainer stems to be passed to the batch processor.
-trainer_env = environment()
-trainer_env.append('TRAINERS', trainer_stems, separator: ';')
-
-# 3. Process the trainer data files in batch and emit header data + party lists.
 trainer_data = custom_target('trainer_data',
     output: [
         'trdata.narc',
@@ -41,13 +21,10 @@ trainer_data = custom_target('trainer_data',
         trainerproc_exe,
         '-M', '@DEPFILE@',
         '-o', meson.current_build_dir(),
-        trainer_data_dir,
+        meson.global_build_root() / 'generated' / 'trainers.h',
+        meson.current_source_dir() / 'data',
     ],
 
-    env: trainer_env,
-    depend_files: [
-        trainer_data_files,
-    ],
     depfile: 'trainer_data.d',
 )
 

--- a/tools/dataproc/src/common.c
+++ b/tools/dataproc/src/common.c
@@ -662,6 +662,12 @@ void bank_pushraw(datanode_t *root, const char *id, const char *content) {
     dp_obj_putstring(&entry, "en_US", content);
 }
 
+void bank_pushgarbage(datanode_t *root, const char *id, uint64_t size) {
+    datanode_t entry = dp_arr_appobject(root);
+    dp_obj_putstring(&entry, "id", id);
+    dp_obj_putint(&entry, "garbage", size);
+}
+
 void bank_pushlines(datanode_t *root, const char *id, ...) {
     va_list content;
     va_start(content, id);

--- a/tools/dataproc/src/common.h
+++ b/tools/dataproc/src/common.h
@@ -188,13 +188,17 @@ nitroarc_packer_t init_narc(u16 num_files, bool named, bool stripped);
 
 void bank_pushnode(datanode_t *root, const char *id, datanode_t content);
 void bank_pushraw(datanode_t *root, const char *id, const char *content);
+void bank_pushgarbage(datanode_t *root, const char *id, uint64_t size);
 void bank_pushlines(datanode_t *root, const char *id, ...);
 
 #define bank_push(bank, id, content)      \
     _Generic((content),                   \
         char *:       bank_pushraw,       \
         const char *: bank_pushraw,       \
-        datanode_t:   bank_pushnode       \
+        datanode_t:   bank_pushnode,      \
+        int:          bank_pushgarbage,   \
+        int64_t:      bank_pushgarbage,   \
+        uint64_t:     bank_pushgarbage    \
     )(&textbanks[bank].root, id, content)
 
 #define bank_pushm(bank, id, ...) bank_pushlines(&textbanks[bank].root, id, __VA_ARGS__, NULL)

--- a/tools/dataproc/src/dexproc.c
+++ b/tools/dataproc/src/dexproc.c
@@ -11,6 +11,11 @@
 
 #include "constants/species.h"
 
+static enum_template_t enums[] = {
+    include_enum("generated/species.h", "enum Species"),
+    { .from_file = NULL },
+};
+
 static header_template_t headers[] = {
     { .out_filename = "regional_pokedex_size.h" },
     { .out_filename = NULL                      },
@@ -33,7 +38,7 @@ static int  addl_done(void);
 
 int main(int argc, char *argv[]) {
     parse_args(&argc, &argv);
-    common_init(DATAPROC_F_JSON, NULL, NULL, headers, NULL, __FILE__, depfile_fpath, output_dir, pre_init, NULL);
+    common_init(DATAPROC_F_JSON, enums, NULL, headers, NULL, __FILE__, depfile_fpath, output_dir, pre_init, NULL);
 
     datafile_t df   = { 0 };
     unsigned   errc = EXIT_SUCCESS;
@@ -47,8 +52,6 @@ int main(int argc, char *argv[]) {
 
 static void pre_init(void) {
     assert(NATIONAL_DEX_COUNT < UINT16_MAX);
-    dp_regmetang(Species);
-
     national_count = NATIONAL_DEX_COUNT + 1; // include SPECIES_NONE
     national       = calloc(national_count, sizeof(*national));
 }
@@ -66,7 +69,7 @@ static void proc_regional(datafile_t *df) {
     regional       = calloc(regional_count, sizeof(*regional));
     for (u16 i = 0; i < regional_count; i++) {
         datanode_t curr   = dp_arrelem(array, i);
-        datanode_t mapped = dp_lookup(curr, "Species");
+        datanode_t mapped = dp_lookup(curr, "enum Species");
         if (mapped.type != DATAPROC_T_MAPPED) continue;
 
         const u16 species = dp_u16(mapped);

--- a/tools/dataproc/src/frontierproc.c
+++ b/tools/dataproc/src/frontierproc.c
@@ -10,13 +10,18 @@
 #include "nitroarc.h"
 
 #include "constants/moves.h"
-#include "generated/natures.h"
-#include "generated/items.h"
-#include "generated/species.h"
-#include "generated/trainer_classes.h"
-#include "generated/trainer_message_types.h"
 
 #include "struct_defs/battle_frontier_pokemon_data.h"
+
+static enum_template_t enums[] = {
+    include_enum("generated/items.h",                 "enum Item"),
+    include_enum("generated/moves.h",                 "enum Move"),
+    include_enum("generated/natures.h",               "enum Nature"),
+    include_enum("generated/species.h",               "enum Species"),
+    include_enum("generated/trainer_classes.h",       "enum TrainerClass"),
+    include_enum("generated/trainer_message_types.h", "enum TrainerMessageType"),
+    { .from_file = NULL },
+};
 
 enum {
     A_FRONTIER_TRAINERS,
@@ -50,7 +55,6 @@ static char **pk_registry     = NULL;
 static size_t len_pk_registry = 0;
 
 static void parse_args(int *pargc, char ***pargv);
-static void pre_init(void);
 static int  sort_strcmp(const void *lhs, const void *rhs);
 
 static void pack_pokemon_set(datafile_t *df);
@@ -73,7 +77,7 @@ int main(int argc, char *argv[]) {
     archives[A_FRONTIER_TRAINERS].num_files = (u16)len_tr_registry;
     archives[A_FRONTIER_POKEMON].num_files  = (u16)len_pk_registry;
 
-    common_init(DATAPROC_F_JSON, NULL, archives, NULL, textbanks, __FILE__, depfile_fpath, output_dir, pre_init, NULL);
+    common_init(DATAPROC_F_JSON, enums, archives, NULL, textbanks, __FILE__, depfile_fpath, output_dir, NULL, NULL);
 
     char       buf[BUFSIZE];
     datafile_t df   = { 0 };
@@ -126,9 +130,9 @@ static const char *ev_flags[] = {
 
 static void pack_pokemon_set(datafile_t *df) {
     BattleFrontierPokemonData result = {
-        .species = enum_u16(".species", Species),
-        .nature  = enum_u8(".nature", Nature),
-        .item    = enum_u16(".item", Item),
+        .species = enum_u16(".species", enum Species),
+        .nature  = enum_u8(".nature", enum Nature),
+        .item    = enum_u16(".item", enum Item),
         .form    = u16(".form"),
     };
 
@@ -140,7 +144,7 @@ static void pack_pokemon_set(datafile_t *df) {
     }
 
     size_t i = 0;
-    for (; i < num_moves; i++) result.moves[i] = dp_u16(dp_lookup(dp_arrelem(moves, i), "Move"));
+    for (; i < num_moves; i++) result.moves[i] = dp_u16(dp_lookup(dp_arrelem(moves, i), "enum Move"));
     for (; i < LEARNED_MOVES_MAX; i++) result.moves[i] = MOVE_NONE;
 
     for (i = 0; i < countof(ev_flags); i++) {
@@ -160,7 +164,7 @@ static void pack_trainer(datafile_t *df) {
     const size_t size   = 2 + n_sets;
 
     u16 *trainer = calloc(size, sizeof(*trainer));
-    trainer[0]   = dp_u16(dp_lookup(dp_get(df, ".class"), "TrainerClass"));
+    trainer[0]   = dp_u16(dp_lookup(dp_get(df, ".class"), "enum TrainerClass"));
     trainer[1]   = 0;
 
     for (size_t i = 0; i < n_sets; i++) {
@@ -177,10 +181,7 @@ static void pack_trainer(datafile_t *df) {
 static void emit_trainer_name(datafile_t *df, const char *stem) {
     char buf[BUFSIZE] = { 0 };
 
-    const char *name  = dp_string(dp_get(df, ".name"));
-    datanode_t  entry = dp_arr_appobject(&textbanks[T_TRAINER_NAMES].root);
-    dp_obj_putstring(&entry, "id", strfmt("FrontierTrainerNames_Text_%s", stem));
-    dp_obj_putstring(&entry, "en_US", name);
+    bank_push(T_TRAINER_NAMES, strfmt("FrontierTrainerNames_Text_%s", stem), string(".name"));
 }
 
 static void emit_trainer_messages(datafile_t *df, const char *stem) {
@@ -191,33 +192,15 @@ static void emit_trainer_messages(datafile_t *df, const char *stem) {
     for (size_t i = 0; i < n_messages; i++) {
         datanode_t message   = dp_arrelem(messages, i);
         datanode_t type_node = dp_objmemb(message, "type");
-        datanode_t lookup    = dp_lookup(type_node, "TrainerMessageType");
+        datanode_t lookup    = dp_lookup(type_node, "enum TrainerMessageType");
         if (lookup.type != DATAPROC_T_MAPPED) continue;
 
         const char *type  = dp_string(type_node);
-        datanode_t  entry = dp_arr_appobject(&textbanks[T_TRAINER_MESSAGES].root);
-        dp_obj_putstring(&entry, "id", strfmt("FrontierTrainerMessages_Text_%s_%s", stem, type));
-        if (dp_hasmemb(message, "en_US")) {
-            datanode_t content = dp_objmemb(message, "en_US");
-            if (content.type == DATAPROC_T_STRING) {
-                dp_obj_putstring(&entry, "en_US", dp_string(content));
-            }
-            else if (content.type == DATAPROC_T_ARRAY) {
-                datanode_t   lines   = dp_obj_putarray(&entry, "en_US");
-                const size_t n_lines = dp_arrlen(content);
-                for (size_t j = 0; j < n_lines; j++) {
-                    dp_arr_appstring(&lines, dp_string(dp_arrelem(content, j)));
-                }
-            }
-            else {
-                dp_error(&content, "expected message content to be a string or an array");
-            }
-        }
-        else if (dp_hasmemb(message, "garbage")) {
-            dp_obj_putint(&entry, "garbage", dp_u64(dp_objmemb(message, "garbage")));
-        }
+        const char *id    = strfmt("FrontierTrainerMessages_Text_%s_%s", stem, type);
+        if      (dp_hasmemb(message, "en_US"))   bank_push(T_TRAINER_MESSAGES, id, dp_objmemb(message, "en_US"));
+        else if (dp_hasmemb(message, "garbage")) bank_push(T_TRAINER_MESSAGES, id, dp_u64(dp_objmemb(message, "garbage")));
         else {
-            dp_error(&message, "expected exactly one of either 'en_US' or 'garbage'");
+            dp_warn(&message, "expected exactly one of either 'en_US' or 'garbage'; preferring 'en_US'");
         }
     }
 }
@@ -231,15 +214,6 @@ static int sort_strcmp(const void *lhs, const void *rhs) {
     else if (r->def == NULL) return -1;
 
     return strcmp(l->def, r->def);
-}
-
-static void pre_init(void) {
-    dp_regmetang(Item);
-    dp_regmetang(Move);
-    dp_regmetang(Nature);
-    dp_regmetang(Species);
-    dp_regmetang(TrainerClass);
-    dp_regmetang(TrainerMessageType);
 }
 
 static void usage(const char *fmt, ...);

--- a/tools/dataproc/src/itemproc.c
+++ b/tools/dataproc/src/itemproc.c
@@ -317,46 +317,27 @@ static int pack_berries(void) {
 }
 
 static void proc_text(const char *stem, const char *name, const char *plural, datanode_t *article, datanode_t *desc) {
-    datanode_t entry;
-    char       buf[BUFSIZE] = { 0 };
+#define strfmt2(fmt, ...) (snprintf(buf2, BUFSIZE, fmt, __VA_ARGS__), buf2)
+    char buf[BUFSIZE] = { 0 };
+    char buf2[BUFSIZE] = { 0 };
 
-    entry = dp_arr_appobject(&textbanks[T_ITEM_NAMES].root);
-    dp_obj_putstring(&entry, "id", strfmt("ItemNames_Text_%s", stem));
-    dp_obj_putstring(&entry, "en_US", name);
+    bank_push(T_ITEM_NAMES, strfmt("ItemNames_Text_%s", stem), name);
+    bank_push(T_ITEM_NAMES_PLURAL, strfmt("ItemNamesPlural_Text_%s", stem), plural);
 
-    entry = dp_arr_appobject(&textbanks[T_ITEM_NAMES_PLURAL].root);
-    dp_obj_putstring(&entry, "id", strfmt("ItemNamesPlural_Text_%s", stem));
-    dp_obj_putstring(&entry, "en_US", plural);
-
-    entry = dp_arr_appobject(&textbanks[T_ITEM_NAMES_WITH_ARTICLE].root);
-    dp_obj_putstring(&entry, "id", strfmt("ItemNamesWithArticles_Text_%s", stem));
-    if (strcmp(plural, "???") == 0) dp_obj_putstring(&entry, "en_US", plural);
+    char *article_id = strfmt2("ItemNamesWithArticles_Text_%s", stem);
+    if (strcmp(plural, "???") == 0) {
+        bank_push(T_ITEM_NAMES_WITH_ARTICLE, article_id, plural);
+    }
     else if (article->type == DATAPROC_T_NULL) {
-        dp_obj_putstring(&entry, "en_US", strfmt("{COLOR 255}%s{COLOR 0}", name));
+        bank_push(T_ITEM_NAMES_WITH_ARTICLE, article_id, strfmt("{COLOR 255}%s{COLOR 0}", name));
     }
     else {
-        dp_obj_putstring(&entry, "en_US", strfmt("%s {COLOR 255}%s{COLOR 0}", dp_string(*article), name));
+        bank_push(T_ITEM_NAMES_WITH_ARTICLE, article_id, strfmt("%s {COLOR 255}%s{COLOR 0}", dp_string(*article), name));
     }
 
-    entry = dp_arr_appobject(&textbanks[T_ITEM_DESCRIPTIONS].root);
-    dp_obj_putstring(&entry, "id", strfmt("ItemDescriptions_Text_%s", stem));
-    if (desc) {
-        datanode_t desc_node = *desc;
-        if (desc_node.type == DATAPROC_T_STRING) {
-            dp_obj_putstring(&entry, "en_US", dp_string(desc_node));
-        }
-        else if (desc_node.type == DATAPROC_T_ARRAY) {
-            datanode_t   lines   = dp_obj_putarray(&entry, "en_US");
-            const size_t n_lines = dp_arrlen(desc_node);
-            for (size_t j = 0; j < n_lines; j++) {
-                dp_arr_appstring(&lines, dp_string(dp_arrelem(desc_node, j)));
-            }
-        }
-        else {
-            dp_error(desc, "expected content to be a string or an array");
-        }
-    }
-    else dp_obj_putint(&entry, "garbage", 0);
+    if (desc) bank_push(T_ITEM_DESCRIPTIONS, strfmt("ItemDescriptions_Text_%s", stem), *desc);
+    else      bank_push(T_ITEM_DESCRIPTIONS, strfmt("ItemDescriptions_Text_%s", stem), 0);
+#undef strfmt2
 }
 
 static void add_idmap(datafile_t *df, size_t i, size_t data_id) {

--- a/tools/dataproc/src/npctradeproc.c
+++ b/tools/dataproc/src/npctradeproc.c
@@ -149,10 +149,7 @@ static void proc_text(datafile_t *df, size_t i) {
     check_name(&pk_name, pk_name_val, pk_name_len, MON_NAME_LEN, "traded Pokemon");
     check_name(&tr_name, tr_name_val, tr_name_len, TRAINER_NAME_LEN, "trading Trainer");
 
-    datanode_t entry = dp_arr_appobject(&textbanks[0].root);
-    dp_obj_putstring(&entry, "id", strfmt("NPCTradeNames_Text_Mon%zu", i));
-    dp_obj_putstring(&entry, "en_US", pk_name_val);
-
+    bank_push(0, strfmt("NPCTradeNames_Text_Mon%zu", i), pk_name_val);
     memcpy(s_trainernames[i], tr_name_val, tr_name_len); // store for later
 }
 
@@ -160,9 +157,7 @@ static void pack_trainernames(size_t count) {
     char buf[BUFSIZE] = { 0 };
 
     for (size_t i = 0; i < count; i++) {
-        datanode_t entry = dp_arr_appobject(&textbanks[0].root);
-        dp_obj_putstring(&entry, "id", strfmt("NPCTradeNames_Text_Trainer%zu", i));
-        dp_obj_putstring(&entry, "en_US", s_trainernames[i]);
+        bank_push(0, strfmt("NPCTradeNames_Text_Trainer%zu", i), s_trainernames[i]);
     }
 
     free(s_trainernames[0]);

--- a/tools/dataproc/src/speciesproc.c
+++ b/tools/dataproc/src/speciesproc.c
@@ -13,24 +13,12 @@
 #include "dataproc.h"
 #include "nitroarc.h"
 
-// IWYU pragma: begin_keep
 #include "constants/items.h"
-#include "generated/abilities.h"
-#include "generated/egg_groups.h"
-#include "generated/exp_rates.h"
 #include "generated/evolution_methods.h"
-#include "generated/footprint_sizes.h"
 #include "generated/gender_ratios.h"
-#include "generated/moves.h"
-#include "generated/pal_park_land_area.h"
-#include "generated/pal_park_water_area.h"
 #include "generated/pokemon_body_shapes.h"
-#include "generated/pokemon_colors.h"
 #include "generated/pokemon_types.h"
-#include "generated/shadow_sizes.h"
 #include "generated/species.h"
-#include "generated/tutor_locations.h"
-// IWYU pragma: end_keep
 
 #include "struct_defs/species.h"
 #include "struct_defs/species_sprite_data.h"
@@ -121,18 +109,43 @@ static char **registry         = NULL;
 static size_t len_registry     = 0;
 
 static enum_template_t enums[] = {
-    { .from_file = "constants/footstep_house.h", .with_prefix = "FOOTPRINT_TYPE", .for_type = "FOOTPRINT_TYPE", .from_defs = true },
+    include_defs("constants/footstep_house.h",      "FOOTPRINT_TYPE"),
+    include_enum("generated/abilities.h",           "enum Ability"),
+    include_enum("generated/egg_groups.h",          "enum EggGroup"),
+    include_enum("generated/exp_rates.h",           "enum ExpRate"),
+    include_enum("generated/evolution_methods.h",   "enum EvolutionMethod"),
+    include_enum("generated/footprint_sizes.h",     "enum FootprintSize"),
+    include_enum("generated/gender_ratios.h",       "enum GenderRatio"),
+    include_enum("generated/items.h",               "enum Item"),
+    include_enum("generated/moves.h",               "enum Move"),
+    include_enum("generated/pal_park_land_area.h",  "enum PalParkLandArea"),
+    include_enum("generated/pal_park_water_area.h", "enum PalParkWaterArea"),
+    include_enum("generated/pokemon_body_shapes.h", "enum PokemonBodyShape"),
+    include_enum("generated/pokemon_colors.h",      "enum PokemonColor"),
+    include_enum("generated/pokemon_types.h",       "enum PokemonType"),
+    include_enum("generated/shadow_sizes.h",        "enum ShadowSize"),
+    include_enum("generated/species.h",             "enum Species"),
+    include_enum("generated/tutor_locations.h",     "enum TutorLocation"),
     { .from_file = NULL },
 };
 
+enum {
+    A_PERSONAL,
+    A_EVOLUTIONS,
+    A_LEVEL_LEARNSETS,
+    A_SPRITE_OFFSETS,
+    A_POKEDEX_INDICES_GIRA_ALTERED,
+    A_POKEDEX_INDICES_GIRA_ORIGIN,
+};
+
 static archive_template_t archives[] = {
-    { .out_filename = "pl_personal.narc"     },
-    { .out_filename = "evo.narc"             },
-    { .out_filename = "wotbl.narc"           },
-    { .out_filename = "height.narc"          },
-    { .out_filename = "zukan_data_gira.narc" },
-    { .out_filename = "zukan_data.narc"      },
-    { .out_filename = NULL                   },
+    [A_PERSONAL]                     = { .out_filename = "pl_personal.narc"     },
+    [A_EVOLUTIONS]                   = { .out_filename = "evo.narc"             },
+    [A_LEVEL_LEARNSETS]              = { .out_filename = "wotbl.narc"           },
+    [A_SPRITE_OFFSETS]               = { .out_filename = "height.narc"          },
+    [A_POKEDEX_INDICES_GIRA_ALTERED] = { .out_filename = "zukan_data_gira.narc" },
+    [A_POKEDEX_INDICES_GIRA_ORIGIN]  = { .out_filename = "zukan_data.narc"      },
+    { .out_filename = NULL },
 };
 
 enum {
@@ -226,20 +239,20 @@ static const char *alt_forms_with_data[] = { // NOTE: also implicitly defines th
     "rotom/forms/mow",
 };
 
-#define NATIONAL_DEX_MAX SPECIES_EGG
-
-#define SOURCE_NAME "tools/dataproc/src/speciesproc.c"
+#define NATIONAL_DEX_MAX SPECIES_EGG // NOTE: This is distinct from NATIONAL_DEX_COUNT
 
 int main(int argc, char **argv) {
     parse_args(&argc, &argv);
 
     splitenv("SPECIES", &registry, &len_registry, alt_forms_with_data, countof(alt_forms_with_data));
-    archives[0].num_files = (u16)len_registry;
-    archives[1].num_files = (u16)len_registry;
-    archives[2].num_files = (u16)len_registry;
-    archives[3].num_files = (u16)(4 * NATIONAL_DEX_MAX);
-    archives[4].num_files = (u16)(27 + (NUM_POKEMON_TYPES - 1) + NUM_BODY_SHAPES); // NOTE: The Mystery type is not packed
-    archives[5].num_files = (u16)(27 + (NUM_POKEMON_TYPES - 1) + NUM_BODY_SHAPES);
+    archives[A_PERSONAL].num_files        = (u16)len_registry;
+    archives[A_EVOLUTIONS].num_files      = (u16)len_registry;
+    archives[A_LEVEL_LEARNSETS].num_files = (u16)len_registry;
+    archives[A_SPRITE_OFFSETS].num_files  = (u16)(4 * NATIONAL_DEX_MAX);
+
+    // NOTE: The Mystery type is not packed into these
+    archives[A_POKEDEX_INDICES_GIRA_ALTERED].num_files = (u16)(27 + (NUM_POKEMON_TYPES - 1) + NUM_BODY_SHAPES);
+    archives[A_POKEDEX_INDICES_GIRA_ORIGIN].num_files  = (u16)(27 + (NUM_POKEMON_TYPES - 1) + NUM_BODY_SHAPES);
 
     common_init(DATAPROC_F_JSON, enums, archives, headers, textbanks, __FILE__, depfile_fpath, output_dir, pre_init, post_init);
 
@@ -331,23 +344,6 @@ static u16  giratina_origin_shape_count  = 0;
 static SpeciesDexIndex *sortables = NULL; // for sorting by name, height, weight
 
 static void pre_init(void) {
-    dp_regmetang(Ability);
-    dp_regmetang(EggGroup);
-    dp_regmetang(ExpRate);
-    dp_regmetang(EvolutionMethod);
-    dp_regmetang(FootprintSize);
-    dp_regmetang(GenderRatio);
-    dp_regmetang(Item);
-    dp_regmetang(Move);
-    dp_regmetang(PalParkLandArea);
-    dp_regmetang(PalParkWaterArea);
-    dp_regmetang(PokemonBodyShape);
-    dp_regmetang(PokemonColor);
-    dp_regmetang(PokemonType);
-    dp_regmetang(ShadowSize);
-    dp_regmetang(Species);
-    dp_regmetang(TutorLocation);
-
     palpark        = calloc(NATIONAL_DEX_MAX - 1, sizeof(SpeciesPalPark)); // NOTE: SPECIES_NONE does not have an entry
     offspring      = calloc(len_registry, sizeof(*offspring));
     sprite_data    = calloc(NATIONAL_DEX_MAX, sizeof(SpeciesSpriteData));
@@ -421,7 +417,7 @@ static void post_init(void) {
         for (size_t i = 0; i < len_tutorable_moves; i++) {
             datanode_t elem = dp_arrelem(array, i);
             datanode_t move = dp_objmemb(elem, "move");
-            if (dp_lookup(move, "Move").type == DATAPROC_T_ERR) continue;
+            if (dp_lookup(move, "enum Move").type == DATAPROC_T_ERR) continue;
 
             tutorable_moves[i] = dp_string(move);
             fprintf(*f_tutorables, "    { %s, %u, %u, %u, %u, %s },\n",
@@ -430,7 +426,7 @@ static void post_init(void) {
                     dp_u8(dp_objmemb(elem, "blueCost")),
                     dp_u8(dp_objmemb(elem, "yellowCost")),
                     dp_u8(dp_objmemb(elem, "greenCost")),
-                    dp_string(dp_lookup_s(dp_objmemb(elem, "location"), "TutorLocation")));
+                    dp_string(dp_lookup_s(dp_objmemb(elem, "location"), "enum TutorLocation")));
         }
 
         tutorset_size = (len_tutorable_moves + 7) / 8;
@@ -443,7 +439,7 @@ static void post_init(void) {
         sinnohdex        = calloc(sinnohdex_size, sizeof(*sinnohdex));
 
         for (size_t i = 0; i < sinnohdex_size; i++) {
-            u16 memb = dp_u16(dp_lookup(dp_arrelem(array, i), "Species"));
+            u16 memb = dp_u16(dp_lookup(dp_arrelem(array, i), "enum Species"));
             switch (memb) {
             case SPECIES_NONE:
             case SPECIES_ARCEUS:
@@ -478,13 +474,13 @@ static SpeciesData proc_personal(datafile_t *df) {
         },
 
         .types = {
-            enum_u8(".types[0]", PokemonType),
-            enum_u8(".types[1]", PokemonType),
+            enum_u8(".types[0]", enum PokemonType),
+            enum_u8(".types[1]", enum PokemonType),
         },
 
         .abilities = {
-            enum_u8(".abilities[0]", Ability),
-            enum_u8(".abilities[1]", Ability),
+            enum_u8(".abilities[0]", enum Ability),
+            enum_u8(".abilities[1]", enum Ability),
         },
 
         .evYields = {
@@ -497,22 +493,22 @@ static SpeciesData proc_personal(datafile_t *df) {
         },
 
         .wildHeldItems = {
-            .common = enum_u16(".held_items.common", Item),
-            .rare   = enum_u16(".held_items.rare", Item),
+            .common = enum_u16(".held_items.common", enum Item),
+            .rare   = enum_u16(".held_items.rare", enum Item),
         },
 
         .eggGroups = {
-            enum_u8(".egg_groups[0]", EggGroup),
-            enum_u8(".egg_groups[1]", EggGroup),
+            enum_u8(".egg_groups[0]", enum EggGroup),
+            enum_u8(".egg_groups[1]", enum EggGroup),
         },
 
         .baseExpReward  = u8(".base_exp_reward"),
         .baseFriendship = u8(".base_friendship"),
-        .bodyColor      = (u8)(enum_u8(".body_color", PokemonColor) & maxbit(7)),
+        .bodyColor      = (u8)(enum_u8(".body_color", enum PokemonColor) & maxbit(7)),
         .catchRate      = u8(".catch_rate"),
-        .expRate        = enum_u8(".exp_rate", ExpRate),
+        .expRate        = enum_u8(".exp_rate", enum ExpRate),
         .flipSprite     = boolean(".flip_sprite"),
-        .genderRatio    = enum_u8(".gender_ratio", GenderRatio),
+        .genderRatio    = enum_u8(".gender_ratio", enum GenderRatio),
         .hatchCycles    = u8(".hatch_cycles"),
         .safariFleeRate = u8(".safari_flee_rate"),
 
@@ -567,7 +563,7 @@ static SpeciesEvolutionList proc_evolutions(datafile_t *df) {
 
     for (size_t i = 0; i < len_evos; i++) {
         datanode_t entry  = dp_arrelem(evolutions, i);
-        datanode_t method = dp_lookup(dp_arrelem(entry, 0), "EvolutionMethod");
+        datanode_t method = dp_lookup(dp_arrelem(entry, 0), "enum EvolutionMethod");
         if (method.type == DATAPROC_T_ERR) continue; // Don't bother if the evolution method is invalid
 
         datanode_t param   = { .type = DATAPROC_T_MAPPED, .mapped = 0 };
@@ -581,7 +577,7 @@ static SpeciesEvolutionList proc_evolutions(datafile_t *df) {
         case EVO_LEVEL_MAGNETIC_FIELD:
         case EVO_LEVEL_MOSS_ROCK:
         case EVO_LEVEL_ICE_ROCK:
-            species = dp_lookup(dp_arrelem(entry, 1), "Species");
+            species = dp_lookup(dp_arrelem(entry, 1), "enum Species");
             break;
 
         case EVO_LEVEL:
@@ -596,7 +592,7 @@ static SpeciesEvolutionList proc_evolutions(datafile_t *df) {
         case EVO_LEVEL_MALE:
         case EVO_LEVEL_FEMALE:
             param   = dp_arrelem(entry, 1);
-            species = dp_lookup(dp_arrelem(entry, 2), "Species");
+            species = dp_lookup(dp_arrelem(entry, 2), "enum Species");
             break;
 
         case EVO_TRADE_WITH_HELD_ITEM:
@@ -605,18 +601,18 @@ static SpeciesEvolutionList proc_evolutions(datafile_t *df) {
         case EVO_USE_ITEM_FEMALE:
         case EVO_LEVEL_WITH_HELD_ITEM_DAY:
         case EVO_LEVEL_WITH_HELD_ITEM_NIGHT:
-            param   = dp_lookup(dp_arrelem(entry, 1), "Item");
-            species = dp_lookup(dp_arrelem(entry, 2), "Species");
+            param   = dp_lookup(dp_arrelem(entry, 1), "enum Item");
+            species = dp_lookup(dp_arrelem(entry, 2), "enum Species");
             break;
 
         case EVO_LEVEL_KNOW_MOVE:
-            param   = dp_lookup(dp_arrelem(entry, 1), "Move");
-            species = dp_lookup(dp_arrelem(entry, 2), "Species");
+            param   = dp_lookup(dp_arrelem(entry, 1), "enum Move");
+            species = dp_lookup(dp_arrelem(entry, 2), "enum Species");
             break;
 
         case EVO_LEVEL_SPECIES_IN_PARTY:
-            param   = dp_lookup(dp_arrelem(entry, 1), "Species");
-            species = dp_lookup(dp_arrelem(entry, 2), "Species");
+            param   = dp_lookup(dp_arrelem(entry, 1), "enum Species");
+            species = dp_lookup(dp_arrelem(entry, 2), "enum Species");
             break;
 
         default:
@@ -654,7 +650,7 @@ static SpeciesLearnsetSized proc_lvlearnset(datafile_t *df) {
         datanode_t level = dp_arrelem(entry, 0);
         datanode_t move  = dp_arrelem(entry, 1);
 
-        result.data.entries[result.size].move  = (u16)(dp_u16(dp_lookup(move, "Move")) & maxbit(9));
+        result.data.entries[result.size].move  = (u16)(dp_u16(dp_lookup(move, "enum Move")) & maxbit(9));
         result.data.entries[result.size].level = (u16)(dp_u8(level) & maxbit(7));
         result.size++;
     }
@@ -673,8 +669,8 @@ static SpeciesPalPark proc_palpark(datafile_t *df, size_t i) {
     if (i == SPECIES_NONE || i >= NATIONAL_DEX_MAX) return result;
 
     datanode_t catching_show   = dp_get(df, ".catching_show");
-    datanode_t land_area       = dp_lookup(dp_objmemb(catching_show, "pal_park_land_area"), "PalParkLandArea");
-    datanode_t water_area      = dp_lookup(dp_objmemb(catching_show, "pal_park_water_area"), "PalParkWaterArea");
+    datanode_t land_area       = dp_lookup(dp_objmemb(catching_show, "pal_park_land_area"), "enum PalParkLandArea");
+    datanode_t water_area      = dp_lookup(dp_objmemb(catching_show, "pal_park_water_area"), "enum PalParkWaterArea");
     datanode_t catching_points = dp_objmemb(catching_show, "catching_points");
     datanode_t rarity          = dp_objmemb(catching_show, "rarity");
     datanode_t unused_u16      = dp_objmemb(catching_show, "unused");
@@ -690,7 +686,7 @@ static SpeciesPalPark proc_palpark(datafile_t *df, size_t i) {
 
 static enum Species proc_offspring(datafile_t *df, size_t i) {
     return i <= SPECIES_BAD_EGG
-        ? (enum Species)enum_u16(".offspring", Species)
+        ? (enum Species)enum_u16(".offspring", enum Species)
         : (enum Species)i;
 }
 
@@ -772,8 +768,8 @@ static SpeciesDexData proc_dexdata(datafile_t *df, size_t i, const char *base_di
         // Don't bother emitting errors here; they'll get reported later
         u8 type0 = 0, type1 = 0;
         if (dp_load(&origin_df, origin_fpath) == 0) {
-            type0 = dp_u8(dp_lookup(dp_get(&origin_df, ".types[0]"), "PokemonType"));
-            type1 = dp_u8(dp_lookup(dp_get(&origin_df, ".types[1]"), "PokemonType"));
+            type0 = dp_u8(dp_lookup(dp_get(&origin_df, ".types[0]"), "enum PokemonType"));
+            type1 = dp_u8(dp_lookup(dp_get(&origin_df, ".types[1]"), "enum PokemonType"));
         }
 
         datanode_t origin = dp_objmemb(dexdata, "origin_forme");
@@ -785,7 +781,7 @@ static SpeciesDexData proc_dexdata(datafile_t *df, size_t i, const char *base_di
                 .weight  = get_weight_hectograms(origin, (enum Species)i),
             },
 
-            .body_shape = dp_u8(dp_lookup(dp_objmemb(origin, "body_shape"), "PokemonBodyShape")),
+            .body_shape = dp_u8(dp_lookup(dp_objmemb(origin, "body_shape"), "enum PokemonBodyShape")),
             .type0      = type0,
             .type1      = type1,
             .tr_scale_f = dp_u16(dp_objmemb(origin, "trainer_scale_f")),
@@ -812,9 +808,9 @@ static SpeciesDexData proc_dexdata(datafile_t *df, size_t i, const char *base_di
             .weight  = get_weight_hectograms(dexdata, (enum Species)i),
         },
 
-        .body_shape = dp_u8(dp_lookup(dp_objmemb(dexdata, "body_shape"), "PokemonBodyShape")),
-        .type0      = dp_u8(dp_lookup(dp_get(df, ".types[0]"), "PokemonType")),
-        .type1      = dp_u8(dp_lookup(dp_get(df, ".types[1]"), "PokemonType")),
+        .body_shape = dp_u8(dp_lookup(dp_objmemb(dexdata, "body_shape"), "enum PokemonBodyShape")),
+        .type0      = dp_u8(dp_lookup(dp_get(df, ".types[0]"), "enum PokemonType")),
+        .type1      = dp_u8(dp_lookup(dp_get(df, ".types[1]"), "enum PokemonType")),
         .tr_scale_f = dp_u16(dp_objmemb(dexdata, "trainer_scale_f")),
         .pk_scale_f = dp_u16(dp_objmemb(dexdata, "pokemon_scale_f")),
         .tr_scale_m = dp_u16(dp_objmemb(dexdata, "trainer_scale_m")),
@@ -874,7 +870,7 @@ static SpeciesSpriteData proc_spritedata(datafile_t *df) {
     return (SpeciesSpriteData){
         .yOffset       = s8(".front.addl_y_offset"),
         .xOffsetShadow = s8(".shadow.x_offset"),
-        .shadowSize    = enum_u8(".shadow.size", ShadowSize),
+        .shadowSize    = enum_u8(".shadow.size", enum ShadowSize),
         .faceAnims     = {
             [0] = proc_spriteanim(dp_get(df, ".front")),
             [1] = proc_spriteanim(dp_get(df, ".back")),
@@ -900,7 +896,7 @@ static void emit_tutorables(datafile_t *df, size_t i) {
     for (size_t i = 0; i < dp_arrlen(dn); i++) {
         datanode_t  move   = dp_arrelem(dn, i);
         const char *move_s = dp_string(move);
-        if (dp_lookup(move, "Move").type == DATAPROC_T_ERR) continue;
+        if (dp_lookup(move, "enum Move").type == DATAPROC_T_ERR) continue;
 
         const char *found = NULL;
         size_t      idx   = 0;
@@ -924,7 +920,7 @@ static void emit_eggmoves(datafile_t *df, const char *species_upper) {
     for (size_t i = 0; i < dp_arrlen(dn); i++) {
         datanode_t  move   = dp_arrelem(dn, i);
         const char *move_s = dp_string(move);
-        dp_lookup(move, "Move"); // only to verify that this is a move name
+        dp_lookup(move, "enum Move"); // only to verify that this is a move name
 
         fprintf(*f_egg_moves, "    %s,\n", move_s);
     }
@@ -938,7 +934,7 @@ static void emit_footprints(datafile_t *df, size_t i, const char *species_upper)
 
     datanode_t  root = dp_get(df, ".footprint");
     const bool  has  = dp_bool(dp_objmemb(root, "has"));
-    const char *size = dp_string(dp_lookup_s(dp_objmemb(root, "size"), "FootprintSize"));
+    const char *size = dp_string(dp_lookup_s(dp_objmemb(root, "size"), "enum FootprintSize"));
     const char *type = dp_string(dp_lookup_s(dp_objmemb(root, "type"), "FOOTPRINT_TYPE"));
 
     fprintf(*f_footprint_sizes, "    { %s, %s },\n",
@@ -1205,15 +1201,15 @@ static void emit_textbanks(datafile_t *df, size_t i, const char *species, Specie
 }
 
 static void pack(Container *species, size_t i) {
-    nitroarc_ppack(&archives[0].packer, &species->personal, sizeof(SpeciesData), NULL);
-    nitroarc_ppack(&archives[1].packer, &species->evolutions, sizeof(SpeciesEvolutionList), NULL);
-    nitroarc_ppack(&archives[2].packer, &species->levelup_learnset.data, (u32)species->levelup_learnset.size, NULL);
+    nitroarc_ppack(&archives[A_PERSONAL].packer, &species->personal, sizeof(SpeciesData), NULL);
+    nitroarc_ppack(&archives[A_EVOLUTIONS].packer, &species->evolutions, sizeof(SpeciesEvolutionList), NULL);
+    nitroarc_ppack(&archives[A_LEVEL_LEARNSETS].packer, &species->levelup_learnset.data, (u32)species->levelup_learnset.size, NULL);
 
     if (i < NATIONAL_DEX_MAX) {
-        nitroarc_ppack(&archives[3].packer, &species->heights.back_female,  species->heights.has_female ? 1 : 0, NULL);
-        nitroarc_ppack(&archives[3].packer, &species->heights.back_male,    species->heights.has_male   ? 1 : 0, NULL);
-        nitroarc_ppack(&archives[3].packer, &species->heights.front_female, species->heights.has_female ? 1 : 0, NULL);
-        nitroarc_ppack(&archives[3].packer, &species->heights.front_male,   species->heights.has_male   ? 1 : 0, NULL);
+        nitroarc_ppack(&archives[A_SPRITE_OFFSETS].packer, &species->heights.back_female,  species->heights.has_female ? 1 : 0, NULL);
+        nitroarc_ppack(&archives[A_SPRITE_OFFSETS].packer, &species->heights.back_male,    species->heights.has_male   ? 1 : 0, NULL);
+        nitroarc_ppack(&archives[A_SPRITE_OFFSETS].packer, &species->heights.front_female, species->heights.has_female ? 1 : 0, NULL);
+        nitroarc_ppack(&archives[A_SPRITE_OFFSETS].packer, &species->heights.front_male,   species->heights.has_male   ? 1 : 0, NULL);
 
         size_t offset = sizeof(SpeciesSpriteData) * i;
         memcpy(sprite_data + offset, &species->spritedata, sizeof(SpeciesSpriteData));
@@ -1444,7 +1440,7 @@ static int pack_dexdata(nitroarc_packer_t *p) {
 }
 
 static int pack_dexdata_giratina_altered(void) {
-    return pack_dexdata(&archives[4].packer);
+    return pack_dexdata(&archives[A_POKEDEX_INDICES_GIRA_ALTERED].packer);
 }
 
 #define swap(x, y) do { x ^= y; y ^= x; x ^= y; } while (0)
@@ -1484,7 +1480,7 @@ static void swap_giratina(void) {
 
 static int pack_dexdata_giratina_origin(void) {
     swap_giratina(); // swap-in
-    int result = pack_dexdata(&archives[5].packer);
+    int result = pack_dexdata(&archives[A_POKEDEX_INDICES_GIRA_ORIGIN].packer);
     swap_giratina(); // swap-out
     return result;
 }

--- a/tools/dataproc/src/trainerproc.c
+++ b/tools/dataproc/src/trainerproc.c
@@ -7,28 +7,26 @@
 
 #include "common.h"
 #include "dataproc.h"
+#include "libenum.h"
 #include "nitroarc.h"
 
-// We want to ignore these messages in the generated constants (really just the AI flags)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-#pragma GCC diagnostic ignored "-Wshift-count-overflow"
-
-// IWYU pragma: begin_keep
 #include "constants/battle.h"
 #include "constants/moves.h"
 #include "constants/pokemon.h"
-#include "generated/ai_flags.h"
-#include "generated/items.h"
-#include "generated/species.h"
 #include "generated/trainers.h"
 #include "generated/trainer_classes.h"
-#include "generated/trainer_message_types.h"
-// IWYU pragma: end_keep
-
-#pragma GCC diagnostic pop
 
 #include "struct_defs/trainer_data.h"
+
+static enum_template_t enums[] = {
+    include_enum("generated/ai_flags.h",              "enum AIFlag"),
+    include_enum("generated/items.h",                 "enum Item"),
+    include_enum("generated/moves.h",                 "enum Move"),
+    include_enum("generated/species.h",               "enum Species"),
+    include_enum("generated/trainer_classes.h",       "enum TrainerClass"),
+    include_enum("generated/trainer_message_types.h", "enum TrainerMessageType"),
+    { .from_file = NULL },
+};
 
 enum {
     A_TRAINER_HEADERS,
@@ -57,12 +55,11 @@ static textbank_template_t textbanks[] = {
     { .out_filename = NULL },
 };
 
-static char  *program_name  = NULL;
-static char  *base_dir      = NULL;
-static char  *depfile_fpath = "trainer_data.d";
-static char  *output_dir    = ".";
-static char **registry      = NULL;
-static size_t len_registry  = 0;
+static char *program_name  = NULL;
+static char *filename     = NULL;
+static char *base_dir      = NULL;
+static char *depfile_path = "trainer_data.d";
+static char *output_dir    = ".";
 
 typedef struct TrainerParty {
     TrainerMonWithMovesAndItem party[MAX_PARTY_SIZE];
@@ -75,53 +72,62 @@ typedef struct Container {
 } Container;
 
 static void parse_args(int *pargc, char ***pargv);
-static void pre_init(void);
 
 static Container proc_trainer(datafile_t *df, enum TrainerID trainer);
 static void emit_name(datafile_t *df, enum TrainerID trainer, const TrainerHeader *trainer_header, const char *stem);
 static void proc_messages(datafile_t *df, enum TrainerID trainer);
 static void pack(Container *trainer);
-static int  postproc_messages(void);
 static void emit_trainer_scripts(size_t trainer_count);
+static int  emit_trainer_messages(enum_seq_t *trainers);
+static void prep_trainer_messages(size_t trainer_count);
 
 int main(int argc, char *argv[]) {
-    parse_args(&argc, &argv);
-
-    splitenv("TRAINERS", &registry, &len_registry, NULL, 0);
-    archives[A_TRAINER_HEADERS].num_files = (u16)len_registry;
-    archives[A_TRAINER_PARTIES].num_files = (u16)len_registry;
-
-    common_init(DATAPROC_F_JSON, NULL, archives, headers, textbanks, __FILE__, depfile_fpath, output_dir, pre_init, NULL);
-
-    char       buf[256];
+    char       buf[BUFSIZE];
     datafile_t df   = { 0 };
     unsigned   errc = EXIT_SUCCESS;
 
+    parse_args(&argc, &argv);
+    enum_seq_t trainers = common_initenum(
+        filename, "TrainerID",
+        .sourcefile  = __FILE__,
+        .depfile     = depfile_path,
+        .outdir      = output_dir,
+        .format      = DATAPROC_F_JSON,
+        .enums       = enums,
+        .archives    = archives,
+        .headers     = headers,
+        .textbanks   = textbanks,
+    );
+
     // The primary processing loop here handles all trainer headers and parties, and also
     // emits the name of each trainer to a text-bank. It does not actually emit any of the
-    // message data, which is handled by postproc_messages.
-    for (size_t i = 0; i < len_registry; i++) {
-        snprintf(buf, 256, "%s.json", registry[i]);
-        char *path = pathjoin(base_dir, NULL, buf);
+    // message data, which is handled by emit_trainer_messages.
+    prep_trainer_messages(trainers.size);
+    for (size_t i = 0; i < trainers.size; i++) {
+        const char *stem = trainers.members[i].name + lengthof("TRAINER_");
 
-        if (dp_load(&df, path) == 0) {
+        char *basename = strlower(stem);
+        char *filepath = pathjoin(base_dir, NULL, strfmt("%s.json", basename));
+        declare_dep(filepath);
+
+        if (dp_load(&df, filepath) == 0) {
             enum TrainerID id      = (enum TrainerID)i;
             Container      trainer = proc_trainer(&df, id);
 
-            emit_name(&df, id, &trainer.header, registry[i]);
+            emit_name(&df, id, &trainer.header, basename);
             proc_messages(&df, id); // For post-processing
             pack(&trainer);
         }
 
         if (dp_report(&df) == DIAG_ERROR) errc = EXIT_FAILURE;
 
-        free(path);
+        free(filepath);
         dp_free(&df);
     }
 
-    emit_trainer_scripts(len_registry);
-
-    return common_done(errc, postproc_messages);
+    emit_trainer_scripts(trainers.size);
+    if (emit_trainer_messages(&trainers)) errc = EXIT_FAILURE;
+    return common_done(errc, NULL);
 }
 
 Container proc_trainer(datafile_t *df, enum TrainerID trainer) {
@@ -135,7 +141,7 @@ Container proc_trainer(datafile_t *df, enum TrainerID trainer) {
 
     TrainerHeader header = {
         .monDataType = 0, // initiailized below
-        .trainerType = enum_u8(".class", TrainerClass),
+        .trainerType = enum_u8(".class", enum TrainerClass),
         .sprite      = 0,
         .partySize   = (u8)party_size,
         .items       = { 0 }, // initialized below
@@ -146,7 +152,7 @@ Container proc_trainer(datafile_t *df, enum TrainerID trainer) {
     datanode_t ai_flags      = dp_get(df, ".ai_flags");
     size_t     ai_flags_size = dp_arrlen(ai_flags);
     for (size_t i = 0; i < ai_flags_size; i++) {
-        header.aiMask = header.aiMask | dp_u32(dp_lookup(dp_arrelem(ai_flags, i), "AIFlag"));
+        header.aiMask = header.aiMask | dp_u32(dp_lookup(dp_arrelem(ai_flags, i), "enum AIFlag"));
     }
 
     datanode_t items      = dp_get(df, ".items");
@@ -156,7 +162,7 @@ Container proc_trainer(datafile_t *df, enum TrainerID trainer) {
         items_size = MAX_TRAINER_ITEMS;
     }
     for (size_t i = 0; i < items_size; i++) {
-        header.items[i] = dp_u16(dp_lookup(dp_arrelem(items, i), "Item"));
+        header.items[i] = dp_u16(dp_lookup(dp_arrelem(items, i), "enum Item"));
     }
 
     TrainerParty trparty = { .size = (unsigned)party_size };
@@ -175,7 +181,7 @@ Container proc_trainer(datafile_t *df, enum TrainerID trainer) {
         party_member = dp_arrelem(party, i);
 
         // We always store the maximum possible data, then trim it when packing
-        u16 species = dp_u16(dp_lookup(dp_objmemb(party_member, "species"), "Species"));
+        u16 species = dp_u16(dp_lookup(dp_objmemb(party_member, "species"), "enum Species"));
         u16 form    = dp_u8(dp_objmemb(party_member, "form"));
         trparty.party[i] = (TrainerMonWithMovesAndItem){
             .ivScale = dp_u16(dp_objmemb(party_member, "iv_scale")),
@@ -184,7 +190,7 @@ Container proc_trainer(datafile_t *df, enum TrainerID trainer) {
             .cbSeal  = dp_u16(dp_objmemb(party_member, "ball_seal")),
         };
 
-        if (party_has_items) trparty.party[i].item = dp_u16(dp_lookup(dp_objmemb(party_member, "item"), "Item"));
+        if (party_has_items) trparty.party[i].item = dp_u16(dp_lookup(dp_objmemb(party_member, "item"), "enum Item"));
         if (party_has_moves) {
             datanode_t moves      = dp_objmemb(party_member, "moves");
             size_t     moves_size = dp_arrlen(moves);
@@ -194,7 +200,7 @@ Container proc_trainer(datafile_t *df, enum TrainerID trainer) {
             }
 
             for (size_t j = 0; j < moves_size; j++) {
-                trparty.party[i].moves[j] = dp_u16(dp_lookup(dp_arrelem(moves, j), "Move"));
+                trparty.party[i].moves[j] = dp_u16(dp_lookup(dp_arrelem(moves, j), "enum Move"));
             }
             for (size_t j = moves_size; j < LEARNED_MOVES_MAX; j++) {
                 trparty.party[i].moves[j] = MOVE_NONE;
@@ -207,6 +213,7 @@ early_exit:
 }
 
 static void emit_name(datafile_t *df, enum TrainerID trainer, const TrainerHeader *trainer_header, const char *stem) {
+#define strfmt2(fmt, ...) (snprintf(buf2, BUFSIZE, fmt, __VA_ARGS__), buf2)
     static const enum TrainerClass uncompressed_classes[] = {
         TRAINER_CLASS_RIVAL,
         TRAINER_CLASS_TOWER_TYCOON,
@@ -224,7 +231,8 @@ static void emit_name(datafile_t *df, enum TrainerID trainer, const TrainerHeade
         TRAINER_CHERYL_BATTLEGROUND,
     };
 
-    char buf[256] = { 0 };
+    char buf[BUFSIZE]  = { 0 };
+    char buf2[BUFSIZE] = { 0 };
 
     const char       *name  = string(".name");
     enum TrainerClass class = trainer_header->trainerType;
@@ -237,9 +245,9 @@ static void emit_name(datafile_t *df, enum TrainerID trainer, const TrainerHeade
         if (uncompressed_trainers[i] == trainer) compressed = false;
     }
 
-    datanode_t entry = dp_arr_appobject(&textbanks[T_TRAINER_NAMES].root);
-    dp_obj_putstring(&entry, "id", strfmt("NPCTrainerNames_Text_%s", stem));
-    dp_obj_putstring(&entry, "en_US", strfmt(compressed ? "{TRNAME}%s" : "%s", name));
+    bank_push(T_TRAINER_NAMES, strfmt("NPCTrainerNames_Text_%s", stem),
+              strfmt2(compressed ? "{TRNAME}%s" : "%s", name));
+#undef strfmt2
 }
 
 typedef struct TrainerMessagesEntry {
@@ -284,7 +292,7 @@ static void proc_messages(datafile_t *df, enum TrainerID trainer) {
 
     for (size_t i = 0; i < p_messages->count; i++) {
         datanode_t entry     = dp_arrelem(messages, i);
-        p_messages->types[i] = dp_u16(dp_lookup(dp_objmemb(entry, "type"), "TrainerMessageType"));
+        p_messages->types[i] = dp_u16(dp_lookup(dp_objmemb(entry, "type"), "enum TrainerMessageType"));
 
         for (size_t j = 0; j < i; j++) {
             if (p_messages->types[j] == p_messages->types[i]) {
@@ -344,15 +352,15 @@ static TrainerMessage *trtbl    = NULL;
 static u16            *trtblofs = NULL;
 static TrainerMessage *p_trtbl  = NULL;
 
-static int postproc_messages(void) {
-    qsort(trainer_messages, len_registry, sizeof(*trainer_messages), sort_byindex);
+static int emit_trainer_messages(enum_seq_t *trainers) {
+    qsort(trainer_messages, trainers->size, sizeof(*trainer_messages), sort_byindex);
 
-    trtbl    = calloc(count_trtbl,  sizeof(*trtbl));
-    trtblofs = calloc(len_registry, sizeof(*trtblofs));
+    trtbl    = calloc(count_trtbl,    sizeof(*trtbl));
+    trtblofs = calloc(trainers->size, sizeof(*trtblofs));
     p_trtbl  = trtbl;
 
     char buf[BUFSIZE] = { 0 };
-    for (size_t i = 0; i < len_registry; i++) {
+    for (size_t i = 0; i < trainers->size; i++) {
         TrainerMessagesEntry *entry = &trainer_messages[i];
         if (entry->count == 0) continue;
 
@@ -362,8 +370,10 @@ static int postproc_messages(void) {
             p_trtbl->messageType = entry->types[message_id];
             p_trtbl++;
 
+            // Insert the messages here more mechanically due to the structure.
             datanode_t bank_entry = dp_arr_appobject(&textbanks[T_TRAINER_MESSAGES].root);
-            dp_obj_putstring(&bank_entry, "id", strfmt("NPCTrainerMessages_Text_%s_%zu", registry[i], message_id));
+            dp_obj_putstring(&bank_entry, "id",
+                             strfmt("NPCTrainerMessages_Text_%s_%zu", trainers->members[i].name, message_id));
             if (entry->garbage[message_id]) {
                 dp_obj_putint(&bank_entry, "garbage", entry->garbage[message_id]);
             }
@@ -379,8 +389,8 @@ static int postproc_messages(void) {
         }
     }
 
-    return fdump_blobnarc(trtbl,    (u32)(count_trtbl  * sizeof(*trtbl)),    "trtbl.narc")
-        || fdump_blobnarc(trtblofs, (u32)(len_registry * sizeof(*trtblofs)), "trtblofs.narc")
+    return fdump_blobnarc(trtbl,    (u32)(count_trtbl  * sizeof(*trtbl)),      "trtbl.narc")
+        || fdump_blobnarc(trtblofs, (u32)(trainers->size * sizeof(*trtblofs)), "trtblofs.narc")
         || EXIT_SUCCESS;
 }
 
@@ -432,15 +442,8 @@ static void pack(Container *trainer) {
         NULL);
 }
 
-static void pre_init(void) {
-    dp_regmetang(AIFlag);
-    dp_regmetang(Item);
-    dp_regmetang(Move);
-    dp_regmetang(Species);
-    dp_regmetang(TrainerClass);
-    dp_regmetang(TrainerMessageType);
-
-    trainer_messages = calloc(len_registry, sizeof(*trainer_messages));
+static void prep_trainer_messages(size_t count) {
+    trainer_messages = calloc(count, sizeof(*trainer_messages));
 }
 
 static void emit_trainer_scripts(size_t trainer_count) {
@@ -461,8 +464,8 @@ static void parse_args(int *pargc, char ***pargv) {
     int c = 0;
     while ((c = getopt(*pargc, *pargv, ":o:t:s:M:h")) != -1) {
         switch (c) {
-        case 'o': output_dir       = optarg; break;
-        case 'M': depfile_fpath    = optarg; break;
+        case 'o': output_dir   = optarg; break;
+        case 'M': depfile_path = optarg; break;
 
         case 'h': usage(NULL);                                 break;
         case ':': usage("missing argument for '-%c'", optopt); break;
@@ -472,9 +475,11 @@ static void parse_args(int *pargc, char ***pargv) {
 
     *pargc -= optind;
     *pargv += optind;
-    if (*pargc < 1) usage("missing required argument BASEDIR");
+    if (*pargc < 1) usage("missing required argument ENUMFILE");
+    if (*pargc < 2) usage("missing required argument BASEDIR");
 
-    base_dir = (*pargv)[0];
+    filename = (*pargv)[0];
+    base_dir = (*pargv)[1];
 }
 
 static void usage(const char *fmt, ...) {


### PR DESCRIPTION
I was able to port `trainerproc` to the enum-based convention relatively easily. `speciesproc` and `frontierproc` will require more work, as they are multi-domain. `speciesproc` in particular may not be one we *want* to migrate to that convention, because we need to know about the other species-related files to organize other parts of the build (sprites, icons, etc.).

In the future, I'll also make an update to `speciesproc` so that it emits the species-level ordering for archives like `pokefoot`.