### PR TITLE
Fix incorrect probability in EvalAttack quad-effective comment

### DIFF
--- a/src/battle/trainer_ai/script.s
+++ b/src/battle/trainer_ai/script.s
@@ -6372,7 +6372,7 @@ EvalAttack_MaybeDeprioritize:
     AddToMoveScore -2
 
 EvalAttack_CheckQuadEffective:
-    // If quad-effective, 31.25% chance of score +2.
+    // If quad-effective, 68.75% chance of score +2.
     IfMoveEffectivenessEquals TYPE_MULTI_QUADRUPLE_DAMAGE, EvalAttack_TryScorePlus2
     PopOrEnd 
 


### PR DESCRIPTION
The quad-effective comment says a 31.25% chance of +2, but the +2 fires 68.75% of the time. `IfRandomLessThan 80` only skips it when `rand % 256 < 80`. Comment-only `.s` change, so the build still matches.