### PR TITLE
Standardize init, sign, and coord event script entry names

### DIFF
--- a/res/field/scripts/scripts_acuity_lakefront.s
+++ b/res/field/scripts/scripts_acuity_lakefront.s
@@ -6,7 +6,7 @@
     ScriptEntry AcuityLakefront_OnTransition
     ScriptEntry AcuityLakefront_OnLoad
     ScriptEntry AcuityLakefront_ArrowSignpostLakeAcuity
-    ScriptEntry AcuityLakefront_TriggerRival
+    ScriptEntry AcuityLakefront_CoordEvent_Rival
     ScriptEntryEnd
 
 AcuityLakefront_OnLoad:
@@ -40,7 +40,7 @@ AcuityLakefront_ArrowSignpostLakeAcuity:
     ShowArrowSign AcuityLakefront_Text_SignLakeAcuityAhead
     End
 
-AcuityLakefront_TriggerRival:
+AcuityLakefront_CoordEvent_Rival:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     AddFreeCamera VAR_0x8004, VAR_0x8005

--- a/res/field/scripts/scripts_amity_square.s
+++ b/res/field/scripts/scripts_amity_square.s
@@ -12,10 +12,10 @@
 
 
     ScriptEntry AmitySquare_OnTransition
-    ScriptEntry AmitySquare_Trigger_WestGate
-    ScriptEntry AmitySquare_Trigger_ExitAmitySquare
-    ScriptEntry AmitySquare_Trigger_EastGate
-    ScriptEntry AmitySquare_Trigger_ExitAmitySquare
+    ScriptEntry AmitySquare_CoordEvent_WestGate
+    ScriptEntry AmitySquare_CoordEvent_ExitAmitySquare
+    ScriptEntry AmitySquare_CoordEvent_EastGate
+    ScriptEntry AmitySquare_CoordEvent_ExitAmitySquare
     ScriptEntry AmitySquare_FollowerMon
     ScriptEntry AmitySquare_WestReceptionist
     ScriptEntry AmitySquare_EastReceptionist
@@ -85,7 +85,7 @@ AmitySquare_SetGiftManPosition3:
     SetObjectEventPos LOCALID_GIFT_MAN, 48, 41
     End
 
-AmitySquare_Trigger_WestGate:
+AmitySquare_CoordEvent_WestGate:
     LockAll
     SetVar VAR_0x8001, 1
     ApplyMovement LOCALID_PLAYER, AmitySquare_Movement_PlayerWalkOnSpotWest
@@ -93,7 +93,7 @@ AmitySquare_Trigger_WestGate:
     GoTo AmitySquare_CheckHasNationalDex
     End
 
-AmitySquare_Trigger_EastGate:
+AmitySquare_CoordEvent_EastGate:
     LockAll
     SetVar VAR_0x8001, 2
     ApplyMovement LOCALID_PLAYER, AmitySquare_Movement_PlayerWalkOnSpotEast
@@ -230,7 +230,7 @@ AmitySquare_Unused:
     ReleaseAll
     End
 
-AmitySquare_Trigger_ExitAmitySquare:
+AmitySquare_CoordEvent_ExitAmitySquare:
     LockAll
     FadeScreenOut
     WaitFadeScreen
@@ -240,10 +240,10 @@ AmitySquare_Trigger_ExitAmitySquare:
 
 AmitySquare_RemoveFollower:
     RemoveObject LOCALID_FOLLOWER_MON
-    GoTo AmitySquare_Trigger_ExitAmitySquare_End
+    GoTo AmitySquare_CoordEvent_ExitAmitySquare_End
     End
 
-AmitySquare_Trigger_ExitAmitySquare_End:
+AmitySquare_CoordEvent_ExitAmitySquare_End:
     FadeScreenIn
     WaitFadeScreen
     SetVar VAR_FOLLOWER_MON_ACTIVE, FALSE

--- a/res/field/scripts/scripts_battle_arcade.s
+++ b/res/field/scripts/scripts_battle_arcade.s
@@ -5,10 +5,10 @@
 
 
     ScriptEntry BattleArcade_SingleAttendant
-    ScriptEntry BattleArcade_OnFrameResumeChallenge
-    ScriptEntry BattleArcade_OnFrameDidntSaveBeforeQuit
-    ScriptEntry BattleArcade_OnFrameChallengeEndedCompletedRound
-    ScriptEntry BattleArcade_OnFrameChallengeEnded
+    ScriptEntry BattleArcade_OnFrame_ResumeChallenge
+    ScriptEntry BattleArcade_OnFrame_DidntSaveBeforeQuit
+    ScriptEntry BattleArcade_OnFrame_ChallengeEndedCompletedRound
+    ScriptEntry BattleArcade_OnFrame_ChallengeEnded
     ScriptEntry BattleArcade_MultiAttendant
     ScriptEntry BattleArcade_Worker
     ScriptEntry BattleArcade_ParasolLady
@@ -444,7 +444,7 @@ BattleArcade_ExplainMultiChallenge:
     Message BattleArcade_Text_ExplainMultiChallenge
     Return
 
-BattleArcade_OnFrameResumeChallenge:
+BattleArcade_OnFrame_ResumeChallenge:
     RecordHeapMemory
     SetVar VAR_MAP_LOCAL_3, 1
     SetVar VAR_BATTLE_ARCADE_LOBBY_LOAD_ACTION, 0
@@ -462,13 +462,13 @@ BattleArcade_SaveGame:
     WaitSE SEQ_SE_DP_SAVE
     Return
 
-BattleArcade_OnFrameDidntSaveBeforeQuit:
+BattleArcade_OnFrame_DidntSaveBeforeQuit:
     Message BattleArcade_Text_DidntSaveBeforeQuit
     ScrCmd_2DC VAR_BATTLE_ARCADE_CHALLENGE_TYPE
     GoTo BattleArcade_EndChallenge
     End
 
-BattleArcade_OnFrameChallengeEndedCompletedRound:
+BattleArcade_OnFrame_ChallengeEndedCompletedRound:
     CallIfEq VAR_BATTLE_ARCADE_CHALLENGE_TYPE, FRONTIER_CHALLENGE_SINGLE, BattleArcade_IncrementTrainerScoreRoundCompleted
     CallIfEq VAR_BATTLE_ARCADE_CHALLENGE_TYPE, FRONTIER_CHALLENGE_DOUBLE, BattleArcade_IncrementTrainerScoreRoundCompleted
     CallIfEq VAR_BATTLE_ARCADE_PRINT_STATE, 1, BattleArcade_EarnedSilverPrint
@@ -499,7 +499,7 @@ BattleArcade_EarnedGoldPrint:
     Common_CheckAllFrontierGoldPrintsObtained
     Return
 
-BattleArcade_OnFrameChallengeEnded:
+BattleArcade_OnFrame_ChallengeEnded:
     GoTo BattleArcade_EndChallenge
     End
 

--- a/res/field/scripts/scripts_battle_castle.s
+++ b/res/field/scripts/scripts_battle_castle.s
@@ -5,10 +5,10 @@
 
 
     ScriptEntry BattleCastle_SingleAttendant
-    ScriptEntry BattleCastle_OnFrameResumeChallenge
-    ScriptEntry BattleCastle_OnFrameDidntSaveBeforeQuit
-    ScriptEntry BattleCastle_OnFrameChallengeEndedCompletedRound
-    ScriptEntry BattleCastle_OnFrameChallengeEnded
+    ScriptEntry BattleCastle_OnFrame_ResumeChallenge
+    ScriptEntry BattleCastle_OnFrame_DidntSaveBeforeQuit
+    ScriptEntry BattleCastle_OnFrame_ChallengeEndedCompletedRound
+    ScriptEntry BattleCastle_OnFrame_ChallengeEnded
     ScriptEntry BattleCastle_MultiAttendant
     ScriptEntry BattleCastle_Artist
     ScriptEntry BattleCastle_Socialite
@@ -439,7 +439,7 @@ BattleCastle_ExplainMultiChallenge:
     Message BattleCastle_Text_ExplainMultiChallenge
     Return
 
-BattleCastle_OnFrameResumeChallenge:
+BattleCastle_OnFrame_ResumeChallenge:
     RecordHeapMemory
     SetVar VAR_MAP_LOCAL_3, 1
     SetVar VAR_BATTLE_CASTLE_LOBBY_LOAD_ACTION, 0
@@ -457,13 +457,13 @@ BattleCastle_SaveGame:
     WaitSE SEQ_SE_DP_SAVE
     Return
 
-BattleCastle_OnFrameDidntSaveBeforeQuit:
+BattleCastle_OnFrame_DidntSaveBeforeQuit:
     Message BattleCastle_Text_DidntSaveBeforeQuit
     ScrCmd_2D5 VAR_BATTLE_CASTLE_CHALLENGE_TYPE
     GoTo BattleCastle_EndChallenge
     End
 
-BattleCastle_OnFrameChallengeEndedCompletedRound:
+BattleCastle_OnFrame_ChallengeEndedCompletedRound:
     CallIfEq VAR_BATTLE_CASTLE_CHALLENGE_TYPE, FRONTIER_CHALLENGE_SINGLE, BattleCastle_IncrementTrainerScoreRoundCompleted
     CallIfEq VAR_BATTLE_CASTLE_CHALLENGE_TYPE, FRONTIER_CHALLENGE_DOUBLE, BattleCastle_IncrementTrainerScoreRoundCompleted
     CallIfEq VAR_BATTLE_CASTLE_PRINT_STATE, 1, BattleCastle_EarnedSilverPrint
@@ -494,7 +494,7 @@ BattleCastle_EarnedGoldPrint:
     Common_CheckAllFrontierGoldPrintsObtained
     Return
 
-BattleCastle_OnFrameChallengeEnded:
+BattleCastle_OnFrame_ChallengeEnded:
     GoTo BattleCastle_EndChallenge
     End
 

--- a/res/field/scripts/scripts_battle_factory.s
+++ b/res/field/scripts/scripts_battle_factory.s
@@ -5,10 +5,10 @@
 
 
     ScriptEntry BattleFactory_SingleAttendant
-    ScriptEntry BattleFactory_OnFrameResumeChallenge
-    ScriptEntry BattleFactory_OnFrameDidntSaveBeforeQuit
-    ScriptEntry BattleFactory_OnFrameChallengeEndedCompletedRound
-    ScriptEntry BattleFactory_OnFrameChallengeEnded
+    ScriptEntry BattleFactory_OnFrame_ResumeChallenge
+    ScriptEntry BattleFactory_OnFrame_DidntSaveBeforeQuit
+    ScriptEntry BattleFactory_OnFrame_ChallengeEndedCompletedRound
+    ScriptEntry BattleFactory_OnFrame_ChallengeEnded
     ScriptEntry BattleFactory_MultiAttendant
     ScriptEntry BattleFactory_PokemonBreederF
     ScriptEntry BattleFactory_Sailor
@@ -396,7 +396,7 @@ BattleFactory_ExplainMultiChallenge:
     Message BattleFactory_Text_ExplainMultiChallenge
     Return
 
-BattleFactory_OnFrameResumeChallenge:
+BattleFactory_OnFrame_ResumeChallenge:
     RecordHeapMemory
     SetVar VAR_MAP_LOCAL_3, 1
     SetVar VAR_BATTLE_FACTORY_LOBBY_LOAD_ACTION, 0
@@ -414,13 +414,13 @@ BattleFactory_SaveGame:
     WaitSE SEQ_SE_DP_SAVE
     Return
 
-BattleFactory_OnFrameDidntSaveBeforeQuit:
+BattleFactory_OnFrame_DidntSaveBeforeQuit:
     Message BattleFactory_Text_DidntSaveBeforeQuit
     ScrCmd_2C5 VAR_BATTLE_FACTORY_CHALLENGE_TYPE, VAR_BATTLE_FACTORY_CHALLENGE_LEVEL
     GoTo BattleFactory_EndChallenge
     End
 
-BattleFactory_OnFrameChallengeEndedCompletedRound:
+BattleFactory_OnFrame_ChallengeEndedCompletedRound:
     CallIfEq VAR_BATTLE_FACTORY_CHALLENGE_TYPE, FRONTIER_CHALLENGE_SINGLE, BattleFactory_IncrementTrainerScoreRoundCompleted
     CallIfEq VAR_BATTLE_FACTORY_CHALLENGE_TYPE, FRONTIER_CHALLENGE_DOUBLE, BattleFactory_IncrementTrainerScoreRoundCompleted
     CallIfEq VAR_BATTLE_FACTORY_PRINT_STATE, 1, BattleFactory_EarnedSilverPrint
@@ -451,7 +451,7 @@ BattleFactory_EarnedGoldPrint:
     Common_CheckAllFrontierGoldPrintsObtained
     Return
 
-BattleFactory_OnFrameChallengeEnded:
+BattleFactory_OnFrame_ChallengeEnded:
     GoTo BattleFactory_EndChallenge
     End
 

--- a/res/field/scripts/scripts_battle_frontier.s
+++ b/res/field/scripts/scripts_battle_frontier.s
@@ -28,18 +28,18 @@
     ScriptEntry BattleFrontier_AttendantSouthwest
     ScriptEntry BattleFrontier_Unused24
     ScriptEntry BattleFrontier_AttendantSoutheast
-    ScriptEntry BattleFrontier_SignBattleTower
-    ScriptEntry BattleFrontier_SignBattleHall
-    ScriptEntry BattleFrontier_SignBattleCastle
-    ScriptEntry BattleFrontier_SignBattleArcade
-    ScriptEntry BattleFrontier_SignBattleFactory
+    ScriptEntry BattleFrontier_TrainerTipsSignpostBattleTower
+    ScriptEntry BattleFrontier_TrainerTipsSignpostBattleHall
+    ScriptEntry BattleFrontier_TrainerTipsSignpostBattleCastle
+    ScriptEntry BattleFrontier_TrainerTipsSignpostBattleArcade
+    ScriptEntry BattleFrontier_TrainerTipsSignpostBattleFactory
     ScriptEntry BattleFrontier_StatueWest
     ScriptEntry BattleFrontier_StatueEast
     ScriptEntry BattleFrontier_ScaleModel
-    ScriptEntry BattleFrontier_TriggerEnterBattleHall
-    ScriptEntry BattleFrontier_TriggerEnterBattleCastle
-    ScriptEntry BattleFrontier_TriggerEnterBattleArcade
-    ScriptEntry BattleFrontier_TriggerEnterBattleFactory
+    ScriptEntry BattleFrontier_CoordEvent_EnterBattleHall
+    ScriptEntry BattleFrontier_CoordEvent_EnterBattleCastle
+    ScriptEntry BattleFrontier_CoordEvent_EnterBattleArcade
+    ScriptEntry BattleFrontier_CoordEvent_EnterBattleFactory
     ScriptEntry BattleFrontier_OnTransition
     ScriptEntryEnd
 
@@ -175,23 +175,23 @@ BattleFrontier_AttendantSoutheast:
     ReleaseAll
     End
 
-BattleFrontier_SignBattleTower:
+BattleFrontier_TrainerTipsSignpostBattleTower:
     ShowLandmarkSign BattleFrontier_Text_SignBattleTower
     End
 
-BattleFrontier_SignBattleHall:
+BattleFrontier_TrainerTipsSignpostBattleHall:
     ShowLandmarkSign BattleFrontier_Text_SignBattleHall
     End
 
-BattleFrontier_SignBattleCastle:
+BattleFrontier_TrainerTipsSignpostBattleCastle:
     ShowLandmarkSign BattleFrontier_Text_SignBattleCastle
     End
 
-BattleFrontier_SignBattleArcade:
+BattleFrontier_TrainerTipsSignpostBattleArcade:
     ShowLandmarkSign BattleFrontier_Text_SignBattleArcade
     End
 
-BattleFrontier_SignBattleFactory:
+BattleFrontier_TrainerTipsSignpostBattleFactory:
     ShowLandmarkSign BattleFrontier_Text_SignBattleFactory
     End
 
@@ -207,7 +207,7 @@ BattleFrontier_ScaleModel:
     EventMessage BattleFrontier_Text_ScaleModelBattleFrontier
     End
 
-BattleFrontier_TriggerEnterBattleHall:
+BattleFrontier_CoordEvent_EnterBattleHall:
     LockAll
     ApplyMovement LOCALID_PLAYER, BattleFrontier_Movement_PlayerEnterBattleHall
     WaitMovement
@@ -224,7 +224,7 @@ BattleFrontier_Movement_PlayerEnterBattleHall:
     WalkFastWest 5
     EndMovement
 
-BattleFrontier_TriggerEnterBattleCastle:
+BattleFrontier_CoordEvent_EnterBattleCastle:
     LockAll
     ApplyMovement LOCALID_PLAYER, BattleFrontier_Movement_PlayerEnterBattleCastle
     WaitMovement
@@ -241,7 +241,7 @@ BattleFrontier_Movement_PlayerEnterBattleCastle:
     WalkFastWest 6
     EndMovement
 
-BattleFrontier_TriggerEnterBattleArcade:
+BattleFrontier_CoordEvent_EnterBattleArcade:
     LockAll
     ApplyMovement LOCALID_PLAYER, BattleFrontier_Movement_PlayerEnterBattleArcade
     WaitMovement
@@ -258,7 +258,7 @@ BattleFrontier_Movement_PlayerEnterBattleArcade:
     WalkFastEast 5
     EndMovement
 
-BattleFrontier_TriggerEnterBattleFactory:
+BattleFrontier_CoordEvent_EnterBattleFactory:
     LockAll
     ApplyMovement LOCALID_PLAYER, BattleFrontier_Movement_PlayerEnterBattleFactory
     WaitMovement

--- a/res/field/scripts/scripts_battle_frontier_gate_to_fight_area.s
+++ b/res/field/scripts/scripts_battle_frontier_gate_to_fight_area.s
@@ -3,7 +3,7 @@
 #include "res/field/events/events_battle_frontier_gate_to_fight_area.h"
 
 
-    ScriptEntry BattleFrontierGateToFightArea_OnFrameFirstEntry
+    ScriptEntry BattleFrontierGateToFightArea_OnFrame_FirstEntry
     ScriptEntry BattleFrontierGateToFightArea_AttendantGeneral
     ScriptEntry BattleFrontierGateToFightArea_AttendantBattleTower
     ScriptEntry BattleFrontierGateToFightArea_AttendantBattleFactory
@@ -21,7 +21,7 @@ BattleFrontierGateToFightArea_OnTransition:
     SetFlag FLAG_FIRST_ARRIVAL_BATTLE_PARK
     End
 
-BattleFrontierGateToFightArea_OnFrameFirstEntry:
+BattleFrontierGateToFightArea_OnFrame_FirstEntry:
     LockAll
     SetVar VAR_BATTLE_FRONTIER_GATE_TO_FIGHT_AREA_STATE, 1
     SetFlag FLAG_HIDE_JUBILIFE_TV_3F_GLOBAL_RANKING_ROOM_WORKER

--- a/res/field/scripts/scripts_battle_hall.s
+++ b/res/field/scripts/scripts_battle_hall.s
@@ -6,10 +6,10 @@
 
 
     ScriptEntry BattleHall_SingleAttendant
-    ScriptEntry BattleHall_OnFrameResumeChallenge
-    ScriptEntry BattleHall_OnFrameDidntSaveBeforeQuit
-    ScriptEntry BattleHall_OnFrameChallengeEndedCompletedRound
-    ScriptEntry BattleHall_OnFrameChallengeEnded
+    ScriptEntry BattleHall_OnFrame_ResumeChallenge
+    ScriptEntry BattleHall_OnFrame_DidntSaveBeforeQuit
+    ScriptEntry BattleHall_OnFrame_ChallengeEndedCompletedRound
+    ScriptEntry BattleHall_OnFrame_ChallengeEnded
     ScriptEntry BattleHall_MultiAttendant
     ScriptEntry BattleHall_Hiker
     ScriptEntry BattleHall_SnowpointNPC
@@ -567,7 +567,7 @@ BattleHall_ExplainMultiChallenge:
     Message BattleHall_Text_ExplainMultiChallenge
     Return
 
-BattleHall_OnFrameResumeChallenge:
+BattleHall_OnFrame_ResumeChallenge:
     RecordHeapMemory
     SetVar VAR_MAP_LOCAL_3, 1
     SetVar VAR_BATTLE_HALL_LOBBY_LOAD_ACTION, 0
@@ -585,13 +585,13 @@ BattleHall_SaveGame:
     WaitSE SEQ_SE_DP_SAVE
     Return
 
-BattleHall_OnFrameDidntSaveBeforeQuit:
+BattleHall_OnFrame_DidntSaveBeforeQuit:
     Message BattleHall_Text_DidntSaveBeforeQuit
     ScrCmd_2D1 VAR_BATTLE_HALL_CHALLENGE_TYPE
     GoTo BattleHall_EndChallenge
     End
 
-BattleHall_OnFrameChallengeEndedCompletedRound:
+BattleHall_OnFrame_ChallengeEndedCompletedRound:
     CallIfEq VAR_BATTLE_HALL_CHALLENGE_TYPE, FRONTIER_CHALLENGE_SINGLE, BattleHall_IncrementTrainerScoreRoundCompleted
     CallIfEq VAR_BATTLE_HALL_CHALLENGE_TYPE, FRONTIER_CHALLENGE_DOUBLE, BattleHall_IncrementTrainerScoreRoundCompleted
     CallIfEq VAR_BATTLE_HALL_PRINT_STATE, 1, BattleHall_EarnedSilverPrint
@@ -622,7 +622,7 @@ BattleHall_EarnedGoldPrint:
     Common_CheckAllFrontierGoldPrintsObtained
     Return
 
-BattleHall_OnFrameChallengeEnded:
+BattleHall_OnFrame_ChallengeEnded:
     GoTo BattleHall_EndChallenge
     End
 

--- a/res/field/scripts/scripts_battle_tower.s
+++ b/res/field/scripts/scripts_battle_tower.s
@@ -8,11 +8,11 @@
     ScriptEntry BattleTower_SingleAttendant
     ScriptEntry BattleTower_MultiAttendant
     ScriptEntry BattleTower_WiFiAttendant
-    ScriptEntry BattleTower_OnFrameChallengeEnded
-    ScriptEntry BattleTower_OnFrameResumeChallenge
-    ScriptEntry BattleTower_OnFrameDidntSaveBeforeQuit
+    ScriptEntry BattleTower_OnFrame_ChallengeEnded
+    ScriptEntry BattleTower_OnFrame_ResumeChallenge
+    ScriptEntry BattleTower_OnFrame_DidntSaveBeforeQuit
     ScriptEntry BattleTower_Teala
-    ScriptEntry BattleTower_OnFrameQuitBattleSalon
+    ScriptEntry BattleTower_OnFrame_QuitBattleSalon
     ScriptEntry BattleTower_Unused9
     ScriptEntry BattleTower_Unused10
     ScriptEntry BattleTower_Unused11
@@ -301,11 +301,11 @@ BattleTower_SelectPokemon:
     WaitFadeScreen
     Return
 
-BattleTower_OnFrameResumeChallenge:
+BattleTower_OnFrame_ResumeChallenge:
     LockAll
     SetVar VAR_BATTLE_TOWER_LOBBY_LOAD_ACTION, 0
     CallBattleTowerFunction BT_FUNC_UNK_04, 0, VAR_RESULT
-    GoToIfEq VAR_RESULT, 0, BattleTower_OnFrameDidntSaveBeforeQuit
+    GoToIfEq VAR_RESULT, 0, BattleTower_OnFrame_DidntSaveBeforeQuit
     Message BattleTower_Text_SaveBeforeEntering
     InitBattleTower 1, 0xFFFF
     CallBattleTowerFunction BT_FUNC_GET_CHALLENGE_MODE, 0, VAR_RESULT
@@ -337,7 +337,7 @@ BattleTower_SetVarsResumeMultiChallenge:
     SetVar VAR_BATTLE_TOWER_BATTLE_SALON_STATE, 0
     Return
 
-BattleTower_OnFrameDidntSaveBeforeQuit:
+BattleTower_OnFrame_DidntSaveBeforeQuit:
     LockAll
     Message BattleTower_Text_DidntSaveBeforeQuit
     CallBattleTowerFunction BT_FUNC_UNK_14, 0, VAR_RESULT
@@ -418,7 +418,7 @@ BattleTower_GoToWarpToElevator:
     GoTo BattleTower_WarpToElevator
     End
 
-BattleTower_OnFrameQuitBattleSalon:
+BattleTower_OnFrame_QuitBattleSalon:
     LockAll
     Call BattleTower_ResetVarsClearCommunication
     CallBattleTowerFunction BT_FUNC_CHECK_IS_NULL, 0, VAR_RESULT
@@ -873,7 +873,7 @@ _0EA2:
     GoTo _0E58
     End
 
-BattleTower_OnFrameChallengeEnded:
+BattleTower_OnFrame_ChallengeEnded:
     LockAll
     FadeScreenIn
     WaitFadeScreen

--- a/res/field/scripts/scripts_battle_tower_battle_room.s
+++ b/res/field/scripts/scripts_battle_tower_battle_room.s
@@ -6,8 +6,8 @@
 
 
     ScriptEntry BattleTowerBattleRoom_OnTransition
-    ScriptEntry BattleTowerBattleRoom_OnFrameStartChallenge
-    ScriptEntry BattleTowerBattleRoom_OnFrameResumeChallenge
+    ScriptEntry BattleTowerBattleRoom_OnFrame_StartChallenge
+    ScriptEntry BattleTowerBattleRoom_OnFrame_ResumeChallenge
     ScriptEntry BattleTowerBattleRoom_Unused4
     ScriptEntry BattleTowerBattleRoom_OnResume
     ScriptEntryEnd
@@ -69,7 +69,7 @@ BattleTowerBattleRoom_WarpToLobbbyWiFiAttendant:
     ReleaseAll
     End
 
-BattleTowerBattleRoom_OnFrameStartChallenge:
+BattleTowerBattleRoom_OnFrame_StartChallenge:
     LockAll
     SetVar VAR_BATTLE_TOWER_BATTLE_ROOM_LOAD_ACTION, 3
     CallBattleTowerFunction BT_FUNC_CHECK_IS_NULL, 0, VAR_RESULT
@@ -78,7 +78,7 @@ BattleTowerBattleRoom_OnFrameStartChallenge:
     GoTo BattleTowerBattleRoom_Opponent
     End
 
-BattleTowerBattleRoom_OnFrameResumeChallenge:
+BattleTowerBattleRoom_OnFrame_ResumeChallenge:
     LockAll
     SetVar VAR_BATTLE_TOWER_BATTLE_ROOM_LOAD_ACTION, 3
     CallBattleTowerFunction BT_FUNC_CHECK_IS_NULL, 0, VAR_RESULT

--- a/res/field/scripts/scripts_battle_tower_battle_salon.s
+++ b/res/field/scripts/scripts_battle_tower_battle_salon.s
@@ -12,8 +12,8 @@
     ScriptEntry BattleTowerBattleSalon_Buck
     ScriptEntry BattleTowerBattleSalon_OnTransition
     ScriptEntry BattleTowerBattleSalon_OnResume
-    ScriptEntry BattleTowerBattleSalon_OnFrameEnterBattleSalon
-    ScriptEntry BattleTowerBattleSalon_OnFrameEnterBattleRoom
+    ScriptEntry BattleTowerBattleSalon_OnFrame_EnterBattleSalon
+    ScriptEntry BattleTowerBattleSalon_OnFrame_EnterBattleRoom
     ScriptEntryEnd
 
 BattleTowerBattleSalon_OnTransition:
@@ -92,7 +92,7 @@ BattleTowerBattleSalon_SetAttendantPositionAtDoor:
     SetPosition LOCALID_TEALA, 8, 0, 3, DIR_SOUTH
     End
 
-BattleTowerBattleSalon_OnFrameEnterBattleSalon:
+BattleTowerBattleSalon_OnFrame_EnterBattleSalon:
     LockAll
     SetVar VAR_BATTLE_TOWER_BATTLE_SALON_STATE, 0
     Call BattleTowerBattleSalon_EnterBattleSalon
@@ -126,7 +126,7 @@ BattleTowerBattleSalon_Quit:
     WaitFadeScreen
     End
 
-BattleTowerBattleSalon_OnFrameEnterBattleRoom:
+BattleTowerBattleSalon_OnFrame_EnterBattleRoom:
     LockAll
     SetVar VAR_BATTLE_TOWER_BATTLE_SALON_STATE, 0
     Message BattleTowerBattleSalon_Text_ShowYouToMultiBattleRoom

--- a/res/field/scripts/scripts_battle_tower_corridor.s
+++ b/res/field/scripts/scripts_battle_tower_corridor.s
@@ -5,7 +5,7 @@
 
     ScriptEntry BattleTowerCorridorMulti_OnTransition
     ScriptEntry BattleTowerCorridorMulti_OnResume
-    ScriptEntry BattleTowerCorridorMulti_OnFrameEnterBattleRoom
+    ScriptEntry BattleTowerCorridorMulti_OnFrame_EnterBattleRoom
     ScriptEntryEnd
 
 BattleTowerCorridorMulti_OnTransition:
@@ -19,7 +19,7 @@ BattleTowerCorridorMulti_HidePlayer:
     HideObject LOCALID_PLAYER
     Return
 
-BattleTowerCorridorMulti_OnFrameEnterBattleRoom:
+BattleTowerCorridorMulti_OnFrame_EnterBattleRoom:
     LockAll
     Call BattleTowerCorridorMulti_EnterCorridor
     GetRandom VAR_RESULT, 4

--- a/res/field/scripts/scripts_battle_tower_corridor_multi.s
+++ b/res/field/scripts/scripts_battle_tower_corridor_multi.s
@@ -5,7 +5,7 @@
 
     ScriptEntry BattleTowerCorridorMulti_OnTransition
     ScriptEntry BattleTowerCorridorMulti_OnResume
-    ScriptEntry BattleTowerCorridorMulti_OnFrameEnterBattleRoom
+    ScriptEntry BattleTowerCorridorMulti_OnFrame_EnterBattleRoom
     ScriptEntryEnd
 
 BattleTowerCorridorMulti_OnTransition:
@@ -37,7 +37,7 @@ BattleTowerCorridorMulti_HidePlayerMoveCamera:
     MoveCamera 8, 0, 0
     Return
 
-BattleTowerCorridorMulti_OnFrameEnterBattleRoom:
+BattleTowerCorridorMulti_OnFrame_EnterBattleRoom:
     LockAll
     Call BattleTowerCorridorMulti_EnterCorridor
     Call BattleTowerCorridorMulti_WalkToBattleRoom

--- a/res/field/scripts/scripts_battle_tower_elevator.s
+++ b/res/field/scripts/scripts_battle_tower_elevator.s
@@ -4,9 +4,9 @@
 
 
     ScriptEntry BattleTowerElevator_OnTransition
-    ScriptEntry BattleTowerElevator_OnFrameEnterBattleRoom
-    ScriptEntry BattleTowerElevator_OnFrameEnterMultiBattleRoom
-    ScriptEntry BattleTowerElevator_OnFrameEnterBattleSalon
+    ScriptEntry BattleTowerElevator_OnFrame_EnterBattleRoom
+    ScriptEntry BattleTowerElevator_OnFrame_EnterMultiBattleRoom
+    ScriptEntry BattleTowerElevator_OnFrame_EnterBattleSalon
     ScriptEntryEnd
 
 BattleTowerElevator_OnTransition:
@@ -74,21 +74,21 @@ BattleTowerElevator_ElevatorAnimation:
     Call BattleTowerElevator_Exit
     Return
 
-BattleTowerElevator_OnFrameEnterBattleRoom:
+BattleTowerElevator_OnFrame_EnterBattleRoom:
     LockAll
     SetVar VAR_MAP_LOCAL_0, ELEVATOR_DIR_UP
     Call BattleTowerElevator_ElevatorAnimation
     GoTo BattleTowerElevator_BattleRoomCheckWiFi
     End
 
-BattleTowerElevator_OnFrameEnterMultiBattleRoom:
+BattleTowerElevator_OnFrame_EnterMultiBattleRoom:
     LockAll
     SetVar VAR_MAP_LOCAL_0, ELEVATOR_DIR_UP
     Call BattleTowerElevator_ElevatorAnimation
     GoTo BattleTowerElevator_MultiBattleRoom
     End
 
-BattleTowerElevator_OnFrameEnterBattleSalon:
+BattleTowerElevator_OnFrame_EnterBattleSalon:
     LockAll
     SetVar VAR_MAP_LOCAL_0, ELEVATOR_DIR_DOWN
     Call BattleTowerElevator_ElevatorAnimation

--- a/res/field/scripts/scripts_battle_tower_multi_battle_room.s
+++ b/res/field/scripts/scripts_battle_tower_multi_battle_room.s
@@ -7,8 +7,8 @@
 
     ScriptEntry BattleTowerMultiBattleRoom_OnTransition
     ScriptEntry BattleTowerMultiBattleRoom_OnResume
-    ScriptEntry BattleTowerMultiBattleRoom_OnFrameEnter
-    ScriptEntry BattleTowerMultiBattleRoom_OnFrameContinueMultiChallenge
+    ScriptEntry BattleTowerMultiBattleRoom_OnFrame_Enter
+    ScriptEntry BattleTowerMultiBattleRoom_OnFrame_ContinueMultiChallenge
     ScriptEntryEnd
 
 BattleTowerMultiBattleRoom_OnTransition:
@@ -84,7 +84,7 @@ BattleTowerMultiBattleRoom_EndCommunicationWarpToLobby:
     ReleaseAll
     End
 
-BattleTowerMultiBattleRoom_OnFrameEnter:
+BattleTowerMultiBattleRoom_OnFrame_Enter:
     LockAll
     SetVar VAR_BATTLE_TOWER_MULTI_BATTLE_ROOM_LOAD_ACTION, 3
     Call BattleTowerMultiBattleRoom_PlayersEnter
@@ -93,7 +93,7 @@ BattleTowerMultiBattleRoom_OnFrameEnter:
     GoTo BattleTowerMultiBattleRoom_DoMultiBattle
     End
 
-BattleTowerMultiBattleRoom_OnFrameContinueMultiChallenge:
+BattleTowerMultiBattleRoom_OnFrame_ContinueMultiChallenge:
     LockAll
     SetVar VAR_BATTLE_TOWER_MULTI_BATTLE_ROOM_LOAD_ACTION, 3
     Call BattleTowerMultiBattleRoom_PlayersEnter

--- a/res/field/scripts/scripts_battleground.s
+++ b/res/field/scripts/scripts_battleground.s
@@ -10,7 +10,7 @@
 
     ScriptEntry Battleground_ExpertM
     ScriptEntry Battleground_Buck
-    ScriptEntry Battleground_OnFrameWelcome
+    ScriptEntry Battleground_OnFrame_Welcome
     ScriptEntry Battleground_OnTransition
     ScriptEntry Battleground_Trainer1
     ScriptEntry Battleground_Trainer2
@@ -187,7 +187,7 @@ Battleground_Movement_BuckLeaveZ9:
     WalkNormalSouth 2
     EndMovement
 
-Battleground_OnFrameWelcome:
+Battleground_OnFrame_Welcome:
     LockAll
     SetVar VAR_BATTLEGROUND_STATE, 1
     ApplyMovement LOCALID_EXPERT_M, Battleground_Movement_ExpertFExclamationMark

--- a/res/field/scripts/scripts_canalave_city.s
+++ b/res/field/scripts/scripts_canalave_city.s
@@ -6,10 +6,10 @@
 
 
     ScriptEntry CanalaveCity_OnTransition
-    ScriptEntry CanalaveCity_TriggerRival
+    ScriptEntry CanalaveCity_CoordEvent_Rival
     ScriptEntry CanalaveCity_RivalBridge
-    ScriptEntry CanalaveCity_OnFrameRivalOutsideGym
-    ScriptEntry CanalaveCity_OnFrameAfterExplosion
+    ScriptEntry CanalaveCity_OnFrame_RivalOutsideGym
+    ScriptEntry CanalaveCity_OnFrame_AfterExplosion
     ScriptEntry CanalaveCity_ProfRowan
     ScriptEntry CanalaveCity_Counterpart
     ScriptEntry CanalaveCity_Collector
@@ -18,16 +18,16 @@
     ScriptEntry CanalaveCity_Lass
     ScriptEntry CanalaveCity_Psyduck
     ScriptEntry CanalaveCity_OldMan
-    ScriptEntry CanalaveCity_MapSign
-    ScriptEntry CanalaveCity_GymSign
-    ScriptEntry CanalaveCity_SignCanalaveLibrary
-    ScriptEntry CanalaveCity_SignSailorEldritchsHouse
-    ScriptEntry CanalaveCity_SignCanalaveDock
-    ScriptEntry CanalaveCity_SignHarborInn
+    ScriptEntry CanalaveCity_MapSignpost
+    ScriptEntry CanalaveCity_GymSignpost
+    ScriptEntry CanalaveCity_SignboardCanalaveLibrary
+    ScriptEntry CanalaveCity_SignboardSailorEldritchsHouse
+    ScriptEntry CanalaveCity_SignboardCanalaveDock
+    ScriptEntry CanalaveCity_SignboardHarborInn
     ScriptEntry CanalaveCity_SailorEldritch
     ScriptEntry CanalaveCity_Door
     ScriptEntry CanalaveCity_AskGoingToFullmoonIsland
-    ScriptEntry CanalaveCity_OnFrameAfterDarkrai
+    ScriptEntry CanalaveCity_OnFrame_AfterDarkrai
     ScriptEntry CanalaveCity_OnLoad
     ScriptEntry CanalaveCity_RivalLibrary
     ScriptEntryEnd
@@ -115,7 +115,7 @@ CanalaveCity_SetHarborInnDoorClosed:
     SetWarpEventPos 5, 59, 712
     Return
 
-CanalaveCity_TriggerRival:
+CanalaveCity_CoordEvent_Rival:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     GoToIfEq VAR_0x8005, 723, CanalaveCity_SetRivalBridgePositionZ707
@@ -216,7 +216,7 @@ CanalaveCity_RivalBridge:
     NPCMessage CanalaveCity_Text_TrainAtIronIsland
     End
 
-CanalaveCity_OnFrameRivalOutsideGym:
+CanalaveCity_OnFrame_RivalOutsideGym:
     LockAll
     BufferRivalName 0
     BufferPlayerName 1
@@ -244,7 +244,7 @@ CanalaveCity_Movement_PlayerWatchRivalWalkToLibrary:
     WalkOnSpotNormalWest
     EndMovement
 
-CanalaveCity_OnFrameAfterExplosion:
+CanalaveCity_OnFrame_AfterExplosion:
     LockAll
     ApplyMovement LOCALID_PROF_ROWAN, CanalaveCity_Movement_ProfRowanWalkOnSpotSouth
     WaitMovement
@@ -457,33 +457,33 @@ CanalaveCity_WhatCouldExplode:
     Message CanalaveCity_Text_WhatCouldExplode
     GoTo CanalaveCity_NPCEnd
 
-CanalaveCity_MapSign:
+CanalaveCity_MapSignpost:
     ShowMapSign CanalaveCity_Text_MapSign
     End
 
-CanalaveCity_GymSign:
+CanalaveCity_GymSignpost:
     ShowScrollingSign CanalaveCity_Text_SignPokemonGym
     End
 
-CanalaveCity_SignCanalaveLibrary:
+CanalaveCity_SignboardCanalaveLibrary:
     ShowLandmarkSign CanalaveCity_Text_SignCanalaveLibrary
     End
 
-CanalaveCity_SignSailorEldritchsHouse:
+CanalaveCity_SignboardSailorEldritchsHouse:
     ShowLandmarkSign CanalaveCity_Text_SignSailorEldritchsHouse
     End
 
-CanalaveCity_SignCanalaveDock:
+CanalaveCity_SignboardCanalaveDock:
     ShowLandmarkSign CanalaveCity_Text_SignCanalaveDock
     End
 
-CanalaveCity_SignHarborInn:
+CanalaveCity_SignboardHarborInn:
     Call CanalaveCity_CheckDoDarkraiEvent
-    GoToIfEq VAR_MAP_LOCAL_0, FALSE, CanalaveCity_SignHarborInnFaded
+    GoToIfEq VAR_MAP_LOCAL_0, FALSE, CanalaveCity_SignboardHarborInnFaded
     ShowScrollingSign CanalaveCity_Text_SignHarborInn
     End
 
-CanalaveCity_SignHarborInnFaded:
+CanalaveCity_SignboardHarborInnFaded:
     ShowScrollingSign CanalaveCity_Text_SignHarborInnFaded
     End
 
@@ -647,7 +647,7 @@ CanalaveCity_TakeLunarWingToSon:
     ReleaseAll
     End
 
-CanalaveCity_OnFrameAfterDarkrai:
+CanalaveCity_OnFrame_AfterDarkrai:
     LockAll
     ApplyMovement LOCALID_SAILOR_ELDRITCH, CanalaveCity_Movement_SailorEldritchNoticeWalkToPlayer
     WaitMovement

--- a/res/field/scripts/scripts_canalave_city_harbor_inn.s
+++ b/res/field/scripts/scripts_canalave_city_harbor_inn.s
@@ -4,8 +4,8 @@
 #include "res/field/events/events_canalave_city_harbor_inn.h"
 
     ScriptEntry CanalaveCityHarborInn_OnTransition
-    ScriptEntry CanalaveCityHarborInn_OnFrameSleep
-    ScriptEntry CanalaveCityHarborInn_OnFrameAwaken
+    ScriptEntry CanalaveCityHarborInn_OnFrame_Sleep
+    ScriptEntry CanalaveCityHarborInn_OnFrame_Awaken
     ScriptEntryEnd
 
 CanalaveCityHarborInn_OnTransition:
@@ -45,7 +45,7 @@ CanalaveCityWestHouse_TryStartDarkraiEvent:
 CanalaveCityHarborInn_OnTransitionEnd:
     End
 
-CanalaveCityHarborInn_OnFrameSleep:
+CanalaveCityHarborInn_OnFrame_Sleep:
     LockAll
     WaitTime 30, VAR_RESULT
     Message CanalaveCityHarborInn_Text_ReservationForYou
@@ -96,7 +96,7 @@ CanalaveCityHarborInn_Movement_GymGuideWalkToBed:
     WalkOnSpotNormalEast
     EndMovement
 
-CanalaveCityHarborInn_OnFrameAwaken:
+CanalaveCityHarborInn_OnFrame_Awaken:
     LockAll
     Call CanalaveCityHarborInn_ResetOrFinishDarkraiEvent
     ScrCmd_2B5 MAP_HEADER_CANALAVE_CITY, 58, 714

--- a/res/field/scripts/scripts_canalave_library_2f.s
+++ b/res/field/scripts/scripts_canalave_library_2f.s
@@ -6,9 +6,9 @@
     ScriptEntry CanalaveLibrary2F_SchoolKidM
     ScriptEntry CanalaveLibrary2F_Bookshelves
     ScriptEntry CanalaveLibrary2F_Shelves
-    ScriptEntry CanalaveLibrary2F_Sign
+    ScriptEntry CanalaveLibrary2F_BgSign
     ScriptEntry CanalaveLibrary2F_OnTransition
-    ScriptEntry CanalaveLibrary2F_OnFrameHiker
+    ScriptEntry CanalaveLibrary2F_OnFrame_Hiker
     ScriptEntryEnd
 
 CanalaveLibrary2F_OnTransition:
@@ -62,11 +62,11 @@ CanalaveLibrary2F_Shelves:
     EventMessage CanalaveLibrary2F_Text_ShelvesLinedWithBooks
     End
 
-CanalaveLibrary2F_Sign:
+CanalaveLibrary2F_BgSign:
     EventMessage CanalaveLibrary2F_Text_RefrainFromBringingFood
     End
 
-CanalaveLibrary2F_OnFrameHiker:
+CanalaveLibrary2F_OnFrame_Hiker:
     LockAll
     ApplyMovement LOCALID_HIKER, CanalaveLibrary2F_Movement_HikerNoticeWalkToPlayer
     WaitMovement

--- a/res/field/scripts/scripts_canalave_library_3f.s
+++ b/res/field/scripts/scripts_canalave_library_3f.s
@@ -5,7 +5,7 @@
 
 
     ScriptEntry CanalaveLibrary3F_OnTransition
-    ScriptEntry CanalaveLibrary3F_OnFrameExplosion
+    ScriptEntry CanalaveLibrary3F_OnFrame_Explosion
     ScriptEntry CanalaveLibrary3F_ScientistF
     ScriptEntry CanalaveLibrary3F_Youngster
     ScriptEntry CanalaveLibrary3F_SinnohMyth
@@ -15,7 +15,7 @@
     ScriptEntry CanalaveLibrary3F_TheOriginalStory
     ScriptEntry CanalaveLibrary3F_HorrificMyth
     ScriptEntry CanalaveLibrary3F_SinnohFolkStories
-    ScriptEntry CanalaveLibrary3F_Sign
+    ScriptEntry CanalaveLibrary3F_BgSign
     ScriptEntryEnd
 
 CanalaveLibrary3F_OnTransition:
@@ -32,7 +32,7 @@ CanalaveLibrary3F_SetCounterpartGraphicsLucas:
     SetVar VAR_OBJ_GFX_ID_0, OBJ_EVENT_GFX_PLAYER_M
     End
 
-CanalaveLibrary3F_OnFrameExplosion:
+CanalaveLibrary3F_OnFrame_Explosion:
     LockAll
     BufferRivalName 0
     BufferPlayerName 1
@@ -572,7 +572,7 @@ CanalaveLibrary3F_PutSinnohFolkStoriesBack:
     ReleaseAll
     End
 
-CanalaveLibrary3F_Sign:
+CanalaveLibrary3F_BgSign:
     EventMessage CanalaveLibrary3F_Text_ManyMythsAndLegends
     End
 

--- a/res/field/scripts/scripts_celestic_town.s
+++ b/res/field/scripts/scripts_celestic_town.s
@@ -5,14 +5,14 @@
 
     ScriptEntry CelesticTown_OnTransition
     ScriptEntry CelesticTown_Elder
-    ScriptEntry CelesticTown_TriggerElder
+    ScriptEntry CelesticTown_CoordEvent_Elder
     ScriptEntry CelesticTown_GruntM
-    ScriptEntry CelesticTown_OnFrameCynthia
+    ScriptEntry CelesticTown_OnFrame_Cynthia
     ScriptEntry CelesticTown_Cynthia
     ScriptEntry CelesticTown_ExpertM
     ScriptEntry CelesticTown_AceTrainerF
     ScriptEntry CelesticTown_NinjaBoy
-    ScriptEntry CelesticTown_MapSign
+    ScriptEntry CelesticTown_MapSignpost
     ScriptEntry CelesticTown_EtchingDialga
     ScriptEntry CelesticTown_EtchingPalkia
     ScriptEntryEnd
@@ -179,7 +179,7 @@ CelesticTown_UnusedMovement2:
     WalkOnSpotNormalSouth
     EndMovement
 
-CelesticTown_TriggerElder:
+CelesticTown_CoordEvent_Elder:
     LockAll
     ApplyMovement LOCALID_PLAYER, CelesticTown_Movement_PlayerFaceWest
     ApplyMovement LOCALID_ELDER, CelesticTown_Movement_ElderWalkOnSpotEast
@@ -221,7 +221,7 @@ CelesticTown_ExamineRuins:
     ReleaseAll
     End
 
-CelesticTown_OnFrameCynthia:
+CelesticTown_OnFrame_Cynthia:
     LockAll
     ApplyMovement LOCALID_PLAYER, CelesticTown_Movement_PlayerWalkOnSpotEast
     ApplyMovement LOCALID_CYNTHIA, CelesticTown_Movement_CynthiaNoticePlayer
@@ -279,7 +279,7 @@ CelesticTown_NinjaBoy:
     NPCMessage CelesticTown_Text_APokemonCreatedSinnoh
     End
 
-CelesticTown_MapSign:
+CelesticTown_MapSignpost:
     ShowMapSign CelesticTown_Text_MapSign
     End
 

--- a/res/field/scripts/scripts_contest_hall_lobby.s
+++ b/res/field/scripts/scripts_contest_hall_lobby.s
@@ -3,7 +3,7 @@
 #include "res/field/events/events_contest_hall_lobby.h"
 
 
-    ScriptEntry ContestHallLobby_OnFrameFirstEntry
+    ScriptEntry ContestHallLobby_OnFrame_FirstEntry
     ScriptEntry ContestHallLobby_Frame0
     ScriptEntry ContestHallLobby_Frame1
     ScriptEntry ContestHallLobby_Frame2
@@ -16,7 +16,7 @@
     ScriptEntry ContestHallLobby_Fantina
     ScriptEntryEnd
 
-ContestHallLobby_OnFrameFirstEntry:
+ContestHallLobby_OnFrame_FirstEntry:
     LockAll
     ApplyMovement LOCALID_KEIRA, ContestHallLobby_Movement_KeiraNoticePlayer
     WaitMovement

--- a/res/field/scripts/scripts_distortion_world_1f.s
+++ b/res/field/scripts/scripts_distortion_world_1f.s
@@ -6,8 +6,8 @@
 
     ScriptEntry DistortionWorld1F_OnTransition
     ScriptEntry DistortionWorld1F_Portal
-    ScriptEntry DistortionWorld1F_OnFrameFirstEntry
-    ScriptEntry DistortionWorld1F_TriggerCynthiaElevator
+    ScriptEntry DistortionWorld1F_OnFrame_FirstEntry
+    ScriptEntry DistortionWorld1F_CoordEvent_CynthiaElevator
     ScriptEntry DistortionWorld1F_CynthiaElevator
     ScriptEntryEnd
 
@@ -38,7 +38,7 @@ DistortionWorld1F_ReturnToSpearPillar:
     WaitFadeScreen
     End
 
-DistortionWorld1F_OnFrameFirstEntry:
+DistortionWorld1F_OnFrame_FirstEntry:
     LockAll
     ApplyMovement LOCALID_PLAYER, DistortionWorld1F_Movement_PlayerWalkWest
     WaitMovement
@@ -81,7 +81,7 @@ DistortionWorld1F_OnFrameFirstEntry:
     ReleaseAll
     End
 
-DistortionWorld1F_TriggerCynthiaElevator:
+DistortionWorld1F_CoordEvent_CynthiaElevator:
     LockAll
     Message DistortionWorld1F_Text_SlabMovesIfYouStep
     WaitABPadPress

--- a/res/field/scripts/scripts_distortion_world_b1f.s
+++ b/res/field/scripts/scripts_distortion_world_b1f.s
@@ -6,15 +6,15 @@
 #define LOCALID_MESPRIT 129
 
     ScriptEntry DistortionWorldB1F_OnTransition
-    ScriptEntry DistortionWorldB1F_OnFrameFirstEntry
-    ScriptEntry DistortionWorldB1F_TriggerMesprit
+    ScriptEntry DistortionWorldB1F_OnFrame_FirstEntry
+    ScriptEntry DistortionWorldB1F_CoordEvent_Mesprit
     ScriptEntryEnd
 
 DistortionWorldB1F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-DistortionWorldB1F_OnFrameFirstEntry:
+DistortionWorldB1F_OnFrame_FirstEntry:
     LockAll
     ApplyMovement LOCALID_PLAYER, DistortionWorldB1F_Movement_PlayerWalkOnSpotNorth
     ApplyMovement LOCALID_CYNTHIA, DistortionWorldB1F_Movement_CynthiaWalkOnSpotSouth
@@ -29,7 +29,7 @@ DistortionWorldB1F_OnFrameFirstEntry:
     ReleaseAll
     End
 
-DistortionWorldB1F_TriggerMesprit:
+DistortionWorldB1F_CoordEvent_Mesprit:
     LockAll
     PlayCry SPECIES_MESPRIT
     Message DistortionWorldB1F_Text_MespritCry

--- a/res/field/scripts/scripts_distortion_world_b2f.s
+++ b/res/field/scripts/scripts_distortion_world_b2f.s
@@ -5,7 +5,7 @@
 #define LOCALID_CYNTHIA 128
 
     ScriptEntry DistortionWorldB2F_OnTransition
-    ScriptEntry DistortionWorldB2F_OnFrameFirstEntry
+    ScriptEntry DistortionWorldB2F_OnFrame_FirstEntry
     ScriptEntry DistortionWorldB2F_Cynthia
     ScriptEntryEnd
 
@@ -13,7 +13,7 @@ DistortionWorldB2F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-DistortionWorldB2F_OnFrameFirstEntry:
+DistortionWorldB2F_OnFrame_FirstEntry:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     GoToIfEq VAR_DISTORTION_WORLD_PROGRESS, 5, DistortionWorldB2F_Cynthia

--- a/res/field/scripts/scripts_distortion_world_b3f.s
+++ b/res/field/scripts/scripts_distortion_world_b3f.s
@@ -5,14 +5,14 @@
 #define LOCALID_CYRUS 128
 
     ScriptEntry DistortionWorldB3F_OnTransition
-    ScriptEntry DistortionWorldB3F_TriggerCyrus
+    ScriptEntry DistortionWorldB3F_CoordEvent_Cyrus
     ScriptEntryEnd
 
 DistortionWorldB3F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-DistortionWorldB3F_TriggerCyrus:
+DistortionWorldB3F_CoordEvent_Cyrus:
     LockAll
     AddDistortionWorldMapObject LOCALID_CYRUS
     ApplyMovement LOCALID_CYRUS, DistortionWorldB3F_Movement_CyrusEnter

--- a/res/field/scripts/scripts_distortion_world_b6f.s
+++ b/res/field/scripts/scripts_distortion_world_b6f.s
@@ -11,9 +11,9 @@
     ScriptEntry DistortionWorldB6F_Cynthia
     ScriptEntry DistortionWorldB6F_CynthiaPuzzleFinished
     ScriptEntry DistortionWorldB6F_WereGettingClose
-    ScriptEntry DistortionWorldB6F_TriggerMespritBoulderInPit
-    ScriptEntry DistortionWorldB6F_TriggerUxieBoulderInPit
-    ScriptEntry DistortionWorldB6F_TriggerAzelfBoulderInPit
+    ScriptEntry DistortionWorldB6F_CoordEvent_MespritBoulderInPit
+    ScriptEntry DistortionWorldB6F_CoordEvent_UxieBoulderInPit
+    ScriptEntry DistortionWorldB6F_CoordEvent_AzelfBoulderInPit
     ScriptEntry DistortionWorldB6F_BoulderPit
     ScriptEntryEnd
 
@@ -46,7 +46,7 @@ DistortionWorldB6F_WereGettingClose:
     NPCMessage DistortionWorldB6F_Text_WereGettingClose
     End
 
-DistortionWorldB6F_TriggerMespritBoulderInPit:
+DistortionWorldB6F_CoordEvent_MespritBoulderInPit:
     LockAll
     PlayCry SPECIES_MESPRIT
     Message DistortionWorldB6F_Text_MespritCry
@@ -58,7 +58,7 @@ DistortionWorldB6F_TriggerMespritBoulderInPit:
     ReleaseAll
     End
 
-DistortionWorldB6F_TriggerUxieBoulderInPit:
+DistortionWorldB6F_CoordEvent_UxieBoulderInPit:
     LockAll
     PlayCry SPECIES_UXIE
     Message DistortionWorldB6F_Text_UxieCry
@@ -70,7 +70,7 @@ DistortionWorldB6F_TriggerUxieBoulderInPit:
     ReleaseAll
     End
 
-DistortionWorldB6F_TriggerAzelfBoulderInPit:
+DistortionWorldB6F_CoordEvent_AzelfBoulderInPit:
     LockAll
     PlayCry SPECIES_AZELF
     Message DistortionWorldB6F_Text_AzelfCry

--- a/res/field/scripts/scripts_distortion_world_b7f.s
+++ b/res/field/scripts/scripts_distortion_world_b7f.s
@@ -6,9 +6,9 @@
 #define LOCALID_CYRUS   129
 
     ScriptEntry DistortionWorldB7F_OnTransition
-    ScriptEntry DistortionWorldB7F_TriggerWarpToGiratinaRoom
-    ScriptEntry DistortionWorldB7F_OnFrameFirstEntry
-    ScriptEntry DistortionWorldB7F_TriggerCynthiaCyrus
+    ScriptEntry DistortionWorldB7F_CoordEvent_WarpToGiratinaRoom
+    ScriptEntry DistortionWorldB7F_OnFrame_FirstEntry
+    ScriptEntry DistortionWorldB7F_CoordEvent_CynthiaCyrus
     ScriptEntry DistortionWorldB7F_Cyrus
     ScriptEntry DistortionWorldB7F_Cynthia
     ScriptEntryEnd
@@ -17,7 +17,7 @@ DistortionWorldB7F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-DistortionWorldB7F_TriggerWarpToGiratinaRoom:
+DistortionWorldB7F_CoordEvent_WarpToGiratinaRoom:
     FadeScreenOut
     WaitFadeScreen
     Warp MAP_HEADER_DISTORTION_WORLD_GIRATINA_ROOM, 0, 15, 25, DIR_NORTH
@@ -25,7 +25,7 @@ DistortionWorldB7F_TriggerWarpToGiratinaRoom:
     WaitFadeScreen
     End
 
-DistortionWorldB7F_OnFrameFirstEntry:
+DistortionWorldB7F_OnFrame_FirstEntry:
     LockAll
     ApplyMovement LOCALID_CYNTHIA, DistortionWorldB7F_Movement_CynthiaWalkOnSpotNorth
     ApplyMovement LOCALID_PLAYER, DistortionWorldB7F_Movement_PlayerWalkOnSpotNorth
@@ -37,7 +37,7 @@ DistortionWorldB7F_OnFrameFirstEntry:
     SetVar VAR_DISTORTION_WORLD_PROGRESS, 8
     End
 
-DistortionWorldB7F_TriggerCynthiaCyrus:
+DistortionWorldB7F_CoordEvent_CynthiaCyrus:
     LockAll
     Message DistortionWorldB7F_Text_YouWereAlreadyHere
     CloseMessage

--- a/res/field/scripts/scripts_distortion_world_giratina_room.s
+++ b/res/field/scripts/scripts_distortion_world_giratina_room.s
@@ -10,11 +10,11 @@
     ScriptEntry DistortionWorldGiratinaRoom_OnTransition
     ScriptEntry DistortionWorldGiratinaRoom_OnLoad
     ScriptEntry DistortionWorldGiratinaRoom_Portal
-    ScriptEntry DistortionWorldGiratinaRoom_TriggerWarpToB7F
+    ScriptEntry DistortionWorldGiratinaRoom_CoordEvent_WarpToB7F
     ScriptEntry DistortionWorldGiratinaRoom_Giratina
     ScriptEntry DistortionWorldGiratinaRoom_Cynthia
-    ScriptEntry DistortionWorldGiratinaRoom_TriggerFirstShadow
-    ScriptEntry DistortionWorldGiratinaRoom_TriggerGiratinaArrival
+    ScriptEntry DistortionWorldGiratinaRoom_CoordEvent_FirstShadow
+    ScriptEntry DistortionWorldGiratinaRoom_CoordEvent_GiratinaArrival
     ScriptEntryEnd
 
 DistortionWorldGiratinaRoom_OnTransition:
@@ -55,7 +55,7 @@ DistortionWorldGiratinaRoom_GoToSendoffSpring:
     WaitFadeScreen
     End
 
-DistortionWorldGiratinaRoom_TriggerWarpToB7F:
+DistortionWorldGiratinaRoom_CoordEvent_WarpToB7F:
     FadeScreenOut
     WaitFadeScreen
     Warp MAP_HEADER_DISTORTION_WORLD_B7F, 0, 89, 57, DIR_SOUTH
@@ -148,7 +148,7 @@ DistortionWorldGiratinaRoom_Cynthia:
     NPCMessage DistortionWorldGiratinaRoom_Text_LetsGoBackHome
     End
 
-DistortionWorldGiratinaRoom_TriggerFirstShadow:
+DistortionWorldGiratinaRoom_CoordEvent_FirstShadow:
     LockAll
     PlayCry SPECIES_GIRATINA
     Message DistortionWorldGiratinaRoom_Text_GiratinaCryGiygogagogwoh
@@ -158,7 +158,7 @@ DistortionWorldGiratinaRoom_TriggerFirstShadow:
     ReleaseAll
     End
 
-DistortionWorldGiratinaRoom_TriggerGiratinaArrival:
+DistortionWorldGiratinaRoom_CoordEvent_GiratinaArrival:
     LockAll
     BufferPlayerName 0
     Message DistortionWorldGiratinaRoom_Text_GiratinaIsEyeingPlayer

--- a/res/field/scripts/scripts_eterna_city.s
+++ b/res/field/scripts/scripts_eterna_city.s
@@ -4,7 +4,7 @@
 #include "res/field/events/events_eterna_city.h"
 
 
-    ScriptEntry EternaCity_TriggerCynthiaGiveCut
+    ScriptEntry EternaCity_CoordEvent_CynthiaGiveCut
     ScriptEntry EternaCity_GruntM1
     ScriptEntry EternaCity_GruntM2
     ScriptEntry EternaCity_GruntM3
@@ -15,22 +15,22 @@
     ScriptEntry EternaCity_AceTrainerF
     ScriptEntry EternaCity_ExpertM
     ScriptEntry EternaCity_NinjaBoy
-    ScriptEntry EternaCity_MapSign
+    ScriptEntry EternaCity_MapSignpost
     ScriptEntry EternaCity_GymSignpost
-    ScriptEntry EternaCity_LandmarkSignRadRickshawsCycleShop
-    ScriptEntry EternaCity_LandmarkSignTeamGalacticEternaBuilding
-    ScriptEntry EternaCity_LandmarkSignUndergroundMansHouse
-    ScriptEntry EternaCity_LandmarkSignEternaCondominiums
+    ScriptEntry EternaCity_SignboardRadRickshawsCycleShop
+    ScriptEntry EternaCity_SignboardTeamGalacticEternaBuilding
+    ScriptEntry EternaCity_SignboardUndergroundMansHouse
+    ScriptEntry EternaCity_SignboardEternaCondominiums
     ScriptEntry EternaCity_Statue
     ScriptEntry EternaCity_PokemonBreederF2
-    ScriptEntry EternaCity_TriggerBlockExitSouth
+    ScriptEntry EternaCity_CoordEvent_BlockExitSouth
     ScriptEntry EternaCity_OnTransition
     ScriptEntry EternaCity_BugCatcher2
-    ScriptEntry EternaCity_TriggerBlockExitWest
+    ScriptEntry EternaCity_CoordEvent_BlockExitWest
     ScriptEntry EternaCity_Gardenia
-    ScriptEntry EternaCity_TriggerRival
-    ScriptEntry EternaCity_TriggerCynthiaTryGiveEgg
-    ScriptEntry EternaCity_TriggerCynthiaBlockBikeShop
+    ScriptEntry EternaCity_CoordEvent_Rival
+    ScriptEntry EternaCity_CoordEvent_CynthiaTryGiveEgg
+    ScriptEntry EternaCity_CoordEvent_CynthiaBlockBikeShop
     ScriptEntry EternaCity_Cynthia
     ScriptEntryEnd
 
@@ -97,7 +97,7 @@ EternaCity_DoYouUseYourBikesKickstand:
     ReleaseAll
     End
 
-EternaCity_MapSign:
+EternaCity_MapSignpost:
     ShowMapSign EternaCity_Text_EternaCityHistoryLiving
     End
 
@@ -105,23 +105,23 @@ EternaCity_GymSignpost:
     ShowScrollingSign EternaCity_Text_EternaCityPokemonGymLeaderGardeniaMasterOfVividPlantPokemon
     End
 
-EternaCity_LandmarkSignRadRickshawsCycleShop:
+EternaCity_SignboardRadRickshawsCycleShop:
     ShowLandmarkSign EternaCity_Text_RadRickshawsCycleShopGetOnAndRide
     End
 
-EternaCity_LandmarkSignTeamGalacticEternaBuilding:
+EternaCity_SignboardTeamGalacticEternaBuilding:
     ShowLandmarkSign EternaCity_Text_TeamGalacticEternaBuildingWeWantYourPokemon
     End
 
-EternaCity_LandmarkSignUndergroundMansHouse:
+EternaCity_SignboardUndergroundMansHouse:
     ShowLandmarkSign EternaCity_Text_UndergroundMansHouseGoinDownForAdventure
     End
 
-EternaCity_LandmarkSignEternaCondominiums:
+EternaCity_SignboardEternaCondominiums:
     ShowLandmarkSign EternaCity_Text_EternaCondominiumsNameRatingServicesAvailable
     End
 
-EternaCity_TriggerCynthiaGiveCut:
+EternaCity_CoordEvent_CynthiaGiveCut:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     GoToIfEq VAR_0x8005, 522, EternaCity_SetCynthiaPositionForGiveCutZ522
@@ -395,7 +395,7 @@ EternaCity_GoingUndergroundWithTheExplorerKitIsABlastIsntIt:
     NPCMessage EternaCity_Text_GoingUndergroundWithTheExplorerKitIsABlastIsntIt
     End
 
-EternaCity_TriggerBlockExitSouth:
+EternaCity_CoordEvent_BlockExitSouth:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     CallIfEq VAR_0x8004, 303, EternaCity_PokemonBreederFBlockExitSouthX303
@@ -565,7 +565,7 @@ EternaCity_ItFeelsGreatRidingABikeWithTheWindInYourFaceDoesntIt:
     ReleaseAll
     End
 
-EternaCity_TriggerBlockExitWest:
+EternaCity_CoordEvent_BlockExitWest:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     CallIfEq VAR_0x8005, 532, EternaCity_BugCatcher2BlockExitWestZ532
@@ -702,7 +702,7 @@ EternaCity_Movement_GardeniaEnterGym:
     WalkNormalNorth
     EndMovement
 
-EternaCity_TriggerRival:
+EternaCity_CoordEvent_Rival:
     LockAll
     ScrCmd_32D
     ScrCmd_331
@@ -1008,7 +1008,7 @@ EternaCity_Movement_CyrusLeave:
     WalkNormalWest 14
     EndMovement
 
-EternaCity_TriggerCynthiaTryGiveEgg:
+EternaCity_CoordEvent_CynthiaTryGiveEgg:
     LockAll
     SetObjectEventDir LOCALID_CYNTHIA, DIR_EAST
     SetObjectEventMovementType LOCALID_CYNTHIA, MOVEMENT_TYPE_LOOK_EAST
@@ -1206,7 +1206,7 @@ EternaCity_OhYouDontNeedToFeelObligated:
     SetVar VAR_ETERNA_CITY_STATE, 4
     Return
 
-EternaCity_TriggerCynthiaBlockBikeShop:
+EternaCity_CoordEvent_CynthiaBlockBikeShop:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     GoToIfEq VAR_0x8005, 540, EternaCity_CynthiaWalkOnSpotEastZ540

--- a/res/field/scripts/scripts_eterna_city_underground_man_house.s
+++ b/res/field/scripts/scripts_eterna_city_underground_man_house.s
@@ -10,7 +10,7 @@
     ScriptEntry EternaCityUndergroundManHouse_UndergroundMan
     ScriptEntry EternaCityUndergroundManHouse_Youngster
     ScriptEntry EternaCityUndergroundManHouse_ScientistM
-    ScriptEntry EternaCityUndergroundManHouse_Sign
+    ScriptEntry EternaCityUndergroundManHouse_BgSign
     ScriptEntry EternaCityUndergroundManHouse_PC
     ScriptEntry EternaCityUndergroundManHouse_BugCatcher
     ScriptEntryEnd
@@ -463,7 +463,7 @@ EternaCityUndergroundManHouse_OhYoudLikeMoreAdviceOnDiggingUpTreasureAndSpheres:
     ReleaseAll
     End
 
-EternaCityUndergroundManHouse_Sign:
+EternaCityUndergroundManHouse_BgSign:
     EventMessage EternaCityUndergroundManHouse_Text_NewAndOnSaleUndergroundRadar
     End
 

--- a/res/field/scripts/scripts_eterna_forest.s
+++ b/res/field/scripts/scripts_eterna_forest.s
@@ -2,18 +2,18 @@
 #include "res/text/bank/eterna_forest.h"
 #include "res/field/events/events_eterna_forest.h"
 
-    ScriptEntry EternaForest_TriggerStartFollowingCheryl
-    ScriptEntry EternaForest_TriggerPlayerLeaveCheryl
-    ScriptEntry EternaForest_TriggerCherylLeavePlayer
+    ScriptEntry EternaForest_CoordEvent_StartFollowingCheryl
+    ScriptEntry EternaForest_CoordEvent_PlayerLeaveCheryl
+    ScriptEntry EternaForest_CoordEvent_CherylLeavePlayer
     ScriptEntry EternaForest_Unused4
     ScriptEntry EternaForest_Unused5
     ScriptEntry EternaForest_BugCatcher
     ScriptEntry EternaForest_Gardenia
-    ScriptEntry EternaForest_LandmarkSignEternaForest
+    ScriptEntry EternaForest_SignboardEternaForest
     ScriptEntry EternaForest_TrainerTipsSignpost
     ScriptEntry EternaForest_MossRock
     ScriptEntry EternaForest_OnTransition
-    ScriptEntry EternaForest_OnFrameCherylOldChateauCutscene
+    ScriptEntry EternaForest_OnFrame_CherylOldChateauCutscene
     ScriptEntryEnd
 
 EternaForest_OnTransition:
@@ -24,7 +24,7 @@ EternaForest_ResetFollowerCherylState:
     SetVar VAR_ETERNA_FOREST_FOLLOWER_CHERYL_STATE, 0
     End
 
-EternaForest_TriggerStartFollowingCheryl:
+EternaForest_CoordEvent_StartFollowingCheryl:
     LockAll
     SetPlayerBike FALSE
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
@@ -85,7 +85,7 @@ EternaForest_Movement_CherylNoticeAndWalkToPlayerX29:
     WalkOnSpotNormalSouth
     EndMovement
 
-EternaForest_TriggerPlayerLeaveCheryl:
+EternaForest_CoordEvent_PlayerLeaveCheryl:
     LockAll
     ClearHasPartner
     SetMovementType LOCALID_CHERYL, MOVEMENT_TYPE_LOOK_SOUTH
@@ -132,7 +132,7 @@ EternaForest_Movement_CherylWalkOnSpotSouth:
     WalkOnSpotNormalSouth
     EndMovement
 
-EternaForest_TriggerCherylLeavePlayer:
+EternaForest_CoordEvent_CherylLeavePlayer:
     LockAll
     ApplyMovement LOCALID_CHERYL, EternaForest_Movement_CherylExclamationMark
     ApplyMovement LOCALID_PLAYER, EternaForest_Movement_PlayerWalkOnSpotWest
@@ -403,7 +403,7 @@ EternaForest_Movement_GardeniaLeaveNorth:
     WalkNormalEast 10
     EndMovement
 
-EternaForest_LandmarkSignEternaForest:
+EternaForest_SignboardEternaForest:
     ShowLandmarkSign EternaForest_Text_TheEternaForestWhereTimeFlowsEternally
     End
 
@@ -415,7 +415,7 @@ EternaForest_MossRock:
     EventMessage EternaForest_Text_TheRockIsCoveredInMoss
     End
 
-EternaForest_OnFrameCherylOldChateauCutscene:
+EternaForest_OnFrame_CherylOldChateauCutscene:
     LockAll
     SetVar VAR_ETERNA_FOREST_CHERYL_OLD_CHATEAU_CUTSCENE_STATE, 2
     ApplyMovement LOCALID_CHERYL, EternaForest_Movement_CherylWalkOnSpotNorth

--- a/res/field/scripts/scripts_fight_area.s
+++ b/res/field/scripts/scripts_fight_area.s
@@ -3,7 +3,7 @@
 #include "res/field/events/events_fight_area.h"
 
 
-    ScriptEntry FightArea_OnFrameRival
+    ScriptEntry FightArea_OnFrame_Rival
     ScriptEntry FightArea_AceTrainerM1
     ScriptEntry FightArea_AceTrainerF1
     ScriptEntry FightArea_PokemonBreederM
@@ -11,7 +11,7 @@
     ScriptEntry FightArea_BattleGirl1
     ScriptEntry FightArea_Sailor1
     ScriptEntry FightArea_Fisherman
-    ScriptEntry FightArea_MapSign
+    ScriptEntry FightArea_MapSignpost
     ScriptEntry FightArea_ArrowSignpostBattleFrontier
     ScriptEntry FightArea_ArrowSignpostRt225
     ScriptEntry FightArea_Sailor2
@@ -58,7 +58,7 @@ FightArea_ActivateRivalFight_Unused:
     ClearFlag FLAG_HIDE_FIGHT_AREA_RIVAL
     End
 
-FightArea_OnFrameRival:
+FightArea_OnFrame_Rival:
     LockAll
     ScrCmd_32D
     ApplyMovement LOCALID_RIVAL, FightArea_Movement_RivalNoticePlayer
@@ -453,7 +453,7 @@ FightArea_AdviceForFishing:
     ReleaseAll
     End
 
-FightArea_MapSign:
+FightArea_MapSignpost:
     ShowMapSign FightArea_Text_MapSign
     End
 

--- a/res/field/scripts/scripts_floaroma_meadow.s
+++ b/res/field/scripts/scripts_floaroma_meadow.s
@@ -4,11 +4,11 @@
 
 
     ScriptEntry FloaromaMeadow_OnTransition
-    ScriptEntry FloaromaMeadow_TriggerGrunts
+    ScriptEntry FloaromaMeadow_CoordEvent_Grunts
     ScriptEntry FloaromaMeadow_UnusedGrunt
     ScriptEntry FloaromaMeadow_UnusedGrunt
     ScriptEntry FloaromaMeadow_PokefanM
-    ScriptEntry FloaromaMeadow_UnusedArrowSign
+    ScriptEntry FloaromaMeadow_UnusedArrowSignpost
     ScriptEntry FloaromaMeadow_ItemWorksKey
     ScriptEntryEnd
 
@@ -16,7 +16,7 @@ FloaromaMeadow_OnTransition:
     SetFlag FLAG_FIRST_ARRIVAL_FLOAROMA_MEADOW
     End
 
-FloaromaMeadow_TriggerGrunts:
+FloaromaMeadow_CoordEvent_Grunts:
     LockAll
     Call FloaromaMeadow_GruntsNoticePlayer
     StartTrainerBattle TRAINER_GALACTIC_GRUNT_FLOAROMA_MEADOW_1
@@ -228,7 +228,7 @@ FloaromaMeadow_OopsyYouDontHaveEnoughMoney:
     ReleaseAll
     End
 
-FloaromaMeadow_UnusedArrowSign:
+FloaromaMeadow_UnusedArrowSignpost:
     ShowArrowSign FloaromaMeadow_Text_Dummy18
     End
 

--- a/res/field/scripts/scripts_floaroma_town.s
+++ b/res/field/scripts/scripts_floaroma_town.s
@@ -10,8 +10,8 @@
     ScriptEntry FloaromaTown_LassEast
     ScriptEntry FloaromaTown_Camper
     ScriptEntry FloaromaTown_MapSignpost
-    ScriptEntry FloaromaTown_LandmarkSignFlowerShop
-    ScriptEntry FloaromaTown_LandmarkSignFloaromaMeadow
+    ScriptEntry FloaromaTown_SignboardFlowerShop
+    ScriptEntry FloaromaTown_SignboardFloaromaMeadow
     ScriptEntry FloaromaTown_Beauty
     ScriptEntryEnd
 
@@ -90,11 +90,11 @@ FloaromaTown_MapSignpost:
     ShowMapSign FloaromaTown_Text_MapSign
     End
 
-FloaromaTown_LandmarkSignFlowerShop:
+FloaromaTown_SignboardFlowerShop:
     ShowLandmarkSign FloaromaTown_Text_PickAPeckOfColorsFlowerShopFreeBerriesAvailable
     End
 
-FloaromaTown_LandmarkSignFloaromaMeadow:
+FloaromaTown_SignboardFloaromaMeadow:
     ShowLandmarkSign FloaromaTown_Text_FloaromaMeadowAheadHoneyAvailable
     End
 

--- a/res/field/scripts/scripts_fuego_ironworks_outside.s
+++ b/res/field/scripts/scripts_fuego_ironworks_outside.s
@@ -2,10 +2,10 @@
 #include "res/text/bank/fuego_ironworks_outside.h"
 
 
-    ScriptEntry FuegoIronworksOutside_Sign
+    ScriptEntry FuegoIronworksOutside_Signboard
     ScriptEntryEnd
 
-FuegoIronworksOutside_Sign:
+FuegoIronworksOutside_Signboard:
     ShowLandmarkSign FuegoIronworksOutside_Text_SignFuegoIronworks
     End
 

--- a/res/field/scripts/scripts_galactic_hq_1f.s
+++ b/res/field/scripts/scripts_galactic_hq_1f.s
@@ -9,7 +9,7 @@
     ScriptEntry GalacticHQ1F_GruntF2
     ScriptEntry GalacticHQ1F_ScientistM1
     ScriptEntry GalacticHQ1F_Door
-    ScriptEntry GalacticHQ1F_Sign
+    ScriptEntry GalacticHQ1F_BgSign
     ScriptEntry GalacticHQ1F_Saturn
     ScriptEntryEnd
 
@@ -143,7 +143,7 @@ GalacticHQ1F_Movement_DoorEastMoveEast:
     WalkFastEast
     EndMovement
 
-GalacticHQ1F_Sign:
+GalacticHQ1F_BgSign:
     EventMessage GalacticHQ1F_Text_TeamGalacticCredo
     End
 

--- a/res/field/scripts/scripts_galactic_hq_2f.s
+++ b/res/field/scripts/scripts_galactic_hq_2f.s
@@ -3,9 +3,9 @@
 
 
     ScriptEntry GalacticHQ2F_Bed
-    ScriptEntry GalacticHQ2F_SignNapRoom
-    ScriptEntry GalacticHQ2F_SignTVRoom
-    ScriptEntry GalacticHQ2F_SignCredo
+    ScriptEntry GalacticHQ2F_BgSignNapRoom
+    ScriptEntry GalacticHQ2F_BgSignTVRoom
+    ScriptEntry GalacticHQ2F_BgSignCredo
     ScriptEntry GalacticHQ2F_KitchenSink
     ScriptEntry GalacticHQ2F_Report
     ScriptEntry GalacticHQ2F_Refrigerator
@@ -42,15 +42,15 @@ GalacticHQ2F_BedEnd:
     ReleaseAll
     End
 
-GalacticHQ2F_SignNapRoom:
+GalacticHQ2F_BgSignNapRoom:
     EventMessage GalacticHQ2F_Text_TeamGalacticNapRoom
     End
 
-GalacticHQ2F_SignTVRoom:
+GalacticHQ2F_BgSignTVRoom:
     EventMessage GalacticHQ2F_Text_TeamGalacticTVRoom
     End
 
-GalacticHQ2F_SignCredo:
+GalacticHQ2F_BgSignCredo:
     EventMessage GalacticHQ2F_Text_TeamGalacticCredo
     End
 

--- a/res/field/scripts/scripts_galactic_hq_3f.s
+++ b/res/field/scripts/scripts_galactic_hq_3f.s
@@ -5,7 +5,7 @@
 
     ScriptEntry GalacticHQ3F_GruntM
     ScriptEntry GalacticHQ3F_Door
-    ScriptEntry GalacticHQ3F_Sign
+    ScriptEntry GalacticHQ3F_BgSign
     ScriptEntryEnd
 
 GalacticHQ3F_GruntM:
@@ -62,7 +62,7 @@ GalacticHQ3F_Movement_DoorEastMoveEast:
     WalkFastEast
     EndMovement
 
-GalacticHQ3F_Sign:
+GalacticHQ3F_BgSign:
     EventMessage GalacticHQ3F_Text_TeamGalacticCredo
     End
 

--- a/res/field/scripts/scripts_galactic_hq_4f.s
+++ b/res/field/scripts/scripts_galactic_hq_4f.s
@@ -4,13 +4,13 @@
 #include "res/field/events/events_galactic_hq_4f.h"
 
 
-    ScriptEntry GalacticHQ4F_TriggerCyrus
+    ScriptEntry GalacticHQ4F_CoordEvent_Cyrus
     ScriptEntry GalacticHQ4F_Door
-    ScriptEntry GalacticHQ4F_SignWarpPanels
+    ScriptEntry GalacticHQ4F_BgSignWarpPanels
     ScriptEntry GalacticHQ4F_Report
     ScriptEntryEnd
 
-GalacticHQ4F_TriggerCyrus:
+GalacticHQ4F_CoordEvent_Cyrus:
     LockAll
     ApplyMovement LOCALID_CYRUS, GalacticHQ4F_Movement_CyrusWalkOnSpotSouth
     WaitMovement
@@ -151,7 +151,7 @@ GalacticHQ4F_Movement_DoorEastMoveEast:
     WalkFastEast
     EndMovement
 
-GalacticHQ4F_SignWarpPanels:
+GalacticHQ4F_BgSignWarpPanels:
     EventMessage GalacticHQ4F_Text_TeamGalacticWarpPanels
     End
 

--- a/res/field/scripts/scripts_galactic_hq_control_room.s
+++ b/res/field/scripts/scripts_galactic_hq_control_room.s
@@ -16,7 +16,7 @@
     ScriptEntry GalacticHQControlRoom_Uxie
     ScriptEntry GalacticHQControlRoom_Mesprit
     ScriptEntry GalacticHQControlRoom_Azelf
-    ScriptEntry GalacticHQControlRoom_TriggerSaturn
+    ScriptEntry GalacticHQControlRoom_CoordEvent_Saturn
     ScriptEntry GalacticHQControlRoom_Charon
     ScriptEntryEnd
 
@@ -304,7 +304,7 @@ GalacticHQControlRoom_Movement_PlayerWalkOnSpotSouth:
     WalkOnSpotNormalSouth
     EndMovement
 
-GalacticHQControlRoom_TriggerSaturn:
+GalacticHQControlRoom_CoordEvent_Saturn:
     LockAll
     ApplyMovement LOCALID_SATURN, GalacticHQControlRoom_Movement_SaturnWalkOnSpotSouth
     WaitMovement

--- a/res/field/scripts/scripts_galactic_hq_hall.s
+++ b/res/field/scripts/scripts_galactic_hq_hall.s
@@ -3,10 +3,10 @@
 #include "res/field/events/events_galactic_hq_hall.h"
 
 
-    ScriptEntry GalacticHQHall_TriggerSpeech
+    ScriptEntry GalacticHQHall_CoordEvent_Speech
     ScriptEntryEnd
 
-GalacticHQHall_TriggerSpeech:
+GalacticHQHall_CoordEvent_Speech:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     ApplyMovement LOCALID_LOOKER, GalacticHQHall_Movement_LookerNoticePlayer

--- a/res/field/scripts/scripts_game_corner.s
+++ b/res/field/scripts/scripts_game_corner.s
@@ -25,7 +25,7 @@
     ScriptEntry GameCorner_LadyPokeBalls
     ScriptEntry GameCorner_Guitarist
     ScriptEntry GameCorner_MaylenesDad
-    ScriptEntry GameCorner_SignBonusRounds
+    ScriptEntry GameCorner_BgSignBonusRounds
     ScriptEntry GameCorner_Looker
     ScriptEntryEnd
 
@@ -312,13 +312,13 @@ GameCorner_MaylenesDad:
     NPCMessage GameCorner_Text_SighNothingGoingMyWayToday
     End
 
-GameCorner_SignBonusRounds:
-    GoToIfGt VAR_CONSECUTIVE_BONUS_ROUND_WINS, 999, GameCorner_SignBonusRounds_GreaterThan999
+GameCorner_BgSignBonusRounds:
+    GoToIfGt VAR_CONSECUTIVE_BONUS_ROUND_WINS, 999, GameCorner_BgSignBonusRounds_GreaterThan999
     BufferNumber 0, VAR_CONSECUTIVE_BONUS_ROUND_WINS
     EventMessage GameCorner_Text_ShootFor10
     End
 
-GameCorner_SignBonusRounds_GreaterThan999:
+GameCorner_BgSignBonusRounds_GreaterThan999:
     BufferNumber 0, 999
     EventMessage GameCorner_Text_ShootFor10
     End

--- a/res/field/scripts/scripts_global_terminal_1f.s
+++ b/res/field/scripts/scripts_global_terminal_1f.s
@@ -15,7 +15,7 @@
     ScriptEntry GlobalTerminal1F_Beauty1
     ScriptEntry GlobalTerminal1F_Picnicker
     ScriptEntry GlobalTerminal1F_Youngster
-    ScriptEntry GlobalTerminal1F_OnFrameExitGTSRoom
+    ScriptEntry GlobalTerminal1F_OnFrame_ExitGTSRoom
     ScriptEntry GlobalTerminal1F_OnResume
     ScriptEntry GlobalTerminal1F_BattleVideoRankingsMachine
     ScriptEntry GlobalTerminal1F_TrainerRankingsMachine
@@ -24,7 +24,7 @@
     ScriptEntry GlobalTerminal1F_PokemonBreederF
     ScriptEntry GlobalTerminal1F_PokemonBreederM
     ScriptEntry GlobalTerminal1F_Beauty2
-    ScriptEntry GlobalTerminal1F_Sign
+    ScriptEntry GlobalTerminal1F_BgSign
     ScriptEntryEnd
 
 GlobalTerminal1F_OnResume:
@@ -35,7 +35,7 @@ GlobalTerminal1F_HidePlayer:
     HideObject LOCALID_PLAYER
     Return
 
-GlobalTerminal1F_OnFrameExitGTSRoom:
+GlobalTerminal1F_OnFrame_ExitGTSRoom:
     LockAll
     Call GlobalTerminal1F_ExitGTSRoom
     ReleaseAll
@@ -529,7 +529,7 @@ GlobalTerminal1F_CheckReceivedBackdrop:
 GlobalTerminal1F_DidntReceivAllBackdrops:
     Return
 
-GlobalTerminal1F_Sign:
+GlobalTerminal1F_BgSign:
     EventMessage GlobalTerminal1F_Text_PanelsLeadTo2F3F
     End
 

--- a/res/field/scripts/scripts_global_terminal_2f.s
+++ b/res/field/scripts/scripts_global_terminal_2f.s
@@ -12,8 +12,8 @@
     ScriptEntry GlobalTerminal2F_Beauty
     ScriptEntry GlobalTerminal2F_Lass
     ScriptEntry GlobalTerminal2F_Twin
-    ScriptEntry GlobalTerminal2F_SignWarp1F
-    ScriptEntry GlobalTerminal2F_SignWarp3F
+    ScriptEntry GlobalTerminal2F_BgSignWarp1F
+    ScriptEntry GlobalTerminal2F_BgSignWarp3F
     ScriptEntry GlobalTerminal2F_BoxDataMachine
     ScriptEntry GlobalTerminal2F_DressUpDataMachine
     ScriptEntryEnd
@@ -54,11 +54,11 @@ GlobalTerminal2F_Twin:
     NPCMessage GlobalTerminal2F_Text_ILikeSneakingGlances
     End
 
-GlobalTerminal2F_SignWarp1F:
+GlobalTerminal2F_BgSignWarp1F:
     EventMessage GlobalTerminal2F_Text_WarpsTo1F
     End
 
-GlobalTerminal2F_SignWarp3F:
+GlobalTerminal2F_BgSignWarp3F:
     EventMessage GlobalTerminal2F_Text_WarpsTo3F
     End
 

--- a/res/field/scripts/scripts_global_terminal_3f.s
+++ b/res/field/scripts/scripts_global_terminal_3f.s
@@ -12,8 +12,8 @@
     ScriptEntry GlobalTerminal3F_Clown
     ScriptEntry GlobalTerminal3F_Guitarist
     ScriptEntry GlobalTerminal3F_Hiker
-    ScriptEntry GlobalTerminal3F_SignWarp1F
-    ScriptEntry GlobalTerminal3F_SignWarp2F
+    ScriptEntry GlobalTerminal3F_BgSignWarp1F
+    ScriptEntry GlobalTerminal3F_BgSignWarp2F
     ScriptEntry GlobalTerminal3F_BattleVideosMachine
     ScriptEntryEnd
 
@@ -53,11 +53,11 @@ GlobalTerminal3F_Hiker:
     NPCMessage GlobalTerminal3F_Text_Hiker2FIsBrother
     End
 
-GlobalTerminal3F_SignWarp1F:
+GlobalTerminal3F_BgSignWarp1F:
     EventMessage GlobalTerminal3F_Text_WarpsTo1F
     End
 
-GlobalTerminal3F_SignWarp2F:
+GlobalTerminal3F_BgSignWarp2F:
     EventMessage GlobalTerminal3F_Text_WarpsTo2F
     End
 

--- a/res/field/scripts/scripts_great_marsh_1.s
+++ b/res/field/scripts/scripts_great_marsh_1.s
@@ -2,7 +2,7 @@
 #include "res/text/bank/great_marsh_1.h"
 
 
-    ScriptEntry GreatMarsh1_SignArea1
+    ScriptEntry GreatMarsh1_SignboardArea1
     ScriptEntry GreatMarsh1_RuinManiac
     ScriptEntryEnd
 
@@ -10,6 +10,6 @@ GreatMarsh1_RuinManiac:
     NPCMessage GreatMarsh1_Text_ThisIsHowYouWin
     End
 
-GreatMarsh1_SignArea1:
+GreatMarsh1_SignboardArea1:
     ShowLandmarkSign GreatMarsh1_Text_SignArea1
     End

--- a/res/field/scripts/scripts_great_marsh_2.s
+++ b/res/field/scripts/scripts_great_marsh_2.s
@@ -3,13 +3,13 @@
 
 
     ScriptEntry GreatMarsh2_ParasolLady
-    ScriptEntry GreatMarsh2_SignArea2
+    ScriptEntry GreatMarsh2_SignboardArea2
     ScriptEntryEnd
 
 GreatMarsh2_ParasolLady:
     NPCMessage GreatMarsh2_Text_PokemonDifferDayToDay
     End
 
-GreatMarsh2_SignArea2:
+GreatMarsh2_SignboardArea2:
     ShowLandmarkSign GreatMarsh2_Text_SignArea2
     End

--- a/res/field/scripts/scripts_great_marsh_3.s
+++ b/res/field/scripts/scripts_great_marsh_3.s
@@ -3,13 +3,13 @@
 
 
     ScriptEntry GreatMarsh3_Collector
-    ScriptEntry GreatMarsh3_SignArea3
+    ScriptEntry GreatMarsh3_SignboardArea3
     ScriptEntryEnd
 
 GreatMarsh3_Collector:
     NPCMessage GreatMarsh3_Text_WhatToDo
     End
 
-GreatMarsh3_SignArea3:
+GreatMarsh3_SignboardArea3:
     ShowLandmarkSign GreatMarsh3_Text_SignArea3
     End

--- a/res/field/scripts/scripts_great_marsh_4.s
+++ b/res/field/scripts/scripts_great_marsh_4.s
@@ -3,13 +3,13 @@
 
 
     ScriptEntry GreatMarsh4_BugCatcher
-    ScriptEntry GreatMarsh4_SignArea4
+    ScriptEntry GreatMarsh4_SignboardArea4
     ScriptEntryEnd
 
 GreatMarsh4_BugCatcher:
     NPCMessage GreatMarsh4_Text_YouGetSuckedDown
     End
 
-GreatMarsh4_SignArea4:
+GreatMarsh4_SignboardArea4:
     ShowLandmarkSign GreatMarsh4_Text_SignArea4
     End

--- a/res/field/scripts/scripts_great_marsh_5.s
+++ b/res/field/scripts/scripts_great_marsh_5.s
@@ -3,13 +3,13 @@
 
 
     ScriptEntry GreatMarsh5_Youngster
-    ScriptEntry GreatMarsh5_SignArea5
+    ScriptEntry GreatMarsh5_SignboardArea5
     ScriptEntryEnd
 
 GreatMarsh5_Youngster:
     NPCMessage GreatMarsh5_Text_IRecommendQuickTrams
     End
 
-GreatMarsh5_SignArea5:
+GreatMarsh5_SignboardArea5:
     ShowLandmarkSign GreatMarsh5_Text_SignArea5
     End

--- a/res/field/scripts/scripts_great_marsh_6.s
+++ b/res/field/scripts/scripts_great_marsh_6.s
@@ -3,7 +3,7 @@
 
 
     ScriptEntry GreatMarsh6_AceTrainerM
-    ScriptEntry GreatMarsh6_SignArea6
+    ScriptEntry GreatMarsh6_SignboardArea6
     ScriptEntryEnd
 
 GreatMarsh6_AceTrainerM:
@@ -62,6 +62,6 @@ GreatMarsh6_BagIsFull:
     ReleaseAll
     End
 
-GreatMarsh6_SignArea6:
+GreatMarsh6_SignboardArea6:
     ShowLandmarkSign GreatMarsh6_Text_Area6
     End

--- a/res/field/scripts/scripts_hall_of_origin.s
+++ b/res/field/scripts/scripts_hall_of_origin.s
@@ -5,9 +5,9 @@
 
 
     ScriptEntry HallOfOrigin_OnLoad
-    ScriptEntry HallOfOrigin_TriggerArceus
+    ScriptEntry HallOfOrigin_CoordEvent_Arceus
     ScriptEntry HallOfOrigin_OnTransition
-    ScriptEntry HallOfOrigin_TriggerArceus
+    ScriptEntry HallOfOrigin_CoordEvent_Arceus
     ScriptEntryEnd
 
 HallOfOrigin_OnTransition:
@@ -31,7 +31,7 @@ HallOfOrigin_RemoveArceus:
     ClearFlag FLAG_MAP_LOCAL
     End
 
-HallOfOrigin_TriggerArceus:
+HallOfOrigin_CoordEvent_Arceus:
     LockAll
     SetVar VAR_HALL_OF_ORIGIN_STATE, 0
     Call HallOfOrigin_PlayerNoticeArceus

--- a/res/field/scripts/scripts_hearthome_city.s
+++ b/res/field/scripts/scripts_hearthome_city.s
@@ -24,16 +24,16 @@
     ScriptEntry HearthomeCity_BabyInPram2
     ScriptEntry HearthomeCity_BlackBelt1
     ScriptEntry HearthomeCity_PokemonBreederF2
-    ScriptEntry HearthomeCity_TriggerBunearyAndKeira
+    ScriptEntry HearthomeCity_CoordEvent_BunearyAndKeira
     ScriptEntry HearthomeCity_MapSignpost
     ScriptEntry HearthomeCity_GymSignpost
-    ScriptEntry HearthomeCity_SignPokemonContestHall
-    ScriptEntry HearthomeCity_SignPokemonFanClub
+    ScriptEntry HearthomeCity_SignboardPokemonContestHall
+    ScriptEntry HearthomeCity_SignboardPokemonFanClub
     ScriptEntry HearthomeCity_ArrowSignpostWest
     ScriptEntry HearthomeCity_ArrowSignpostEast
-    ScriptEntry HearthomeCity_SignAmitySquareWestGate
-    ScriptEntry HearthomeCity_SignAmitySquareEastGate
-    ScriptEntry HearthomeCity_SignPoffinHouse
+    ScriptEntry HearthomeCity_SignboardAmitySquareWestGate
+    ScriptEntry HearthomeCity_SignboardAmitySquareEastGate
+    ScriptEntry HearthomeCity_SignboardPoffinHouse
     ScriptEntry HearthomeCity_GymGuide
     ScriptEntry HearthomeCity_BlackBelt2
     ScriptEntryEnd
@@ -440,7 +440,7 @@ HearthomeCity_PokemonBreederF2:
     NPCMessage HearthomeCity_Text_IdLikeToLiveInHearthome
     End
 
-HearthomeCity_TriggerBunearyAndKeira:
+HearthomeCity_CoordEvent_BunearyAndKeira:
     LockAll
     ApplyMovement LOCALID_PLAYER, HearthomeCity_Movement_PlayerExclamationMark
     WaitMovement
@@ -539,11 +539,11 @@ HearthomeCity_GymSignpost:
     ShowScrollingSign HearthomeCity_Text_SignHearthomeCityPokemonGym
     End
 
-HearthomeCity_SignPokemonContestHall:
+HearthomeCity_SignboardPokemonContestHall:
     ShowLandmarkSign HearthomeCity_Text_SignPokemonContestHall
     End
 
-HearthomeCity_SignPokemonFanClub:
+HearthomeCity_SignboardPokemonFanClub:
     ShowLandmarkSign HearthomeCity_Text_SignPokemonFanClub
     End
 
@@ -555,15 +555,15 @@ HearthomeCity_ArrowSignpostEast:
     ShowArrowSign HearthomeCity_Text_SignRt209SolaceonTown
     End
 
-HearthomeCity_SignAmitySquareWestGate:
+HearthomeCity_SignboardAmitySquareWestGate:
     ShowLandmarkSign HearthomeCity_Text_SignAmitySquareWestGate
     End
 
-HearthomeCity_SignAmitySquareEastGate:
+HearthomeCity_SignboardAmitySquareEastGate:
     ShowLandmarkSign HearthomeCity_Text_SignAmitySquareEastGate
     End
 
-HearthomeCity_SignPoffinHouse:
+HearthomeCity_SignboardPoffinHouse:
     ShowLandmarkSign HearthomeCity_Text_SignThePoffinHouse
     End
 

--- a/res/field/scripts/scripts_hearthome_city_dp_gym_elevator_room_1.s
+++ b/res/field/scripts/scripts_hearthome_city_dp_gym_elevator_room_1.s
@@ -3,20 +3,20 @@
 
 
     ScriptEntry HearthomeCityDPGymElevatorRoom1_OnTransition
-    ScriptEntry HearthomeCityDPGymElevatorRoom1_TriggerMoveLift
-    ScriptEntry HearthomeCityDPGymElevatorRoom1_SignCorrect
-    ScriptEntry HearthomeCityDPGymElevatorRoom1_SignQuestion
+    ScriptEntry HearthomeCityDPGymElevatorRoom1_CoordEvent_MoveLift
+    ScriptEntry HearthomeCityDPGymElevatorRoom1_BgSignCorrect
+    ScriptEntry HearthomeCityDPGymElevatorRoom1_BgSignQuestion
     ScriptEntryEnd
 
 HearthomeCityDPGymElevatorRoom1_OnTransition:
     InitPersistedMapFeaturesForHearthomeGym
     End
 
-HearthomeCityDPGymElevatorRoom1_TriggerMoveLift:
+HearthomeCityDPGymElevatorRoom1_CoordEvent_MoveLift:
     MoveHearthomeGymDPLift
     End
 
-HearthomeCityDPGymElevatorRoom1_SignCorrect:
+HearthomeCityDPGymElevatorRoom1_BgSignCorrect:
     LockAll
     PlaySE SEQ_SE_DP_UG_020
     Message HearthomeCityDPGymElevatorRoom1_Text_Correct
@@ -25,7 +25,7 @@ HearthomeCityDPGymElevatorRoom1_SignCorrect:
     ReleaseAll
     End
 
-HearthomeCityDPGymElevatorRoom1_SignQuestion:
+HearthomeCityDPGymElevatorRoom1_BgSignQuestion:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     Message HearthomeCityDPGymElevatorRoom1_Text_WhatIs3Times13

--- a/res/field/scripts/scripts_hearthome_city_dp_gym_elevator_room_2.s
+++ b/res/field/scripts/scripts_hearthome_city_dp_gym_elevator_room_2.s
@@ -3,20 +3,20 @@
 
 
     ScriptEntry HearthomeCityDPGymElevatorRoom2_OnTransition
-    ScriptEntry HearthomeCityDPGymElevatorRoom2_TriggerMoveLift
-    ScriptEntry HearthomeCityDPGymElevatorRoom2_SignCorrect
-    ScriptEntry HearthomeCityDPGymElevatorRoom2_SignQuestion
+    ScriptEntry HearthomeCityDPGymElevatorRoom2_CoordEvent_MoveLift
+    ScriptEntry HearthomeCityDPGymElevatorRoom2_BgSignCorrect
+    ScriptEntry HearthomeCityDPGymElevatorRoom2_BgSignQuestion
     ScriptEntryEnd
 
 HearthomeCityDPGymElevatorRoom2_OnTransition:
     InitPersistedMapFeaturesForHearthomeGym
     End
 
-HearthomeCityDPGymElevatorRoom2_TriggerMoveLift:
+HearthomeCityDPGymElevatorRoom2_CoordEvent_MoveLift:
     MoveHearthomeGymDPLift
     End
 
-HearthomeCityDPGymElevatorRoom2_SignCorrect:
+HearthomeCityDPGymElevatorRoom2_BgSignCorrect:
     LockAll
     PlaySE SEQ_SE_DP_UG_020
     Message HearthomeCityDPGymElevatorRoom2_Text_Correct
@@ -25,7 +25,7 @@ HearthomeCityDPGymElevatorRoom2_SignCorrect:
     ReleaseAll
     End
 
-HearthomeCityDPGymElevatorRoom2_SignQuestion:
+HearthomeCityDPGymElevatorRoom2_BgSignQuestion:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     Message HearthomeCityDPGymElevatorRoom2_Text_WhatsFirstRoomsAnswer

--- a/res/field/scripts/scripts_iron_island_b1f_right_room.s
+++ b/res/field/scripts/scripts_iron_island_b1f_right_room.s
@@ -2,14 +2,14 @@
 
 
     ScriptEntry IronIslandB1FRightRoom_OnTransition
-    ScriptEntry IronIslandB1FRightRoom_TriggerPlatformLift
+    ScriptEntry IronIslandB1FRightRoom_CoordEvent_PlatformLift
     ScriptEntryEnd
 
 IronIslandB1FRightRoom_OnTransition:
     InitPersistedMapFeaturesForPlatformLift
     End
 
-IronIslandB1FRightRoom_TriggerPlatformLift:
+IronIslandB1FRightRoom_CoordEvent_PlatformLift:
     TriggerPlatformLift
     End
 

--- a/res/field/scripts/scripts_iron_island_b2f_left_room.s
+++ b/res/field/scripts/scripts_iron_island_b2f_left_room.s
@@ -5,14 +5,14 @@
 
 
     ScriptEntry IronIslandB2FLeftRoom_OnTransition
-    ScriptEntry IronIslandB2FLeftRoom_TriggerPlatformLift
-    ScriptEntry IronIslandB2FLeftRoom_TriggerStartFollowingRiley
-    ScriptEntry IronIslandB2FLeftRoom_TriggerPlayerLeaveRiley
+    ScriptEntry IronIslandB2FLeftRoom_CoordEvent_PlatformLift
+    ScriptEntry IronIslandB2FLeftRoom_CoordEvent_StartFollowingRiley
+    ScriptEntry IronIslandB2FLeftRoom_CoordEvent_PlayerLeaveRiley
     ScriptEntry IronIslandB2FLeftRoom_Unused5
     ScriptEntry IronIslandB2FLeftRoom_Unused6
     ScriptEntry IronIslandB2FLeftRoom_Unused7
     ScriptEntry IronIslandB2FLeftRoom_Riley
-    ScriptEntry IronIslandB2FLeftRoom_TriggerGrunts
+    ScriptEntry IronIslandB2FLeftRoom_CoordEvent_Grunts
     ScriptEntryEnd
 
 IronIslandB2FLeftRoom_OnTransition:
@@ -31,11 +31,11 @@ IronIslandB2FLeftRoom_SetRileyPositionAtExit:
     SetObjectEventDir LOCALID_RILEY, DIR_EAST
     End
 
-IronIslandB2FLeftRoom_TriggerPlatformLift:
+IronIslandB2FLeftRoom_CoordEvent_PlatformLift:
     TriggerPlatformLift
     End
 
-IronIslandB2FLeftRoom_TriggerStartFollowingRiley:
+IronIslandB2FLeftRoom_CoordEvent_StartFollowingRiley:
     LockAll
     SetPlayerBike FALSE
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
@@ -77,7 +77,7 @@ IronIslandB2FLeftRoom_HiLetsTeamUp:
     Message IronIslandB2FLeftRoom_Text_HiLetsTeamUp
     Return
 
-IronIslandB2FLeftRoom_TriggerPlayerLeaveRiley:
+IronIslandB2FLeftRoom_CoordEvent_PlayerLeaveRiley:
     LockAll
     ApplyMovement LOCALID_PLAYER, IronIslandB2FLeftRoom_Movement_PlayerWalkOnSpotWest
     ApplyMovement LOCALID_RILEY, IronIslandB2FLeftRoom_Movement_RileyFaceEast
@@ -146,7 +146,7 @@ IronIslandB2FLeftRoom_Movement_RileyWalkBackZ3:
 IronIslandB2FLeftRoom_Unused5:
     End
 
-IronIslandB2FLeftRoom_TriggerGrunts:
+IronIslandB2FLeftRoom_CoordEvent_Grunts:
     LockAll
     ClearHasPartner
     SetMovementType LOCALID_RILEY, MOVEMENT_TYPE_LOOK_WEST

--- a/res/field/scripts/scripts_iron_island_b3f.s
+++ b/res/field/scripts/scripts_iron_island_b3f.s
@@ -2,7 +2,7 @@
 
 
     ScriptEntry IronIslandB3F_OnTransition
-    ScriptEntry IronIslandB3F_TriggerPlatformLift
+    ScriptEntry IronIslandB3F_CoordEvent_PlatformLift
     ScriptEntry IronIslandB3F_Unused
     ScriptEntry IronIslandB3F_OnLoad
     ScriptEntryEnd
@@ -29,7 +29,7 @@ IronIslandB3F_RemoveWarpIronRuinsWithoutRegisteel:
     SetWarpEventPos 2, 17, 1
     End
 
-IronIslandB3F_TriggerPlatformLift:
+IronIslandB3F_CoordEvent_PlatformLift:
     TriggerPlatformLift
     End
 

--- a/res/field/scripts/scripts_jubilife_city.s
+++ b/res/field/scripts/scripts_jubilife_city.s
@@ -5,9 +5,9 @@
 
 
     ScriptEntry JubilifeCity_OnTransition
-    ScriptEntry JubilifeCity_TriggerFirstArrival
-    ScriptEntry JubilifeCity_TriggerLookerBlockRoute203
-    ScriptEntry JubilifeCity_TriggerTeamGalactic
+    ScriptEntry JubilifeCity_CoordEvent_FirstArrival
+    ScriptEntry JubilifeCity_CoordEvent_LookerBlockRoute203
+    ScriptEntry JubilifeCity_CoordEvent_TeamGalactic
     ScriptEntry JubilifeCity_Looker
     ScriptEntry JubilifeCity_SchoolKidM1
     ScriptEntry JubilifeCity_Twin
@@ -20,18 +20,18 @@
     ScriptEntry JubilifeCity_Clown1
     ScriptEntry JubilifeCity_Clown2
     ScriptEntry JubilifeCity_Clown3
-    ScriptEntry JubilifeCity_TriggerPoketchCampaign
+    ScriptEntry JubilifeCity_CoordEvent_PoketchCampaign
     ScriptEntry JubilifeCity_PoketchCoPresident
-    ScriptEntry JubilifeCity_TriggerGTSGreeterBlockPlayer
+    ScriptEntry JubilifeCity_CoordEvent_GTSGreeterBlockPlayer
     ScriptEntry JubilifeCity_KidWithNDS1
     ScriptEntry JubilifeCity_KidWithNDS2
-    ScriptEntry JubilifeCity_MapSign
-    ScriptEntry JubilifeCity_LandmarkSignJubilifeCondominiums
-    ScriptEntry JubilifeCity_LandmarkSignPoketchCompany
-    ScriptEntry JubilifeCity_LandmarkSignTrainersSchool
-    ScriptEntry JubilifeCity_LandmarkSignJubilifeTV
-    ScriptEntry JubilifeCity_LandmarkSignGlobalTerminal
-    ScriptEntry JubilifeCity_TriggerLookerPalPad
+    ScriptEntry JubilifeCity_MapSignpost
+    ScriptEntry JubilifeCity_SignboardJubilifeCondominiums
+    ScriptEntry JubilifeCity_SignboardPoketchCompany
+    ScriptEntry JubilifeCity_SignboardTrainersSchool
+    ScriptEntry JubilifeCity_SignboardJubilifeTV
+    ScriptEntry JubilifeCity_SignboardGlobalTerminal
+    ScriptEntry JubilifeCity_CoordEvent_LookerPalPad
     ScriptEntryEnd
 
 JubilifeCity_OnTransition:
@@ -62,7 +62,7 @@ JubilifeCity_SetCounterpartGraphicsLucas:
     SetVar VAR_OBJ_GFX_ID_0, OBJ_EVENT_GFX_PLAYER_M
     End
 
-JubilifeCity_TriggerFirstArrival:
+JubilifeCity_CoordEvent_FirstArrival:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     GoToIfEq VAR_0x8004, 173, JubilifeCity_FirstArrivalX173
@@ -460,7 +460,7 @@ JubilifeCity_AceTrainerM3:
     NPCMessage JubilifeCity_Text_PastHereIsTheGlobalTerminal
     End
 
-JubilifeCity_TriggerGTSGreeterBlockPlayer:
+JubilifeCity_CoordEvent_GTSGreeterBlockPlayer:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     GoToIfEq VAR_0x8005, 779, JubilifeCity_GTSGreeterBlockPlayerZ779
@@ -558,7 +558,7 @@ JubilifeCity_Movement_PlayerStepBackEast:
     WalkNormalEast
     EndMovement
 
-JubilifeCity_TriggerLookerBlockRoute203:
+JubilifeCity_CoordEvent_LookerBlockRoute203:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     GoToIfEq VAR_0x8005, 757, JubilifeCity_LookerWalkToPlayerZ757
@@ -793,7 +793,7 @@ JubilifeCity_Movement_LookerFaceSouth:
     FaceSouth
     EndMovement
 
-JubilifeCity_TriggerTeamGalactic:
+JubilifeCity_CoordEvent_TeamGalactic:
     LockAll
     ApplyMovement LOCALID_GRUNT_M_2, JubilifeCity_Movement_GruntWalkOnSpotEast
     WaitMovement
@@ -1287,31 +1287,31 @@ JubilifeCity_SchoolKidM2:
     NPCMessage JubilifeCity_Text_AtMostYouCanHaveSixPokemonWithYou
     End
 
-JubilifeCity_MapSign:
+JubilifeCity_MapSignpost:
     ShowMapSign JubilifeCity_Text_MapSign
     End
 
-JubilifeCity_LandmarkSignJubilifeCondominiums:
+JubilifeCity_SignboardJubilifeCondominiums:
     ShowLandmarkSign JubilifeCity_Text_JubilifeCondominiumsTenantsWanted
     End
 
-JubilifeCity_LandmarkSignPoketchCompany:
+JubilifeCity_SignboardPoketchCompany:
     ShowLandmarkSign JubilifeCity_Text_ThePoketchCompanyPokemonWatchesForTheWorld
     End
 
-JubilifeCity_LandmarkSignTrainersSchool:
+JubilifeCity_SignboardTrainersSchool:
     ShowLandmarkSign JubilifeCity_Text_TrainersSchoolTheFirstStepForTrainers
     End
 
-JubilifeCity_LandmarkSignJubilifeTV:
+JubilifeCity_SignboardJubilifeTV:
     ShowLandmarkSign JubilifeCity_Text_JubilifeTVTheFunAndGamesTVStation
     End
 
-JubilifeCity_LandmarkSignGlobalTerminal:
+JubilifeCity_SignboardGlobalTerminal:
     ShowLandmarkSign JubilifeCity_Text_TheGlobalTerminalYourGatewayToTheWholeWorld
     End
 
-JubilifeCity_TriggerPoketchCampaign:
+JubilifeCity_CoordEvent_PoketchCampaign:
     LockAll
     ApplyMovement LOCALID_POKETCH_CO_PRESIDENT, JubilifeCity_Movement_PoketchCoPresidentNoticePlayer
     ApplyMovement LOCALID_PLAYER, JubilifeCity_Movement_PlayerFaceNorthPoketchCoPresident
@@ -1627,7 +1627,7 @@ JubilifeCity_KidWithNDS2:
     NPCMessage JubilifeCity_TextIMadeMyPokemonHoldAnItemBeforeTradingIt
     End
 
-JubilifeCity_TriggerLookerPalPad:
+JubilifeCity_CoordEvent_LookerPalPad:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     SetObjectEventPos LOCALID_LOOKER, 179, VAR_0x8005

--- a/res/field/scripts/scripts_lake_acuity.s
+++ b/res/field/scripts/scripts_lake_acuity.s
@@ -3,10 +3,10 @@
 #include "res/field/events/events_lake_acuity.h"
 
 
-    ScriptEntry LakeAcuity_TriggerJupiterRival
+    ScriptEntry LakeAcuity_CoordEvent_JupiterRival
     ScriptEntryEnd
 
-LakeAcuity_TriggerJupiterRival:
+LakeAcuity_CoordEvent_JupiterRival:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     AddFreeCamera VAR_0x8004, VAR_0x8005

--- a/res/field/scripts/scripts_lake_verity.s
+++ b/res/field/scripts/scripts_lake_verity.s
@@ -7,7 +7,7 @@
     ScriptEntry LakeVerity_OnLoad
     ScriptEntry LakeVerity_ProfRowan
     ScriptEntry LakeVerity_Counterpart
-    ScriptEntry LakeVerity_OnFrameProfRowanNoticePlayer
+    ScriptEntry LakeVerity_OnFrame_ProfRowanNoticePlayer
     ScriptEntry LakeVerity_Mars
     ScriptEntry LakeVerity_GruntM
     ScriptEntryEnd
@@ -154,7 +154,7 @@ LakeVerity_Movement_RowanWalkOnSpotEast:
     WalkOnSpotNormalEast
     EndMovement
 
-LakeVerity_OnFrameProfRowanNoticePlayer:
+LakeVerity_OnFrame_ProfRowanNoticePlayer:
     LockAll
     ApplyMovement LOCALID_PROF_ROWAN, LakeVerity_Movement_RowanNoticePlayer
     WaitMovement

--- a/res/field/scripts/scripts_lake_verity_low_water.s
+++ b/res/field/scripts/scripts_lake_verity_low_water.s
@@ -5,7 +5,7 @@
 
     ScriptEntry LakeVerityLowWater_OnTransition
     ScriptEntry LakeVerityLowWater_OnLoad
-    ScriptEntry LakeVerityLowWater_OnFrameCyrus
+    ScriptEntry LakeVerityLowWater_OnFrame_Cyrus
     ScriptEntry LakeVerityLowWater_ProfRowan
     ScriptEntry LakeVerityLowWater_Counterpart
     ScriptEntry LakeVerityLowWater_UnusedEntry6
@@ -38,7 +38,7 @@ LakeVerityLowWater_HideStarly:
     End
     End
 
-LakeVerityLowWater_OnFrameCyrus:
+LakeVerityLowWater_OnFrame_Cyrus:
     LockAll
     ClearHasPartner
     ApplyMovement LOCALID_RIVAL, LakeVerityLowWater_Movement_RivalEnter

--- a/res/field/scripts/scripts_mt_coronet_1f_south.s
+++ b/res/field/scripts/scripts_mt_coronet_1f_south.s
@@ -3,10 +3,10 @@
 #include "res/field/events/events_mt_coronet_1f_south.h"
 
 
-    ScriptEntry MtCoronet1FSouth_TriggerCyrus
+    ScriptEntry MtCoronet1FSouth_CoordEvent_Cyrus
     ScriptEntryEnd
 
-MtCoronet1FSouth_TriggerCyrus:
+MtCoronet1FSouth_CoordEvent_Cyrus:
     LockAll
     ApplyMovement LOCALID_PLAYER, MtCoronet1FSouth_Movement_PlayerWatchCyrusWalkToPlayer
     ApplyMovement LOCALID_CYRUS, MtCoronet1FSouth_Movement_CyrusWalkToPlayer

--- a/res/field/scripts/scripts_mt_coronet_2f.s
+++ b/res/field/scripts/scripts_mt_coronet_2f.s
@@ -4,7 +4,7 @@
 
 
     ScriptEntry MtCoronet2F_CavePainting
-    ScriptEntry MtCoronet2F_TriggerLooker
+    ScriptEntry MtCoronet2F_CoordEvent_Looker
     ScriptEntry MtCoronet2F_Looker
     ScriptEntry MtCoronet2F_CavePaintingShards
     ScriptEntryEnd
@@ -17,7 +17,7 @@ MtCoronet2F_CavePaintingShards:
     NPCMessage MtCoronet2F_Text_ShardsAreAllThatRemainOfTheAncientCavePainting
     End
 
-MtCoronet2F_TriggerLooker:
+MtCoronet2F_CoordEvent_Looker:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     SetVar VAR_MT_CORONET_2F_STATE, 2

--- a/res/field/scripts/scripts_old_chateau_back_middle_east_room.s
+++ b/res/field/scripts/scripts_old_chateau_back_middle_east_room.s
@@ -3,7 +3,7 @@
 
 
     ScriptEntry OldChateauBackMiddleEastRoom_OnTransition
-    ScriptEntry OldChateauBackMiddleEastRoom_OnFrameTwinLeave
+    ScriptEntry OldChateauBackMiddleEastRoom_OnFrame_TwinLeave
     ScriptEntryEnd
 
 OldChateauBackMiddleEastRoom_OnTransition:
@@ -17,7 +17,7 @@ OldChateauBackMiddleEastRoom_ShowTwin:
     SetVar VAR_OLD_CHATEAU_BACK_MIDDLE_EAST_ROOM_TWIN_STATE, 1
     End
 
-OldChateauBackMiddleEastRoom_OnFrameTwinLeave:
+OldChateauBackMiddleEastRoom_OnFrame_TwinLeave:
     LockAll
     ApplyMovement LOCALID_TWIN, OldChateauBackMiddleEastRoom_Movement_TwinLeave
     WaitMovement

--- a/res/field/scripts/scripts_old_chateau_dining_area.s
+++ b/res/field/scripts/scripts_old_chateau_dining_area.s
@@ -3,7 +3,7 @@
 
 
     ScriptEntry OldChateauDiningArea_OnTransition
-    ScriptEntry OldChateauDiningArea_OnFrameOldManLeave
+    ScriptEntry OldChateauDiningArea_OnFrame_OldManLeave
     ScriptEntryEnd
 
 OldChateauDiningArea_OnTransition:
@@ -17,7 +17,7 @@ OldChateauDiningArea_ShowOldMan:
     SetVar VAR_OLD_CHATEAU_DINING_AREA_OLD_MAN_STATE, 1
     End
 
-OldChateauDiningArea_OnFrameOldManLeave:
+OldChateauDiningArea_OnFrame_OldManLeave:
     LockAll
     ApplyMovement LOCALID_PLAYER, OldChateauDiningArea_Movement_PlayerWatchOldManLeave
     ApplyMovement LOCALID_OLD_MAN, OldChateauDiningArea_Movement_OldManLeave

--- a/res/field/scripts/scripts_oreburgh_city.s
+++ b/res/field/scripts/scripts_oreburgh_city.s
@@ -4,8 +4,8 @@
 
     ScriptEntry OreburghCity_Rival
     ScriptEntry OreburghCity_Youngster
-    ScriptEntry OreburghCity_TriggerYoungster
-    ScriptEntry OreburghCity_TriggerRival
+    ScriptEntry OreburghCity_CoordEvent_Youngster
+    ScriptEntry OreburghCity_CoordEvent_Rival
     ScriptEntry OreburghCity_Hiker
     ScriptEntry OreburghCity_Worker1
     ScriptEntry OreburghCity_Worker2
@@ -16,10 +16,10 @@
     ScriptEntry OreburghCity_Guitarist
     ScriptEntry OreburghCity_PokefanF
     ScriptEntry OreburghCity_Camper
-    ScriptEntry OreburghCity_MapSign
+    ScriptEntry OreburghCity_MapSignpost
     ScriptEntry OreburghCity_GymSignpost
-    ScriptEntry OreburghCity_ScrollingSignOreburghMiningMuseum
-    ScriptEntry OreburghCity_ScrollingSignOreburghMine
+    ScriptEntry OreburghCity_ScrollingSignpostOreburghMiningMuseum
+    ScriptEntry OreburghCity_ScrollingSignpostOreburghMine
     ScriptEntry OreburghCity_Machop1
     ScriptEntry OreburghCity_BattleGirl2
     ScriptEntry OreburghCity_Machop3
@@ -74,7 +74,7 @@ OreburghCity_TheGymLeadersWaitingForYou:
     ReleaseAll
     End
 
-OreburghCity_TriggerRival:
+OreburghCity_CoordEvent_Rival:
     LockAll
     ClearFlag FLAG_HIDE_OREBURGH_CITY_RIVAL
     SetObjectEventMovementType LOCALID_RIVAL, MOVEMENT_TYPE_LOOK_WEST
@@ -304,7 +304,7 @@ OreburghCity_Worker4:
     NPCMessage OreburghCity_Text_ChopChopMachopChopChopAwayOnRocks
     End
 
-OreburghCity_TriggerYoungster:
+OreburghCity_CoordEvent_Youngster:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     GoToIfEq VAR_0x8005, 748, OreburghCity_YoungsterWalkToPlayerZ748
@@ -516,7 +516,7 @@ OreburghCity_Camper:
     NPCMessage OreburghCity_Text_WhenIRunAroundWithMyRunningShoesOnImTheCenterOfAttention
     End
 
-OreburghCity_MapSign:
+OreburghCity_MapSignpost:
     ShowMapSign OreburghCity_Text_MapSign
     End
 
@@ -524,11 +524,11 @@ OreburghCity_GymSignpost:
     ShowScrollingSign OreburghCity_Text_OreburgCityPokemonGymCallMeRoarkTheRock
     End
 
-OreburghCity_ScrollingSignOreburghMiningMuseum:
+OreburghCity_ScrollingSignpostOreburghMiningMuseum:
     ShowLandmarkSign OreburghCity_Text_OreburghMiningMuseumCoalMiningAndYou
     End
 
-OreburghCity_ScrollingSignOreburghMine:
+OreburghCity_ScrollingSignpostOreburghMine:
     ShowLandmarkSign OreburghCity_Text_OreburghMineBewareOfBusyPokemon
     End
 

--- a/res/field/scripts/scripts_oreburgh_gate_1f.s
+++ b/res/field/scripts/scripts_oreburgh_gate_1f.s
@@ -5,7 +5,7 @@
 
     ScriptEntry OreburghGate1F_OnTransition
     ScriptEntry OreburghGate1F_Hiker
-    ScriptEntry OreburghGate1F_HikerTrigger
+    ScriptEntry OreburghGate1F_CoordEvent_Hiker
     ScriptEntryEnd
 
 OreburghGate1F_OnTransition:
@@ -45,7 +45,7 @@ OreburghGate1F_SetFlagReceivedHM06:
     SetVar VAR_OREBURGH_GATE_1F_HIKER_STATE, 2
     Return
 
-OreburghGate1F_HikerTrigger:
+OreburghGate1F_CoordEvent_Hiker:
     LockAll
     ApplyMovement LOCALID_HIKER, OreburghGate1F_Movement_HikerWalkToPlayer
     ApplyMovement LOCALID_PLAYER, OreburghGate1F_Movement_PlayerFaceHiker

--- a/res/field/scripts/scripts_pal_park.s
+++ b/res/field/scripts/scripts_pal_park.s
@@ -4,10 +4,10 @@
 
 
     ScriptEntry PalPark_OnTransition
-    ScriptEntry PalPark_OnFrameCountdown
-    ScriptEntry PalPark_Trigger_CaughtAllPokemon
+    ScriptEntry PalPark_OnFrame_Countdown
+    ScriptEntry PalPark_CoordEvent_CaughtAllPokemon
     ScriptEntry PalPark_RetireFromMenu
-    ScriptEntry PalPark_Trigger_RetireFromGate
+    ScriptEntry PalPark_CoordEvent_RetireFromGate
     ScriptEntry PalPark_Worker
     ScriptEntryEnd
 
@@ -15,7 +15,7 @@ PalPark_OnTransition:
     SetFlag FLAG_FIRST_ARRIVAL_PAL_PARK
     End
 
-PalPark_OnFrameCountdown:
+PalPark_OnFrame_Countdown:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     MessageInstant PalPark_Text_LetTheCountdownBegin
@@ -48,7 +48,7 @@ PalPark_Unused:
     ReleaseAll
     End
 
-PalPark_Trigger_CaughtAllPokemon:
+PalPark_CoordEvent_CaughtAllPokemon:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     PlaySE SEQ_SE_DP_PINPON
@@ -79,7 +79,7 @@ PalPark_RetireFromMenu_WarpOut:
     Call PalPark_ClearFlagAndWarpOut
     End
 
-PalPark_Trigger_RetireFromGate:
+PalPark_CoordEvent_RetireFromGate:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     Call PalPark_AskPlayerRetireFromCatchingShow

--- a/res/field/scripts/scripts_pal_park_lobby.s
+++ b/res/field/scripts/scripts_pal_park_lobby.s
@@ -8,16 +8,16 @@
 
     ScriptEntry PalParkLobby_OnTransition
     ScriptEntry PalParkLobby_Worker
-    ScriptEntry PalParkLobby_OnFrameTallyScore
+    ScriptEntry PalParkLobby_OnFrame_TallyScore
     ScriptEntry PalParkLobby_RecordUnused
     ScriptEntry PalParkLobby_Daughter
     ScriptEntry PalParkLobby_Dad
     ScriptEntry PalParkLobby_ShowWatcherBoy
     ScriptEntry PalParkLobby_ComplaintsLady
     ScriptEntry PalParkLobby_RecordGuy
-    ScriptEntry PalParkLobby_OnFrameProfOak
+    ScriptEntry PalParkLobby_OnFrame_ProfOak
     ScriptEntry PalParkLobby_PoketchAppLady
-    ScriptEntry PalParkLobby_OnFrameExitPalPark
+    ScriptEntry PalParkLobby_OnFrame_ExitPalPark
     ScriptEntry PalParkLobby_GBASlotGiftLady
     ScriptEntryEnd
 
@@ -201,7 +201,7 @@ PalParkLobby_Movement_PlayerEnterPalPark:
     SetInvisible
     EndMovement
 
-PalParkLobby_OnFrameExitPalPark:
+PalParkLobby_OnFrame_ExitPalPark:
     LockAll
     SetVar VAR_PAL_PARK_STATE, 0
     ApplyMovement LOCALID_PLAYER, PalParkLobby_Movement_PlayerExitPalPark
@@ -211,7 +211,7 @@ PalParkLobby_OnFrameExitPalPark:
     ReleaseAll
     End
 
-PalParkLobby_OnFrameTallyScore:
+PalParkLobby_OnFrame_TallyScore:
     LockAll
     SetVar VAR_PAL_PARK_STATE, 0
     ApplyMovement LOCALID_PLAYER, PalParkLobby_Movement_PlayerWalkToWorker
@@ -342,7 +342,7 @@ PalParkLobby_RecordGuy:
     NPCMessage PalParkLobby_Text_CurrentRecordHolder
     End
 
-PalParkLobby_OnFrameProfOak:
+PalParkLobby_OnFrame_ProfOak:
     LockAll
     ClearFlag FLAG_ETERNA_CITY_SOUTH_HOUSE_HIDE_PROF_OAK
     SetVar VAR_CATCHING_SHOW_RECORD, 2000

--- a/res/field/scripts/scripts_pastoria_city.s
+++ b/res/field/scripts/scripts_pastoria_city.s
@@ -15,17 +15,17 @@
     ScriptEntry PastoriaCity_ParasolLady
     ScriptEntry PastoriaCity_Collector2
     ScriptEntry PastoriaCity_AceTrainerM2
-    ScriptEntry PastoriaCity_MapSign
-    ScriptEntry PastoriaCity_GymSign
-    ScriptEntry PastoriaCity_SignGreatMarsh
-    ScriptEntry PastoriaCity_SignSafariGame
+    ScriptEntry PastoriaCity_MapSignpost
+    ScriptEntry PastoriaCity_GymSignpost
+    ScriptEntry PastoriaCity_SignboardGreatMarsh
+    ScriptEntry PastoriaCity_SignboardSafariGame
     ScriptEntry PastoriaCity_Rival
-    ScriptEntry PastoriaCity_TriggerRivalBattle
-    ScriptEntry PastoriaCity_OnFrameExitGym
+    ScriptEntry PastoriaCity_CoordEvent_RivalBattle
+    ScriptEntry PastoriaCity_OnFrame_ExitGym
     ScriptEntry PastoriaCity_CrasherWake
-    ScriptEntry PastoriaCity_TriggerBomb
-    ScriptEntry PastoriaCity_TriggerBlockGreatMarsh
-    ScriptEntry PastoriaCity_TriggerFaceBoard
+    ScriptEntry PastoriaCity_CoordEvent_Bomb
+    ScriptEntry PastoriaCity_CoordEvent_BlockGreatMarsh
+    ScriptEntry PastoriaCity_CoordEvent_FaceBoard
     ScriptEntryEnd
 
 PastoriaCity_OnTransition:
@@ -303,19 +303,19 @@ PastoriaCity_UnusedMovement17:
     WalkOnSpotFastEast
     EndMovement
 
-PastoriaCity_MapSign:
+PastoriaCity_MapSignpost:
     ShowMapSign PastoriaCity_Text_MapSign
     End
 
-PastoriaCity_GymSign:
+PastoriaCity_GymSignpost:
     ShowScrollingSign PastoriaCity_Text_SignPokemonGym
     End
 
-PastoriaCity_SignGreatMarsh:
+PastoriaCity_SignboardGreatMarsh:
     ShowLandmarkSign PastoriaCity_Text_SignGreatMarsh
     End
 
-PastoriaCity_SignSafariGame:
+PastoriaCity_SignboardSafariGame:
     ShowLandmarkSign PastoriaCity_Text_SignSafariGame
     End
 
@@ -368,7 +368,7 @@ PastoriaCity_Movement_RivalWalkOnSpotSouth:
     WalkOnSpotNormalSouth
     EndMovement
 
-PastoriaCity_TriggerRivalBattle:
+PastoriaCity_CoordEvent_RivalBattle:
     LockAll
     ClearFlag FLAG_HIDE_PASTORIA_CITY_RIVAL
     SetObjectEventPos LOCALID_RIVAL, 595, 819
@@ -454,7 +454,7 @@ PastoriaCity_Movement_RivalLeaveAfterBattle:
     WalkFastNorth 9
     EndMovement
 
-PastoriaCity_OnFrameExitGym:
+PastoriaCity_OnFrame_ExitGym:
     LockAll
     ClearFlag FLAG_HIDE_PASTORIA_CITY_RIVAL
     SetObjectEventPos LOCALID_RIVAL, 595, 819
@@ -616,7 +616,7 @@ PastoriaCity_Movement_PlayerWatchCrasherWakeLeave:
     WalkOnSpotNormalEast
     EndMovement
 
-PastoriaCity_TriggerBomb:
+PastoriaCity_CoordEvent_Bomb:
     LockAll
     Call PastoriaCity_Explosion
     ApplyMovement LOCALID_CRASHER_WAKE, PastoriaCity_Movement_CrasherWakeWatchGruntMExitGreatMarsh
@@ -901,7 +901,7 @@ PastoriaCity_Movement_CrasherWakeEnterGreatMarsh:
     WalkNormalNorth 2
     EndMovement
 
-PastoriaCity_TriggerBlockGreatMarsh:
+PastoriaCity_CoordEvent_BlockGreatMarsh:
     LockAll
     ApplyMovement LOCALID_PLAYER, PastoriaCity_Movement_PlayerWalkOnSpotEast
     ApplyMovement LOCALID_RIVAL, PastoriaCity_Movement_RivalWalkOnSpotWest
@@ -938,7 +938,7 @@ PastoriaCity_Movement_RivalPushBackPlayer:
     WalkOnSpotNormalNorth
     EndMovement
 
-PastoriaCity_TriggerFaceBoard:
+PastoriaCity_CoordEvent_FaceBoard:
     LockAll
     GoToIfSet FLAG_BLOCK_PASTORIA_CITY_CROAGUNK_EVENT, PastoriaCity_FaceBoardEnd
     SetVar VAR_PASTORIA_CITY_TRY_CROAGUNK_SCENE_STATE, 1

--- a/res/field/scripts/scripts_pastoria_city_observatory_gate_1f.s
+++ b/res/field/scripts/scripts_pastoria_city_observatory_gate_1f.s
@@ -4,9 +4,9 @@
 
 
     ScriptEntry PastoriaCityObservatoryGate1F_CashierM
-    ScriptEntry PastoriaCityObservatoryGate1F_TriggerTryStartSafariGame
-    ScriptEntry PastoriaCityObservatoryGate1F_OnFrameTryExitEarly
-    ScriptEntry PastoriaCityObservatoryGate1F_OnFrameGameEnded
+    ScriptEntry PastoriaCityObservatoryGate1F_CoordEvent_TryStartSafariGame
+    ScriptEntry PastoriaCityObservatoryGate1F_OnFrame_TryExitEarly
+    ScriptEntry PastoriaCityObservatoryGate1F_OnFrame_GameEnded
     ScriptEntry PastoriaCityObservatoryGate1F_CashierF
     ScriptEntry PastoriaCityObservatoryGate1F_Cowgirl
     ScriptEntry PastoriaCityObservatoryGate1F_OnTransition
@@ -18,7 +18,7 @@ PastoriaCityObservatoryGate1F_OnTransition:
 PastoriaCityObservatoryGate1F_CashierM:
     End
 
-PastoriaCityObservatoryGate1F_TriggerTryStartSafariGame:
+PastoriaCityObservatoryGate1F_CoordEvent_TryStartSafariGame:
     LockAll
     ApplyMovement LOCALID_PLAYER, PastoriaCityObservatoryGate1F_Movement_PlayerWalkOnSpotWest
     WaitMovement
@@ -137,7 +137,7 @@ PastoriaCityObservatoryGate1F_Movement_PlayerWalkSouth:
     WalkNormalSouth
     EndMovement
 
-PastoriaCityObservatoryGate1F_OnFrameTryExitEarly:
+PastoriaCityObservatoryGate1F_OnFrame_TryExitEarly:
     LockAll
     Message PastoriaCityObservatoryGate1F_Text_AskExitGreatMarsh
     ShowYesNoMenu VAR_RESULT
@@ -196,7 +196,7 @@ PastoriaCityObservatoryGate1F_Movement_PlayerReturnToGreatMarsh:
     SetInvisible
     EndMovement
 
-PastoriaCityObservatoryGate1F_OnFrameGameEnded:
+PastoriaCityObservatoryGate1F_OnFrame_GameEnded:
     LockAll
     ApplyMovement LOCALID_PLAYER, PastoriaCityObservatoryGate1F_Movement_PlayerExitGreatMarsh
     WaitMovement

--- a/res/field/scripts/scripts_pokemon_center_2f_common.s
+++ b/res/field/scripts/scripts_pokemon_center_2f_common.s
@@ -16,10 +16,10 @@
     ScriptEntry PokemonCenter2FCommon_UnusedScript9009
     ScriptEntry _06A0
     ScriptEntry PokemonCenter2FCommon_AttendantSignTrainerCard
-    ScriptEntry PokemonCenter2FCommon_OnFrameExitColosseum
-    ScriptEntry PokemonCenter2FCommon_OnFrameExitUnionRoom
-    ScriptEntry PokemonCenter2FCommon_OnFrameExitColosseum
-    ScriptEntry PokemonCenter2FCommon_OnFrameExitColosseum
+    ScriptEntry PokemonCenter2FCommon_OnFrame_ExitColosseum
+    ScriptEntry PokemonCenter2FCommon_OnFrame_ExitUnionRoom
+    ScriptEntry PokemonCenter2FCommon_OnFrame_ExitColosseum
+    ScriptEntry PokemonCenter2FCommon_OnFrame_ExitColosseum
     ScriptEntry PokemonCenter2FCommon_HasBadEggReturnCommon @ 0x2338
     ScriptEntryEnd
 
@@ -31,14 +31,14 @@ PokemonCenter2FCommon_HidePlayer:
     HideObject LOCALID_PLAYER
     Return
 
-PokemonCenter2FCommon_OnFrameExitColosseum:
+PokemonCenter2FCommon_OnFrame_ExitColosseum:
     SetVar VAR_MAP_LOCAL_0, 13
     SetVar VAR_MAP_LOCAL_1, 5
     SetVar VAR_MAP_LOCAL_2, 2
     GoTo PokemonCenter2FCommon_PlayerEnter
     End
 
-PokemonCenter2FCommon_OnFrameExitUnionRoom:
+PokemonCenter2FCommon_OnFrame_ExitUnionRoom:
     SetVar VAR_MAP_LOCAL_0, 8
     SetVar VAR_MAP_LOCAL_1, 5
     SetVar VAR_MAP_LOCAL_2, 2

--- a/res/field/scripts/scripts_pokemon_center_b1f_common.s
+++ b/res/field/scripts/scripts_pokemon_center_b1f_common.s
@@ -3,15 +3,15 @@
 #include "res/text/bank/menu_entries.h"
 
 
-    ScriptEntry PokemonCenterB1FCommon_OnFrameReceivePalPad
+    ScriptEntry PokemonCenterB1FCommon_OnFrame_ReceivePalPad
     ScriptEntry PokemonCenterB1FCommon_AttendantInfo
     ScriptEntry PokemonCenterB1FCommon_AttendantWiFiClub
     ScriptEntry PokemonCenterB1FCommon_OnLoad
     ScriptEntry PokemonCenterB1FCommon_AttendantWifiPlaza
-    ScriptEntry PokemonCenterB1FCommon_OnFrameExitWiFiClub
+    ScriptEntry PokemonCenterB1FCommon_OnFrame_ExitWiFiClub
     ScriptEntryEnd
 
-PokemonCenterB1FCommon_OnFrameReceivePalPad:
+PokemonCenterB1FCommon_OnFrame_ReceivePalPad:
     LockAll
     Message PokemonCenterB1FCommon_Text_HelloRightThisWay
     CloseMessage
@@ -440,7 +440,7 @@ PokemonCenterB1FCommon_Unused:
     ReleaseAll
     End
 
-PokemonCenterB1FCommon_OnFrameExitWiFiClub:
+PokemonCenterB1FCommon_OnFrame_ExitWiFiClub:
     LockAll
     LoadDoorAnimation 0, 0, 5, 2, ANIMATION_TAG_DOOR_1
     Call PokemonCenterB1FCommon_DoorOpenAnimation

--- a/res/field/scripts/scripts_pokemon_day_care.s
+++ b/res/field/scripts/scripts_pokemon_day_care.s
@@ -4,7 +4,7 @@
 
     ScriptEntry PokemonDayCare_OnTransition
     ScriptEntry PokemonDayCare_GymGuide
-    ScriptEntry PokemonDayCare_Sign
+    ScriptEntry PokemonDayCare_BgSign
     ScriptEntryEnd
 
 PokemonDayCare_OnTransition:
@@ -36,7 +36,7 @@ PokemonDayCare_CheckOnDayCarePokemon:
     ReleaseAll
     End
 
-PokemonDayCare_Sign:
+PokemonDayCare_BgSign:
     EventMessage PokemonDayCare_Text_PokemonGrowsWithYou
     End
 

--- a/res/field/scripts/scripts_pokemon_league.s
+++ b/res/field/scripts/scripts_pokemon_league.s
@@ -2,12 +2,12 @@
 #include "res/text/bank/pokemon_league.h"
 
 
-    ScriptEntry PokemonLeague_ArrowSignPokemonleague
+    ScriptEntry PokemonLeague_ArrowSignpostPokemonleague
     ScriptEntry PokemonLeague_SignboardVictoryRoad
     ScriptEntry PokemonLeague_Statue
     ScriptEntryEnd
 
-PokemonLeague_ArrowSignPokemonleague:
+PokemonLeague_ArrowSignpostPokemonleague:
     ShowArrowSign PokemonLeague_Text_PokemonLeagueAhead
     End
 

--- a/res/field/scripts/scripts_pokemon_league_elevator_to_aaron_room.s
+++ b/res/field/scripts/scripts_pokemon_league_elevator_to_aaron_room.s
@@ -3,7 +3,7 @@
 
     ScriptEntry PokemonLeagueElevatorToAaronRoom_OnTransition
     ScriptEntry PokemonLeagueElevatorToAaronRoom_DisablePlatformLift
-    ScriptEntry PokemonLeagueElevatorToAaronRoom_TriggerPlatformLift
+    ScriptEntry PokemonLeagueElevatorToAaronRoom_CoordEvent_PlatformLift
     ScriptEntryEnd
 
 PokemonLeagueElevatorToAaronRoom_OnTransition:
@@ -17,7 +17,7 @@ PokemonLeagueElevatorToAaronRoom_DisablePlatformLift:
     SetVar VAR_MAP_LOCAL_0, 1
     End
 
-PokemonLeagueElevatorToAaronRoom_TriggerPlatformLift:
+PokemonLeagueElevatorToAaronRoom_CoordEvent_PlatformLift:
     TriggerPlatformLift
     SetVar VAR_MAP_LOCAL_0, 1
     End

--- a/res/field/scripts/scripts_pokemon_league_elevator_to_bertha_room.s
+++ b/res/field/scripts/scripts_pokemon_league_elevator_to_bertha_room.s
@@ -3,7 +3,7 @@
 
     ScriptEntry PokemonLeagueElevatorToBerthaRoom_OnTransition
     ScriptEntry PokemonLeagueElevatorToBerthaRoom_DisablePlatformLift
-    ScriptEntry PokemonLeagueElevatorToBerthaRoom_TriggerPlatformLift
+    ScriptEntry PokemonLeagueElevatorToBerthaRoom_CoordEvent_PlatformLift
     ScriptEntryEnd
 
 PokemonLeagueElevatorToBerthaRoom_OnTransition:
@@ -17,7 +17,7 @@ PokemonLeagueElevatorToBerthaRoom_DisablePlatformLift:
     SetVar VAR_MAP_LOCAL_0, 1
     End
 
-PokemonLeagueElevatorToBerthaRoom_TriggerPlatformLift:
+PokemonLeagueElevatorToBerthaRoom_CoordEvent_PlatformLift:
     TriggerPlatformLift
     SetVar VAR_MAP_LOCAL_0, 1
     End

--- a/res/field/scripts/scripts_pokemon_league_elevator_to_champion_room.s
+++ b/res/field/scripts/scripts_pokemon_league_elevator_to_champion_room.s
@@ -3,7 +3,7 @@
 
     ScriptEntry PokemonLeagueElevatorToChampionRoom_OnTransition
     ScriptEntry PokemonLeagueElevatorToChampionRoom_DisablePlatformLift
-    ScriptEntry PokemonLeagueElevatorToChampionRoom_TriggerPlatformLift
+    ScriptEntry PokemonLeagueElevatorToChampionRoom_CoordEvent_PlatformLift
     ScriptEntryEnd
 
 PokemonLeagueElevatorToChampionRoom_OnTransition:
@@ -17,7 +17,7 @@ PokemonLeagueElevatorToChampionRoom_DisablePlatformLift:
     SetVar VAR_MAP_LOCAL_0, 1
     End
 
-PokemonLeagueElevatorToChampionRoom_TriggerPlatformLift:
+PokemonLeagueElevatorToChampionRoom_CoordEvent_PlatformLift:
     TriggerPlatformLift
     SetVar VAR_MAP_LOCAL_0, 1
     End

--- a/res/field/scripts/scripts_pokemon_league_elevator_to_flint_room.s
+++ b/res/field/scripts/scripts_pokemon_league_elevator_to_flint_room.s
@@ -3,7 +3,7 @@
 
     ScriptEntry PokemonLeagueElevatorToFlintRoom_OnTransition
     ScriptEntry PokemonLeagueElevatorToFlintRoom_DisablePlatformLift
-    ScriptEntry PokemonLeagueElevatorToFlintRoom_TriggerPlatformLift
+    ScriptEntry PokemonLeagueElevatorToFlintRoom_CoordEvent_PlatformLift
     ScriptEntryEnd
 
 PokemonLeagueElevatorToFlintRoom_OnTransition:
@@ -17,7 +17,7 @@ PokemonLeagueElevatorToFlintRoom_DisablePlatformLift:
     SetVar VAR_MAP_LOCAL_0, 1
     End
 
-PokemonLeagueElevatorToFlintRoom_TriggerPlatformLift:
+PokemonLeagueElevatorToFlintRoom_CoordEvent_PlatformLift:
     TriggerPlatformLift
     SetVar VAR_MAP_LOCAL_0, 1
     End

--- a/res/field/scripts/scripts_pokemon_league_elevator_to_lucian_room.s
+++ b/res/field/scripts/scripts_pokemon_league_elevator_to_lucian_room.s
@@ -3,7 +3,7 @@
 
     ScriptEntry PokemonLeagueElevatorToLucianRoom_OnTransition
     ScriptEntry PokemonLeagueElevatorToLucianRoom_DisablePlatformLift
-    ScriptEntry PokemonLeagueElevatorToLucianRoom_TriggerPlatformLift
+    ScriptEntry PokemonLeagueElevatorToLucianRoom_CoordEvent_PlatformLift
     ScriptEntryEnd
 
 PokemonLeagueElevatorToLucianRoom_OnTransition:
@@ -17,7 +17,7 @@ PokemonLeagueElevatorToLucianRoom_DisablePlatformLift:
     SetVar VAR_MAP_LOCAL_0, 1
     End
 
-PokemonLeagueElevatorToLucianRoom_TriggerPlatformLift:
+PokemonLeagueElevatorToLucianRoom_CoordEvent_PlatformLift:
     TriggerPlatformLift
     SetVar VAR_MAP_LOCAL_0, 1
     End

--- a/res/field/scripts/scripts_pokemon_league_north_pokecenter_1f.s
+++ b/res/field/scripts/scripts_pokemon_league_north_pokecenter_1f.s
@@ -6,7 +6,7 @@
     ScriptEntry PokemonLeagueNorthPokecenter1F_DoorGuard
     ScriptEntry PokemonLeagueNorthPokecenter1F_VendorCommon
     ScriptEntry PokemonLeagueNorthPokecenter1F_VendorSpecial
-    ScriptEntry PokemonLeagueNorthPokecenter1F_RivalTrigger
+    ScriptEntry PokemonLeagueNorthPokecenter1F_CoordEvent_Rival
     ScriptEntry PokemonLeagueNorthPokecenter1F_OnTransition
     ScriptEntry PokemonLeagueNorthPokecenter1F_AceTrainerF
     ScriptEntry PokemonLeagueNorthPokecenter1F_Guitarist
@@ -105,7 +105,7 @@ PokemonLeagueNorthPokecenter1F_VendorSpecial:
     PokeMartSpecialtiesWithGreeting MART_SPECIALTIES_ID_POKEMON_LEAGUE
     End
 
-PokemonLeagueNorthPokecenter1F_RivalTrigger:
+PokemonLeagueNorthPokecenter1F_CoordEvent_Rival:
     LockAll
     ClearFlag FLAG_HIDE_POKEMON_LEAGUE_NORTH_POKECENTER_1F_RIVAL
     AddObject LOCALID_LEAGUE_NORTH_RIVAL

--- a/res/field/scripts/scripts_pokemon_mansion_office.s
+++ b/res/field/scripts/scripts_pokemon_mansion_office.s
@@ -7,7 +7,7 @@
     ScriptEntry PokemonMansionOffice_MrBacklot
     ScriptEntry PokemonMansionOffice_OldMan
     ScriptEntry PokemonMansionOffice_Policeman
-    ScriptEntry PokemonMansionOffice_TriggerBlockStatue
+    ScriptEntry PokemonMansionOffice_CoordEvent_BlockStatue
     ScriptEntry PokemonMansionOffice_Statue
     ScriptEntry PokemonMansionOffice_Book
     ScriptEntryEnd
@@ -267,7 +267,7 @@ PokemonMansionOffice_Movement_PolicemanFaceWest:
     FaceWest
     EndMovement
 
-PokemonMansionOffice_TriggerBlockStatue:
+PokemonMansionOffice_CoordEvent_BlockStatue:
     LockAll
     ApplyMovement LOCALID_POLICEMAN, PokemonMansionOffice_Movement_PolicemanFaceWest
     WaitMovement

--- a/res/field/scripts/scripts_resort_area.s
+++ b/res/field/scripts/scripts_resort_area.s
@@ -7,17 +7,17 @@
     ScriptEntry ResortArea_Beauty2
     ScriptEntry ResortArea_AceTrainerF
     ScriptEntry ResortArea_BlackBelt
-    ScriptEntry ResortArea_MapSign
-    ScriptEntry ResortArea_SignRibbonSyndicate
+    ScriptEntry ResortArea_MapSignpost
+    ScriptEntry ResortArea_SignboardRibbonSyndicate
     ScriptEntry ResortArea_SwimmerM
-    ScriptEntry ResortArea_TriggerSchoolKidM
+    ScriptEntry ResortArea_CoordEvent_SchoolKidM
     ScriptEntry ResortArea_ProfRowan
     ScriptEntry ResortArea_Roark
     ScriptEntry ResortArea_Gardenia
     ScriptEntry ResortArea_Maylene
     ScriptEntry ResortArea_Byron
     ScriptEntry ResortArea_OnTransition
-    ScriptEntry ResortArea_SignVilla
+    ScriptEntry ResortArea_SignboardVilla
     ScriptEntryEnd
 
 ResortArea_OnTransition:
@@ -90,11 +90,11 @@ ResortArea_BlackBelt:
     NPCMessage ResortArea_Text_DigUpCoolStuff
     End
 
-ResortArea_MapSign:
+ResortArea_MapSignpost:
     ShowMapSign ResortArea_Text_MapSign
     End
 
-ResortArea_SignRibbonSyndicate:
+ResortArea_SignboardRibbonSyndicate:
     ShowLandmarkSign ResortArea_Text_SignRibbonSyndicate
     End
 
@@ -102,7 +102,7 @@ ResortArea_SwimmerM:
     NPCMessage ResortArea_Text_SomethingLurks
     End
 
-ResortArea_TriggerSchoolKidM:
+ResortArea_CoordEvent_SchoolKidM:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     CallIfEq VAR_0x8005, 472, ResortArea_SchoolKidMWalkToPlayerZ472
@@ -409,7 +409,7 @@ ResortArea_ByronDeclinedVisit:
     GoTo ResortArea_VillaVisitorEnd
     End
 
-ResortArea_SignVilla:
+ResortArea_SignboardVilla:
     ShowLandmarkSign ResortArea_Text_SignVilla
     End
 

--- a/res/field/scripts/scripts_resort_area_ribbon_syndicate_1f.s
+++ b/res/field/scripts/scripts_resort_area_ribbon_syndicate_1f.s
@@ -10,7 +10,7 @@
     ScriptEntry ResortAreaRibbonSyndicate1F_Lady
     ScriptEntry ResortAreaRibbonSyndicate1F_Skitty
     ScriptEntry ResortAreaRibbonSyndicate1F_Psyduck
-    ScriptEntry ResortAreaRibbonSyndicate1F_OnFrameCheckEntry
+    ScriptEntry ResortAreaRibbonSyndicate1F_OnFrame_CheckEntry
     ScriptEntry ResortAreaRibbonSyndicate1F_OnTransition
     ScriptEntryEnd
 
@@ -23,7 +23,7 @@ ResortAreaRibbonSyndicate1F_SetBeautyPositionAwayFromDoor:
     SetObjectEventDir LOCALID_BEAUTY, DIR_SOUTH
     End
 
-ResortAreaRibbonSyndicate1F_OnFrameCheckEntry:
+ResortAreaRibbonSyndicate1F_OnFrame_CheckEntry:
     LockAll
     WaitTime 20, VAR_RESULT
     CountPartyRibbons VAR_0x8004

--- a/res/field/scripts/scripts_restaurant.s
+++ b/res/field/scripts/scripts_restaurant.s
@@ -5,7 +5,7 @@
 
     ScriptEntry Restaurant_Waiter
     ScriptEntry Restaurant_OnTransition
-    ScriptEntry Restaurant_OnFrameClosed
+    ScriptEntry Restaurant_OnFrame_Closed
     ScriptEntry Restaurant_ArtistIsmael
     ScriptEntry Restaurant_BeautyHarley
     ScriptEntry Restaurant_RichBoyRoman
@@ -164,7 +164,7 @@ Restaurant_InitTrainersEmilioKaylee:
 Restaurant_InitTrainersReturn:
     Return
 
-Restaurant_OnFrameClosed:
+Restaurant_OnFrame_Closed:
     LockAll
     ApplyMovement LOCALID_PLAYER, Restaurant_Movement_FaceEast
     WaitMovement

--- a/res/field/scripts/scripts_rotoms_room.s
+++ b/res/field/scripts/scripts_rotoms_room.s
@@ -19,7 +19,7 @@
     ScriptEntry RotomsRoom_OnResume
     ScriptEntry RotomsRoom_ApplianceSpot
     ScriptEntry RotomsRoom_OldNotebook
-    ScriptEntry RotomsRoom_OnFrameProfRowan
+    ScriptEntry RotomsRoom_OnFrame_ProfRowan
     ScriptEntryEnd
 
 RotomsRoom_OnResume:
@@ -517,7 +517,7 @@ RotomsRoom_SetStateEnterProfRowan:
     GoTo RotomsRoom_WarpInPlace
     End
 
-RotomsRoom_OnFrameProfRowan:
+RotomsRoom_OnFrame_ProfRowan:
     LockAll
     ClearFlag FLAG_HIDE_ROTOMS_ROOM_PROF_ROWAN
     PlaySE SEQ_SE_DP_KAIDAN2

--- a/res/field/scripts/scripts_route_201.s
+++ b/res/field/scripts/scripts_route_201.s
@@ -3,9 +3,9 @@
 #include "res/field/events/events_route_201.h"
 
     ScriptEntry Route201_OnTransition
-    ScriptEntry Route201_TriggerChooseStarterScene
-    ScriptEntry Route201_TriggerFollowingRivalStopPlayerSouth
-    ScriptEntry Route201_TriggerPickAPokemon
+    ScriptEntry Route201_CoordEvent_ChooseStarterScene
+    ScriptEntry Route201_CoordEvent_FollowingRivalStopPlayerSouth
+    ScriptEntry Route201_CoordEvent_PickAPokemon
     ScriptEntry _0B24
     ScriptEntry Route201_ArrowSignpostTwinleafTown
     ScriptEntry Route201_ArrowSignpostSandgemTown
@@ -15,9 +15,9 @@
     ScriptEntry Route201_SchoolKidM
     ScriptEntry Route201_Lass
     ScriptEntry Route201_Briefcase
-    ScriptEntry Route201_TriggerFollowingRivalStopPlayerEast
+    ScriptEntry Route201_CoordEvent_FollowingRivalStopPlayerEast
     ScriptEntry Route201_ProfRowan
-    ScriptEntry Route201_TriggerLetsCatchThatLegendaryPokemon
+    ScriptEntry Route201_CoordEvent_LetsCatchThatLegendaryPokemon
     ScriptEntryEnd
 
 Route201_OnTransition:
@@ -34,7 +34,7 @@ Route201_SetCounterpartGraphicsLucas:
     SetVar VAR_OBJ_GFX_ID_0, OBJ_EVENT_GFX_PLAYER_M
     End
 
-Route201_TriggerChooseStarterScene:
+Route201_CoordEvent_ChooseStarterScene:
     LockAll
     ApplyMovement LOCALID_RIVAL, Route201_Movement_RivalNoticePlayer
     WaitMovement
@@ -731,7 +731,7 @@ Route201_Movement_CounterpartLeave:
     WalkNormalEast 9
     EndMovement
 
-Route201_TriggerFollowingRivalStopPlayerEast:
+Route201_CoordEvent_FollowingRivalStopPlayerEast:
     LockAll
     GetPlayerDir VAR_RESULT
     GoToIfEq VAR_RESULT, DIR_EAST, Route201_RivalStopPlayerFacingEast
@@ -822,7 +822,7 @@ Route201_Movement_PlayerTurnToRivalSouth:
     WalkOnSpotFastSouth
     EndMovement
 
-Route201_TriggerFollowingRivalStopPlayerSouth:
+Route201_CoordEvent_FollowingRivalStopPlayerSouth:
     LockAll
     ApplyMovement LOCALID_PLAYER, Route201_Movement_PlayerTurnToRivalNorth
     ApplyMovement LOCALID_RIVAL, Route201_Movement_RivalFacePlayerSouth
@@ -869,7 +869,7 @@ Route201_Movement_PlayerTurnToRivalNorth:
     WalkOnSpotFastNorth
     EndMovement
 
-Route201_TriggerPickAPokemon:
+Route201_CoordEvent_PickAPokemon:
     LockAll
     ApplyMovement LOCALID_RIVAL, Route201_Movement_RivalWalkOnSpotNormalSouth
     WaitMovement
@@ -1190,7 +1190,7 @@ Route201_ProfRowan:
     NPCMessage Route201_Text_RowanGoOnChooseAPokemon
     End
 
-Route201_TriggerLetsCatchThatLegendaryPokemon:
+Route201_CoordEvent_LetsCatchThatLegendaryPokemon:
     LockAll
     ApplyMovement LOCALID_RIVAL, Route201_Movement_RivalNoticePlayer
     WaitMovement

--- a/res/field/scripts/scripts_route_202.s
+++ b/res/field/scripts/scripts_route_202.s
@@ -8,7 +8,7 @@
     ScriptEntry Route202_ArrowSignpostSandgemTown
     ScriptEntry Route202_ArrowSignpostJubilifeCity
     ScriptEntry Route202_TrainerTipsSignpost
-    ScriptEntry Route202_TriggerCatchingTutorial
+    ScriptEntry Route202_CoordEvent_CatchingTutorial
     ScriptEntry Route202_Counterpart
     ScriptEntryEnd
 
@@ -49,7 +49,7 @@ Route202_TrainerTipsSignpost:
     ShowScrollingSign Route202_Text_TrainerTipsPokemonInvolvedInBattleEarnExpPoints
     End
 
-Route202_TriggerCatchingTutorial:
+Route202_CoordEvent_CatchingTutorial:
     LockAll
     ApplyMovement LOCALID_COUNTERPART, Route202_Movement_CounterpartNoticePlayer
     ApplyMovement LOCALID_PLAYER, Route202_Movement_PlayerDelay

--- a/res/field/scripts/scripts_route_203.s
+++ b/res/field/scripts/scripts_route_203.s
@@ -8,7 +8,7 @@
     ScriptEntry Route203_ArrowSignpostOreburghCity
     ScriptEntry Route203_TrainerTipsSignpostEast
     ScriptEntry Route203_TrainerTipsSignpostWest
-    ScriptEntry Route203_RivalTrigger
+    ScriptEntry Route203_CoordEvent_Rival
     ScriptEntryEnd
 
 Route203_Lass:
@@ -31,7 +31,7 @@ Route203_TrainerTipsSignpostWest:
     ShowScrollingSign Route203_Text_TrainerTipsPokemonMovesUseEnergyCalledPowerPoints
     End
 
-Route203_RivalTrigger:
+Route203_CoordEvent_Rival:
     LockAll
     ApplyMovement LOCALID_RIVAL, Route203_Movement_RivalNoticePlayer
     WaitMovement

--- a/res/field/scripts/scripts_route_204_south.s
+++ b/res/field/scripts/scripts_route_204_south.s
@@ -4,7 +4,7 @@
 
     ScriptEntry Route204South_Youngster
     ScriptEntry Route204South_ArrowSignpostJubilifeCity
-    ScriptEntry Route204South_LandmarkSignRavagedPath
+    ScriptEntry Route204South_SignboardRavagedPath
     ScriptEntryEnd
 
 Route204South_Youngster:
@@ -15,7 +15,7 @@ Route204South_ArrowSignpostJubilifeCity:
     ShowArrowSign Route204South_Text_Rt204JubilifeCity
     End
 
-Route204South_LandmarkSignRavagedPath:
+Route204South_SignboardRavagedPath:
     ShowLandmarkSign Route204South_Text_RavagedPath
     End
 

--- a/res/field/scripts/scripts_route_205_south.s
+++ b/res/field/scripts/scripts_route_205_south.s
@@ -8,8 +8,8 @@
     ScriptEntry Route205South_Youngster
     ScriptEntry Route205South_Grunts
     ScriptEntry Route205South_LittleGirl
-    ScriptEntry Route205South_TriggerLittleGirl
-    ScriptEntry Route205South_TriggerGrunts
+    ScriptEntry Route205South_CoordEvent_LittleGirl
+    ScriptEntry Route205South_CoordEvent_Grunts
     ScriptEntry Route205South_ArrowSignpostFloaromaTown
     ScriptEntry Route205South_ArrowSignpostEternaForest
     ScriptEntry Route205South_TrainerTipsSignpost
@@ -45,7 +45,7 @@ Route205South_Movement_GruntMEastWalkOnSpotSouth:
     WalkOnSpotNormalSouth
     EndMovement
 
-Route205South_TriggerGrunts:
+Route205South_CoordEvent_Grunts:
     LockAll
     ApplyMovement LOCALID_GRUNT_M_WEST, Route205South_Movement_GruntMWestWalkOnSpotEast
     WaitMovement
@@ -131,7 +131,7 @@ Route205South_HideFloaromaTownGrunts:
     SetVar VAR_VALLEY_WINDWORKS_STATE, 1
     Return
 
-Route205South_TriggerLittleGirl:
+Route205South_CoordEvent_LittleGirl:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     GoToIfEq VAR_0x8005, 659, Route205South_LittleGirlNoticePlayerZ659

--- a/res/field/scripts/scripts_route_206_cycling_road_north_gate.s
+++ b/res/field/scripts/scripts_route_206_cycling_road_north_gate.s
@@ -5,19 +5,19 @@
 
     ScriptEntry Route206CyclingRoadNorthGate_OnTransition
     ScriptEntry Route206CyclingRoadNorthGate_CashierM
-    ScriptEntry Route206CyclingRoadNorthGate_TriggerOnlyBicycles
-    ScriptEntry Route206CyclingRoadNorthGate_TriggerClearFlagForceBikingInGate
+    ScriptEntry Route206CyclingRoadNorthGate_CoordEvent_OnlyBicycles
+    ScriptEntry Route206CyclingRoadNorthGate_CoordEvent_ClearFlagForceBikingInGate
     ScriptEntry Route206CyclingRoadNorthGate_ScientistM
-    ScriptEntry Route206CyclingRoadNorthGate_OnFrame
+    ScriptEntry Route206CyclingRoadNorthGate_OnFrame_TryForceBiking
     ScriptEntryEnd
 
-Route206CyclingRoadNorthGate_OnFrame:
+Route206CyclingRoadNorthGate_OnFrame_TryForceBiking:
     GetPlayerMapPos VAR_MAP_LOCAL_4, VAR_MAP_LOCAL_5
-    CallIfGe VAR_MAP_LOCAL_5, 12, Route206CyclingRoadNorthGate_OnFrameForceBikingInGate
+    CallIfGe VAR_MAP_LOCAL_5, 12, Route206CyclingRoadNorthGate_ForceBikingInGateOnFrame
     SetVar VAR_MAP_LOCAL_3, 1
     End
 
-Route206CyclingRoadNorthGate_OnFrameForceBikingInGate:
+Route206CyclingRoadNorthGate_ForceBikingInGateOnFrame:
     SetFlag FLAG_FORCE_BIKING_IN_GATE
     Return
 
@@ -33,10 +33,10 @@ Route206CyclingRoadNorthGate_CashierM:
     NPCMessage Route206CyclingRoadNorthGate_Text_LearnHowToShiftGearsAndYoullBeAbleToRideAnywhere
     End
 
-Route206CyclingRoadNorthGate_TriggerOnlyBicycles:
+Route206CyclingRoadNorthGate_CoordEvent_OnlyBicycles:
     LockAll
     CheckPlayerOnBike VAR_RESULT
-    GoToIfEq VAR_RESULT, TRUE, Route206CyclingRoadNorthGate_TriggerForceBikingInGate
+    GoToIfEq VAR_RESULT, TRUE, Route206CyclingRoadNorthGate_ForceBikingInGateCoordEvent
     ApplyMovement LOCALID_CASHIER_M_WEST, Route206CyclingRoadNorthGate_Movement_CashierMExclamationMark
     WaitMovement
     Message Route206CyclingRoadNorthGate_Text_CyclingRoadIsOnlyForBicycles
@@ -46,7 +46,7 @@ Route206CyclingRoadNorthGate_TriggerOnlyBicycles:
     ReleaseAll
     End
 
-Route206CyclingRoadNorthGate_TriggerForceBikingInGate:
+Route206CyclingRoadNorthGate_ForceBikingInGateCoordEvent:
     SetFlag FLAG_FORCE_BIKING_IN_GATE
     SetVar VAR_MAP_LOCAL_2, 1
     ReleaseAll
@@ -62,7 +62,7 @@ Route206CyclingRoadNorthGate_Movement_PlayerWalkNorth:
     WalkNormalNorth
     EndMovement
 
-Route206CyclingRoadNorthGate_TriggerClearFlagForceBikingInGate:
+Route206CyclingRoadNorthGate_CoordEvent_ClearFlagForceBikingInGate:
     LockAll
     ClearFlag FLAG_FORCE_BIKING_IN_GATE
     SetVar VAR_MAP_LOCAL_2, 0

--- a/res/field/scripts/scripts_route_206_cycling_road_south_gate.s
+++ b/res/field/scripts/scripts_route_206_cycling_road_south_gate.s
@@ -5,22 +5,22 @@
 
     ScriptEntry Route206CyclingRoadSouthGate_OnTransition
     ScriptEntry Route206CyclingRoadSouthGate_CashierM
-    ScriptEntry Route206CyclingRoadSouthGate_TriggerOnlyCyclists
-    ScriptEntry Route206CyclingRoadSouthGate_TriggerClearFlagForceBikingInGate
+    ScriptEntry Route206CyclingRoadSouthGate_CoordEvent_OnlyCyclists
+    ScriptEntry Route206CyclingRoadSouthGate_CoordEvent_ClearFlagForceBikingInGate
     ScriptEntry Route206CyclingRoadSouthGate_BattleGirl
-    ScriptEntry Route206CyclingRoadSouthGate_OnFrame
+    ScriptEntry Route206CyclingRoadSouthGate_OnFrame_TryForceBiking
     ScriptEntryEnd
 
 Route206CyclingRoadSouthGate_OnTransition:
     End
 
-Route206CyclingRoadSouthGate_OnFrame:
+Route206CyclingRoadSouthGate_OnFrame_TryForceBiking:
     GetPlayerMapPos VAR_MAP_LOCAL_4, VAR_MAP_LOCAL_5
-    CallIfLe VAR_MAP_LOCAL_5, 3, Route206CyclingRoadSouthGate_OnFrameForceBikingInGate
+    CallIfLe VAR_MAP_LOCAL_5, 3, Route206CyclingRoadSouthGate_ForceBikingInGateOnFrame
     SetVar VAR_MAP_LOCAL_3, 1
     End
 
-Route206CyclingRoadSouthGate_OnFrameForceBikingInGate:
+Route206CyclingRoadSouthGate_ForceBikingInGateOnFrame:
     SetFlag FLAG_FORCE_BIKING_IN_GATE
     Return
 
@@ -28,10 +28,10 @@ Route206CyclingRoadSouthGate_CashierM:
     NPCMessage Route206CyclingRoadSouthGate_Text_LearnHowToShiftGearsAndYoullBeAbleToRideAnywhere
     End
 
-Route206CyclingRoadSouthGate_TriggerOnlyCyclists:
+Route206CyclingRoadSouthGate_CoordEvent_OnlyCyclists:
     LockAll
     CheckPlayerOnBike VAR_RESULT
-    GoToIfEq VAR_RESULT, TRUE, Route206CyclingRoadSouthGate_TriggerForceBikingInGate
+    GoToIfEq VAR_RESULT, TRUE, Route206CyclingRoadSouthGate_ForceBikingInGateCoordEvent
     ApplyMovement LOCALID_CASHIER_M_WEST, Route206CyclingRoadSouthGate_Movement_CashierMExclamationMark
     WaitMovement
     Message Route206CyclingRoadSouthGate_Text_CyclingRoadIsOpenOnlyToCyclists
@@ -41,7 +41,7 @@ Route206CyclingRoadSouthGate_TriggerOnlyCyclists:
     ReleaseAll
     End
 
-Route206CyclingRoadSouthGate_TriggerForceBikingInGate:
+Route206CyclingRoadSouthGate_ForceBikingInGateCoordEvent:
     SetFlag FLAG_FORCE_BIKING_IN_GATE
     SetVar VAR_MAP_LOCAL_2, 1
     ReleaseAll
@@ -57,7 +57,7 @@ Route206CyclingRoadSouthGate_Movement_PlayerWalkSouth:
     WalkNormalSouth
     EndMovement
 
-Route206CyclingRoadSouthGate_TriggerClearFlagForceBikingInGate:
+Route206CyclingRoadSouthGate_CoordEvent_ClearFlagForceBikingInGate:
     LockAll
     ClearFlag FLAG_FORCE_BIKING_IN_GATE
     SetVar VAR_MAP_LOCAL_2, 0

--- a/res/field/scripts/scripts_route_207.s
+++ b/res/field/scripts/scripts_route_207.s
@@ -5,12 +5,12 @@
 
 
     ScriptEntry Route207_OnTransition
-    ScriptEntry Route207_TriggerCounterpart
+    ScriptEntry Route207_CoordEvent_Counterpart
     ScriptEntry Route207_Unused
     ScriptEntry Route207_CyclistM
     ScriptEntry Route207_ArrowSignpostMtCoronet
     ScriptEntry Route207_ArrowSignpostOreburghCity
-    ScriptEntry Route207_TrainerTips
+    ScriptEntry Route207_TrainerTipsSignpost
     ScriptEntryEnd
 
 Route207_OnTransition:
@@ -27,7 +27,7 @@ Route207_SetCounterpartGraphicsLucas:
     SetVar VAR_OBJ_GFX_ID_0, OBJ_EVENT_GFX_PLAYER_M
     End
 
-Route207_TriggerCounterpart:
+Route207_CoordEvent_Counterpart:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     SetObjectEventPos LOCALID_COUNTERPART, 331, VAR_0x8005
@@ -167,7 +167,7 @@ Route207_ArrowSignpostOreburghCity:
     ShowArrowSign Route207_Text_Rt207OreburghCity
     End
 
-Route207_TrainerTips:
+Route207_TrainerTipsSignpost:
     ShowScrollingSign Route207_Text_TrainerTipsPokemonMayBecomeImmobilizedIfTheyAreAsleepOrParalyzed
     End
 

--- a/res/field/scripts/scripts_route_208.s
+++ b/res/field/scripts/scripts_route_208.s
@@ -4,9 +4,9 @@
 
     ScriptEntry Route208_ArrowSignpostMtCoronet
     ScriptEntry Route208_ArrowSignpostHearthomeCity
-    ScriptEntry Route208_SignBerryMastersHouse
+    ScriptEntry Route208_SignboardBerryMastersHouse
     ScriptEntry Route208_BlackBelt
-    ScriptEntry Route208_TrainerTips
+    ScriptEntry Route208_TrainerTipsSignpost
     ScriptEntryEnd
 
 Route208_ArrowSignpostMtCoronet:
@@ -17,11 +17,11 @@ Route208_ArrowSignpostHearthomeCity:
     ShowArrowSign Route208_Text_SignRt208HearthomeCity
     End
 
-Route208_SignBerryMastersHouse:
+Route208_SignboardBerryMastersHouse:
     ShowLandmarkSign Route208_Text_SignBerryMastersHouse
     End
 
-Route208_TrainerTips:
+Route208_TrainerTipsSignpost:
     ShowScrollingSign Route208_Text_TrainerTipsWatchBerrySoilColor
     End
 

--- a/res/field/scripts/scripts_route_209.s
+++ b/res/field/scripts/scripts_route_209.s
@@ -10,7 +10,7 @@
     ScriptEntry Route209_JoggerRichard
     ScriptEntry Route209_JoggerRaul
     ScriptEntry Route209_OnTransition
-    ScriptEntry Route209_TrainerTips
+    ScriptEntry Route209_TrainerTipsSignpost
     ScriptEntryEnd
 
 Route209_OnTransition:
@@ -188,7 +188,7 @@ Route209_ArrowSignpostSolaceonTown:
     ShowArrowSign Route209_Text_Rt209SolaceonTown
     End
 
-Route209_TrainerTips:
+Route209_TrainerTipsSignpost:
     ShowScrollingSign Route209_Text_TrainerTipsRegisterKeyItems
     End
 

--- a/res/field/scripts/scripts_route_209_gate_to_hearthome_city.s
+++ b/res/field/scripts/scripts_route_209_gate_to_hearthome_city.s
@@ -4,14 +4,14 @@
 
 
     ScriptEntry Route209GateToHearthomeCity_BattleGirl
-    ScriptEntry Route209GateToHearthomeCity_TriggerRival
+    ScriptEntry Route209GateToHearthomeCity_CoordEvent_Rival
     ScriptEntryEnd
 
 Route209GateToHearthomeCity_BattleGirl:
     NPCMessage Route209GateToHearthomeCity_Text_TheresAWreckedStonePillar
     End
 
-Route209GateToHearthomeCity_TriggerRival:
+Route209GateToHearthomeCity_CoordEvent_Rival:
     LockAll
     ApplyMovement LOCALID_RIVAL, Route209GateToHearthomeCity_Movement_RivalNoticePlayer
     WaitMovement

--- a/res/field/scripts/scripts_route_210_north.s
+++ b/res/field/scripts/scripts_route_210_north.s
@@ -3,19 +3,19 @@
 
 
     ScriptEntry Route210North_BlackBelt
-    ScriptEntry Route210North_ArrowSignCelesticTown
-    ScriptEntry Route210North_SignGrandmaWilmasHouse
+    ScriptEntry Route210North_ArrowSignpostCelesticTown
+    ScriptEntry Route210North_SignboardGrandmaWilmasHouse
     ScriptEntryEnd
 
 Route210North_BlackBelt:
     NPCMessage Route210North_Text_HowDoesDefogWork
     End
 
-Route210North_ArrowSignCelesticTown:
+Route210North_ArrowSignpostCelesticTown:
     ShowArrowSign Route210North_Text_SignCelesticTown
     End
 
-Route210North_SignGrandmaWilmasHouse:
+Route210North_SignboardGrandmaWilmasHouse:
     ShowLandmarkSign Route210North_Text_SignGrandmaWilmasHouse
     End
 

--- a/res/field/scripts/scripts_route_210_south.s
+++ b/res/field/scripts/scripts_route_210_south.s
@@ -6,7 +6,7 @@
     ScriptEntry Route210South_Psyduck
     ScriptEntry Route210South_Unused
     ScriptEntry Route210South_AceTrainerF
-    ScriptEntry Route210South_SignCafeCabin
+    ScriptEntry Route210South_SignboardCafeCabin
     ScriptEntry Route210South_ArrowSignpostSolaceonTown
     ScriptEntry Route210South_JoggerWyatt
     ScriptEntry Route210South_OnTransition
@@ -246,7 +246,7 @@ Route210South_BagIsFull:
     ReleaseAll
     End
 
-Route210South_SignCafeCabin:
+Route210South_SignboardCafeCabin:
     ShowLandmarkSign Route210South_Text_SignCafeCabin
     End
 

--- a/res/field/scripts/scripts_route_211_east.s
+++ b/res/field/scripts/scripts_route_211_east.s
@@ -3,9 +3,9 @@
 
 
     ScriptEntry Route211East_AceTrainerM
-    ScriptEntry Route211East_ArrowSignMtCoronet
-    ScriptEntry Route211East_TrainerTips
-    ScriptEntry Route211East_ArrowSignCelesticTown
+    ScriptEntry Route211East_ArrowSignpostMtCoronet
+    ScriptEntry Route211East_TrainerTipsSignpost
+    ScriptEntry Route211East_ArrowSignpostCelesticTown
     ScriptEntryEnd
 
 Route211East_AceTrainerM:
@@ -44,15 +44,15 @@ Route211East_Movement_ExclamationMark:
     EmoteExclamationMark
     EndMovement
 
-Route211East_ArrowSignMtCoronet:
+Route211East_ArrowSignpostMtCoronet:
     ShowArrowSign Route211East_Text_SignMtCoronet
     End
 
-Route211East_TrainerTips:
+Route211East_TrainerTipsSignpost:
     ShowScrollingSign Route211East_Text_TrainerTipsCheckSupply
     End
 
-Route211East_ArrowSignCelesticTown:
+Route211East_ArrowSignpostCelesticTown:
     ShowArrowSign Route211East_Text_SignCelesticTown
     End
 

--- a/res/field/scripts/scripts_route_212_north.s
+++ b/res/field/scripts/scripts_route_212_north.s
@@ -4,8 +4,8 @@
 
     ScriptEntry Route212North_Youngster
     ScriptEntry Route212North_ArrowSignpostHearthomeCity
-    ScriptEntry Route212North_SignPokemonMansion
-    ScriptEntry Route212North_TrainerTips
+    ScriptEntry Route212North_SignboardPokemonMansion
+    ScriptEntry Route212North_TrainerTipsSignpost
     ScriptEntry Route212North_Collector
     ScriptEntry Route212North_PolicemanBobby
     ScriptEntry Route212North_PolicemanAlex
@@ -50,11 +50,11 @@ Route212North_ArrowSignpostHearthomeCity:
     ShowArrowSign Route212North_Text_SignHearthomeCity
     End
 
-Route212North_SignPokemonMansion:
+Route212North_SignboardPokemonMansion:
     ShowLandmarkSign Route212North_Text_SignPokemonMansion
     End
 
-Route212North_TrainerTips:
+Route212North_TrainerTipsSignpost:
     ShowScrollingSign Route212North_Text_TrainerTipsReorganizeItems
     End
 

--- a/res/field/scripts/scripts_route_212_south.s
+++ b/res/field/scripts/scripts_route_212_south.s
@@ -5,11 +5,11 @@
     ScriptEntry Route212South_SchoolKidM
     ScriptEntry Route212South_Lady
     ScriptEntry Route212South_Collector
-    ScriptEntry Route212South_ArrowSignPastoriaCity
-    ScriptEntry Route212South_SignShardsWanted
+    ScriptEntry Route212South_ArrowSignpostPastoriaCity
+    ScriptEntry Route212South_SignboardShardsWanted
     ScriptEntry Route212South_PolicemanDanny
     ScriptEntry Route212South_OnTransition
-    ScriptEntry Route212South_TrainerTips
+    ScriptEntry Route212South_TrainerTipsSignpost
     ScriptEntryEnd
 
 Route212South_OnTransition:
@@ -40,15 +40,15 @@ Route212South_Collector:
     NPCMessage Route212South_Text_HowAboutPokemonMansion
     End
 
-Route212South_ArrowSignPastoriaCity:
+Route212South_ArrowSignpostPastoriaCity:
     ShowArrowSign Route212South_Text_SignPastoriaCity
     End
 
-Route212South_SignShardsWanted:
+Route212South_SignboardShardsWanted:
     ShowLandmarkSign Route212South_Text_SignShardsWanted
     End
 
-Route212South_TrainerTips:
+Route212South_TrainerTipsSignpost:
     ShowScrollingSign Route212South_Text_TrainerTipsBog
     End
 

--- a/res/field/scripts/scripts_route_213.s
+++ b/res/field/scripts/scripts_route_213.s
@@ -8,9 +8,9 @@
     ScriptEntry Route213_Fisherman
     ScriptEntry Route213_Beauty
     ScriptEntry Route213_Collector
-    ScriptEntry Route213_ArrowSignPastoriaCity
-    ScriptEntry Route213_SignHotelGrandLake
-    ScriptEntry Route213_SignDrFootstepsHouse
+    ScriptEntry Route213_ArrowSignpostPastoriaCity
+    ScriptEntry Route213_SignboardHotelGrandLake
+    ScriptEntry Route213_SignboardDrFootstepsHouse
     ScriptEntryEnd
 
 Route213_OnTransition:
@@ -326,15 +326,15 @@ Route213_Fisherman:
     NPCMessage Route213_Text_TheresAFancyHotel
     End
 
-Route213_ArrowSignPastoriaCity:
+Route213_ArrowSignpostPastoriaCity:
     ShowArrowSign Route213_Text_SignRt213PastoriaCity
     End
 
-Route213_SignHotelGrandLake:
+Route213_SignboardHotelGrandLake:
     ShowLandmarkSign Route213_Text_SignHotelGrandLake
     End
 
-Route213_SignDrFootstepsHouse:
+Route213_SignboardDrFootstepsHouse:
     ShowLandmarkSign Route213_Text_SignDrFootstepsHouse
     End
 

--- a/res/field/scripts/scripts_route_214.s
+++ b/res/field/scripts/scripts_route_214.s
@@ -2,8 +2,8 @@
 #include "res/text/bank/route_214.h"
 
 
-    ScriptEntry Route214_ArrowSignVeilstoneCity
-    ScriptEntry Route214_ArrowSignLakeValor
+    ScriptEntry Route214_ArrowSignpostVeilstoneCity
+    ScriptEntry Route214_ArrowSignpostLakeValor
     ScriptEntry Route214_OnTransition
     ScriptEntry Route214_OnLoad
     ScriptEntryEnd
@@ -37,10 +37,10 @@ Route214_OnTransition:
     GoToIfLt VAR_MAP_LOCAL_0, 10, Route214_RemoveWarpsManiacCaveLongAndTunnel
     End
 
-Route214_ArrowSignVeilstoneCity:
+Route214_ArrowSignpostVeilstoneCity:
     ShowArrowSign Route214_Text_SignVeilstoneCity
     End
 
-Route214_ArrowSignLakeValor:
+Route214_ArrowSignpostLakeValor:
     ShowArrowSign Route214_Text_SignLakeValor
     End

--- a/res/field/scripts/scripts_route_215.s
+++ b/res/field/scripts/scripts_route_215.s
@@ -9,7 +9,7 @@
     ScriptEntry Route215_JoggerScott
     ScriptEntry Route215_JoggerCraig
     ScriptEntry Route215_OnTransition
-    ScriptEntry Route215_TrainerTips
+    ScriptEntry Route215_TrainerTipsSignpost
     ScriptEntryEnd
 
 Route215_OnTransition:
@@ -70,7 +70,7 @@ Route215_ArrowSignpostVeilstoneCity:
     ShowArrowSign Route215_Text_SignRt215VeilstoneCity
     End
 
-Route215_TrainerTips:
+Route215_TrainerTipsSignpost:
     ShowScrollingSign Route215_Text_TrainerTipsPhysicalSpecial
     End
 

--- a/res/field/scripts/scripts_route_216.s
+++ b/res/field/scripts/scripts_route_216.s
@@ -4,7 +4,7 @@
 
     ScriptEntry Route216_Unused
     ScriptEntry Route216_ArrowSignpostMtCoronet
-    ScriptEntry Route216_SignSnowboundLodge
+    ScriptEntry Route216_SignboardSnowboundLodge
     ScriptEntryEnd
 
 Route216_Unused:
@@ -15,7 +15,7 @@ Route216_ArrowSignpostMtCoronet:
     ShowArrowSign Route216_Text_SignRt216MtCoronet
     End
 
-Route216_SignSnowboundLodge:
+Route216_SignboardSnowboundLodge:
     ShowLandmarkSign Route216_Text_SignSnowboundLodge
     End
 

--- a/res/field/scripts/scripts_route_217.s
+++ b/res/field/scripts/scripts_route_217.s
@@ -6,7 +6,7 @@
     ScriptEntry Route217_IceRock
     ScriptEntry Route217_ArrowSignpostLakeAcuity
     ScriptEntry Route217_SnowpointNPCF
-    ScriptEntry Route217_TriggerMaylene
+    ScriptEntry Route217_CoordEvent_Maylene
     ScriptEntryEnd
 
 Route217_IceRock:
@@ -21,7 +21,7 @@ Route217_SnowpointNPCF:
     NPCMessage Route217_Text_ImUsingDowsingMachine
     End
 
-Route217_TriggerMaylene:
+Route217_CoordEvent_Maylene:
     LockAll
     ClearFlag FLAG_HIDE_ROUTE_217_MAYLENE
     AddObject LOCALID_MAYLENE

--- a/res/field/scripts/scripts_route_218_gate_to_canalave_city.s
+++ b/res/field/scripts/scripts_route_218_gate_to_canalave_city.s
@@ -4,10 +4,10 @@
 
 
     ScriptEntry Route218GateToCanalaveCity_Policeman
-    ScriptEntry Route218GateToCanalaveCity_TriggerScientistM
+    ScriptEntry Route218GateToCanalaveCity_CoordEvent_ScientistM
     ScriptEntryEnd
 
-Route218GateToCanalaveCity_TriggerScientistM:
+Route218GateToCanalaveCity_CoordEvent_ScientistM:
     LockAll
     Call Route218GateToCanalaveCity_ScientistMWalkToPlayer
     BufferPlayerName 0

--- a/res/field/scripts/scripts_route_219.s
+++ b/res/field/scripts/scripts_route_219.s
@@ -2,10 +2,10 @@
 #include "res/text/bank/route_219.h"
 
 
-    ScriptEntry Route219_ArrowSignSandgemBeach
+    ScriptEntry Route219_ArrowSignpostSandgemBeach
     ScriptEntryEnd
 
-Route219_ArrowSignSandgemBeach:
+Route219_ArrowSignpostSandgemBeach:
     ShowArrowSign Route219_Text_SignSandgemBeach
     End
 

--- a/res/field/scripts/scripts_route_221.s
+++ b/res/field/scripts/scripts_route_221.s
@@ -4,7 +4,7 @@
 
     ScriptEntry Route221_WorkerWest
     ScriptEntry Route221_WorkerEast
-    ScriptEntry Route221_SignPalPark
+    ScriptEntry Route221_SignboardPalPark
     ScriptEntry Route221_OnTransition
     ScriptEntryEnd
 
@@ -24,7 +24,7 @@ Route221_WorkerEast:
     NPCMessage Route221_Text_GettingPalParkReady
     End
 
-Route221_SignPalPark:
+Route221_SignboardPalPark:
     ShowLandmarkSign Route221_Text_SignPalPark
     End
 

--- a/res/field/scripts/scripts_route_221_house.s
+++ b/res/field/scripts/scripts_route_221_house.s
@@ -3,7 +3,7 @@
 
 
     ScriptEntry Route221House_ExpertM
-    ScriptEntry Route221House_Sign
+    ScriptEntry Route221House_BgSign
     ScriptEntryEnd
 
 Route221House_ExpertM:
@@ -91,7 +91,7 @@ Route221House_ComeAgainTomorrow:
     ReleaseAll
     End
 
-Route221House_Sign:
+Route221House_BgSign:
     EventMessage Route221House_Text_WinItemsFromMe
     End
 

--- a/res/field/scripts/scripts_route_222.s
+++ b/res/field/scripts/scripts_route_222.s
@@ -6,8 +6,8 @@
     ScriptEntry Route222_RichBoy
     ScriptEntry Route222_ArrowSignpostHotelGrandLake
     ScriptEntry Route222_ArrowSignpostSunyshoreCity
-    ScriptEntry Route222_SignPikachuFanClub
-    ScriptEntry Route222_SignPokemonSizeContest
+    ScriptEntry Route222_SignboardPikachuFanClub
+    ScriptEntry Route222_SignboardPokemonSizeContest
     ScriptEntry Route222_PolicemanThomas
     ScriptEntry Route222_OnTransition
     ScriptEntryEnd
@@ -66,11 +66,11 @@ Route222_ArrowSignpostSunyshoreCity:
     ShowArrowSign Route222_Text_SignRt222SunyshoreCity
     End
 
-Route222_SignPikachuFanClub:
+Route222_SignboardPikachuFanClub:
     ShowLandmarkSign Route222_Text_SignPikachuFanClub
     End
 
-Route222_SignPokemonSizeContest:
+Route222_SignboardPokemonSizeContest:
     ShowLandmarkSign Route222_Text_SignPokemonSizeContest
     End
 

--- a/res/field/scripts/scripts_route_224.s
+++ b/res/field/scripts/scripts_route_224.s
@@ -9,7 +9,7 @@
     ScriptEntry Route224_OnResume
     ScriptEntry Route224_Tablet
     ScriptEntry Route224_ProfOak
-    ScriptEntry Route224_TriggerMarley
+    ScriptEntry Route224_CoordEvent_Marley
     ScriptEntry Route224_Marley
     ScriptEntryEnd
 
@@ -324,7 +324,7 @@ Route224_Movement_ShayminLeave:
     WalkSlightlyFastNorth 12
     EndMovement
 
-Route224_TriggerMarley:
+Route224_CoordEvent_Marley:
     LockAll
     ClearFlag FLAG_HIDE_ROUTE_224_MARLEY
     GetPlayerMapPos VAR_0x8004, VAR_0x8005

--- a/res/field/scripts/scripts_route_226_house.s
+++ b/res/field/scripts/scripts_route_226_house.s
@@ -5,7 +5,7 @@
 
     ScriptEntry Route226House_OnTransition
     ScriptEntry Route226House_Meister
-    ScriptEntry Route226House_Sign
+    ScriptEntry Route226House_BgSign
     ScriptEntryEnd
 
 Route226House_OnTransition:
@@ -77,6 +77,6 @@ Route226House_MakeFriendsAnywhere:
     ReleaseAll
     End
 
-Route226House_Sign:
+Route226House_BgSign:
     EventMessage Route226House_Text_VisitedOver150Countries
     End

--- a/res/field/scripts/scripts_route_227.s
+++ b/res/field/scripts/scripts_route_227.s
@@ -3,13 +3,13 @@
 #include "res/field/events/events_route_227.h"
 
 
-    ScriptEntry Route227_TriggerWakeRival
+    ScriptEntry Route227_CoordEvent_WakeRival
     ScriptEntry Route227_ArrowSignpostStarkMountain
-    ScriptEntry Route227_TriggerBuck
+    ScriptEntry Route227_CoordEvent_Buck
     ScriptEntry Route227_Buck
     ScriptEntryEnd
 
-Route227_TriggerWakeRival:
+Route227_CoordEvent_WakeRival:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     CallIfEq VAR_0x8004, 739, Route227_PlayerWalkWestOnSpotNorth
@@ -178,7 +178,7 @@ Route227_Buck:
     NPCMessage Route227_Text_YoureInCharge
     End
 
-Route227_TriggerBuck:
+Route227_CoordEvent_Buck:
     LockAll
     ApplyMovement LOCALID_BUCK, Route227_Movement_BuckNoticePlayer
     ApplyMovement LOCALID_PLAYER, Route227_Movement_PlayerFaceBuck

--- a/res/field/scripts/scripts_route_228_north_house.s
+++ b/res/field/scripts/scripts_route_228_north_house.s
@@ -3,7 +3,7 @@
 
 
     ScriptEntry Route228NorthHouse_ExpertM
-    ScriptEntry Route228NorthHouse_Sign
+    ScriptEntry Route228NorthHouse_BgSign
     ScriptEntryEnd
 
 Route228NorthHouse_ExpertM:
@@ -162,7 +162,7 @@ Route228NorthHouse_AlreadyKnowsMove:
     ReleaseAll
     End
 
-Route228NorthHouse_Sign:
+Route228NorthHouse_BgSign:
     EventMessage Route228NorthHouse_Text_PokemonListedLearnUltimateMoves
     End
 

--- a/res/field/scripts/scripts_sandgem_town.s
+++ b/res/field/scripts/scripts_sandgem_town.s
@@ -4,17 +4,17 @@
 
 
     ScriptEntry SandgemTown_OnTransition
-    ScriptEntry SandgemTown_TriggerCounterpartLeadToLab
-    ScriptEntry SandgemTown_OnFrameExitLab
+    ScriptEntry SandgemTown_CoordEvent_CounterpartLeadToLab
+    ScriptEntry SandgemTown_OnFrame_ExitLab
     ScriptEntry SandgemTown_Youngster
     ScriptEntry SandgemTown_PokemonBreederM
     ScriptEntry SandgemTown_PokemonBreederF
     ScriptEntry SandgemTown_Unused
-    ScriptEntry SandgemTown_MapSign
-    ScriptEntry SandgemTown_LandmarkSignPokemonResearchLab
-    ScriptEntry SandgemTown_LandmarkSignCounterpartMailbox
-    ScriptEntry SandgemTown_LandmarkSignPokeMart
-    ScriptEntry SandgemTown_LandmarkSignPokemonCenter
+    ScriptEntry SandgemTown_MapSignpost
+    ScriptEntry SandgemTown_SignboardPokemonResearchLab
+    ScriptEntry SandgemTown_SignboardCounterpartMailbox
+    ScriptEntry SandgemTown_SignboardPokeMart
+    ScriptEntry SandgemTown_SignboardPokemonCenter
     ScriptEntryEnd
 
 SandgemTown_OnTransition:
@@ -38,7 +38,7 @@ SandgemTown_SetCounterpartGraphicsLucas:
     SetVar VAR_OBJ_GFX_ID_0, OBJ_EVENT_GFX_PLAYER_M
     End
 
-SandgemTown_TriggerCounterpartLeadToLab:
+SandgemTown_CoordEvent_CounterpartLeadToLab:
     LockAll
     ApplyMovement LOCALID_SANDGEM_COUNTERPART, SandgemTown_Movement_CounterpartNoticePlayer
     WaitMovement
@@ -433,7 +433,7 @@ SandgemTown_Movement_RivalLeave:
     WalkFastEast 7
     EndMovement
 
-SandgemTown_OnFrameExitLab:
+SandgemTown_OnFrame_ExitLab:
     LockAll
     LoadDoorAnimation 5, 26, 8, 10, ANIMATION_TAG_DOOR_1
     PlayDoorOpenAnimation ANIMATION_TAG_DOOR_1
@@ -678,24 +678,24 @@ SandgemTown_Unused:
     NPCMessage SandgemTown_Text_ProfessorRowansComeBackToTown
     End
 
-SandgemTown_MapSign:
+SandgemTown_MapSignpost:
     ShowMapSign SandgemTown_Text_MapSign
     End
 
-SandgemTown_LandmarkSignPokemonResearchLab:
+SandgemTown_SignboardPokemonResearchLab:
     ShowLandmarkSign SandgemTown_Text_PokemonResearchLabSign
     End
 
-SandgemTown_LandmarkSignCounterpartMailbox:
+SandgemTown_SignboardCounterpartMailbox:
     BufferCounterpartName 0
     ShowLandmarkSign SandgemTown_Text_CounterpartMailbox
     End
 
-SandgemTown_LandmarkSignPokeMart:
+SandgemTown_SignboardPokeMart:
     ShowLandmarkSign SandgemTown_Text_PokeMartSign
     End
 
-SandgemTown_LandmarkSignPokemonCenter:
+SandgemTown_SignboardPokemonCenter:
     ShowLandmarkSign SandgemTown_Text_PokemonCenterSign
     End
 

--- a/res/field/scripts/scripts_sandgem_town_pokemon_research_lab.s
+++ b/res/field/scripts/scripts_sandgem_town_pokemon_research_lab.s
@@ -4,7 +4,7 @@
 
 
     ScriptEntry SandgemTownLab_OnTransition
-    ScriptEntry SandgemTownLab_OnFrameGetPokedex
+    ScriptEntry SandgemTownLab_OnFrame_GetPokedex
     ScriptEntry SandgemTownLab_ProfRowan
     ScriptEntry SandgemTownLab_UnusedEntry4
     ScriptEntry SandgemTownLab_ScientistM
@@ -17,7 +17,7 @@
     ScriptEntry SandgemTownLab_PC
     ScriptEntry SandgemTownLab_UnusedEntry13
     ScriptEntry SandgemTownLab_Refrigerator
-    ScriptEntry SandgemTownLab_OnFrameReturnedFromDistortionWorld
+    ScriptEntry SandgemTownLab_OnFrame_ReturnedFromDistortionWorld
     ScriptEntryEnd
 
 SandgemTownLab_OnTransition:
@@ -76,7 +76,7 @@ SandgemTownLab_IfYouSeeCynthiaGiveHerMyBestRegards:
     ReleaseAll
     End
 
-SandgemTownLab_OnFrameReturnedFromDistortionWorld:
+SandgemTownLab_OnFrame_ReturnedFromDistortionWorld:
     LockAll
     CallIfEq VAR_EXITED_DISTORTION_WORLD_STATE, 2, SandgemTownLab_IncreaseExitedDistortionWorldState
     BufferPlayerName 1
@@ -126,7 +126,7 @@ SandgemTownLab_Movement_CounterpartTurnOnSpot:
 SandgemTownLab_UnusedEntry4:
     End
 
-SandgemTownLab_OnFrameGetPokedex:
+SandgemTownLab_OnFrame_GetPokedex:
     LockAll
     ApplyMovement LOCALID_COUNTERPART, SandgemTownLab_Movement_CounterpartWalkToProfRowan
     ApplyMovement LOCALID_PLAYER, SandgemTownLab_Movement_PlayerWalkToProfRowan

--- a/res/field/scripts/scripts_sendoff_spring.s
+++ b/res/field/scripts/scripts_sendoff_spring.s
@@ -3,7 +3,7 @@
 #include "res/field/events/events_sendoff_spring.h"
 
 
-    ScriptEntry SendoffSpring_OnFrameCynthia
+    ScriptEntry SendoffSpring_OnFrame_Cynthia
     ScriptEntry SendoffSpring_Cynthia
     ScriptEntry SendoffSpring_OnTransition
     ScriptEntryEnd
@@ -16,7 +16,7 @@ SendoffSpring_ShowTurnbackCaveItem:
     ClearFlag FLAG_HIDE_TURNBACK_CAVE_GIRATINA_ROOM_ITEM
     Return
 
-SendoffSpring_OnFrameCynthia:
+SendoffSpring_OnFrame_Cynthia:
     LockAll
     SetPartyGiratinaForm GIRATINA_FORM_ALTERED
     ScrCmd_2B5 MAP_HEADER_UNKNOWN_266, 762, 714

--- a/res/field/scripts/scripts_snowpoint_city.s
+++ b/res/field/scripts/scripts_snowpoint_city.s
@@ -5,15 +5,15 @@
 
     ScriptEntry SnowpointCity_OnTransition
     ScriptEntry SnowpointCity_TempleGuard
-    ScriptEntry SnowpointCity_TriggerTempleGuard
+    ScriptEntry SnowpointCity_CoordEvent_TempleGuard
     ScriptEntry SnowpointCity_Candice
     ScriptEntry SnowpointCity_AceTrainerSnowF
     ScriptEntry SnowpointCity_SnowpointNPCF1
     ScriptEntry SnowpointCity_SnowpointNPCF2
     ScriptEntry SnowpointCity_SnowpointNPCM
     ScriptEntry SnowpointCity_Sailor
-    ScriptEntry SnowpointCity_MapSign
-    ScriptEntry SnowpointCity_GymSign
+    ScriptEntry SnowpointCity_MapSignpost
+    ScriptEntry SnowpointCity_GymSignpost
     ScriptEntry SnowpointCity_SailorSSSpiral
     ScriptEntryEnd
 
@@ -25,7 +25,7 @@ SnowpointCity_HideCandice:
     SetFlag FLAG_HIDE_SNOWPOINT_CITY_CANDICE
     End
 
-SnowpointCity_TriggerTempleGuard:
+SnowpointCity_CoordEvent_TempleGuard:
     LockAll
     ApplyMovement LOCALID_TEMPLE_GUARD, SnowpointCity_Movement_TempleGuardWalkOnSpotWest
     WaitMovement
@@ -168,11 +168,11 @@ SnowpointCity_Sailor:
     NPCMessage SnowpointCity_Text_NothingExceptionalHere
     End
 
-SnowpointCity_MapSign:
+SnowpointCity_MapSignpost:
     ShowMapSign SnowpointCity_Text_MapSign
     End
 
-SnowpointCity_GymSign:
+SnowpointCity_GymSignpost:
     ShowScrollingSign SnowpointCity_Text_SignPokemonGym
     End
 

--- a/res/field/scripts/scripts_solaceon_town.s
+++ b/res/field/scripts/scripts_solaceon_town.s
@@ -9,12 +9,12 @@
     ScriptEntry SolaceonTown_Cowgirl2
     ScriptEntry SolaceonTown_Rancher2
     ScriptEntry SolaceonTown_RuinManiac
-    ScriptEntry SolaceonTown_MapSign
-    ScriptEntry SolaceonTown_SignPokemonDayCare
-    ScriptEntry SolaceonTown_SignPokemonNewsPress
+    ScriptEntry SolaceonTown_MapSignpost
+    ScriptEntry SolaceonTown_SignboardPokemonDayCare
+    ScriptEntry SolaceonTown_SignboardPokemonNewsPress
     ScriptEntry SolaceonTown_OnTransition
     ScriptEntry SolaceonTown_OnResume
-    ScriptEntry SolaceonTown_TriggerRival
+    ScriptEntry SolaceonTown_CoordEvent_Rival
     ScriptEntryEnd
 
 SolaceonTown_OnResume:
@@ -93,19 +93,19 @@ SolaceonTown_EachPokemonHasItsOwnHistory:
     ReleaseAll
     End
 
-SolaceonTown_MapSign:
+SolaceonTown_MapSignpost:
     ShowMapSign SolaceonTown_Text_MapSign
     End
 
-SolaceonTown_SignPokemonDayCare:
+SolaceonTown_SignboardPokemonDayCare:
     ShowLandmarkSign SolaceonTown_Text_SignPokemonDayCare
     End
 
-SolaceonTown_SignPokemonNewsPress:
+SolaceonTown_SignboardPokemonNewsPress:
     ShowLandmarkSign SolaceonTown_Text_SignPokemonNewsPress
     End
 
-SolaceonTown_TriggerRival:
+SolaceonTown_CoordEvent_Rival:
     LockAll
     ApplyMovement LOCALID_PLAYER, SolaceonTown_Movement_PlayerNoticeRival
     WaitMovement

--- a/res/field/scripts/scripts_spear_pillar.s
+++ b/res/field/scripts/scripts_spear_pillar.s
@@ -7,9 +7,9 @@
 
     ScriptEntry SpearPillar_OnTransition
     ScriptEntry SpearPillar_OnLoad
-    ScriptEntry SpearPillar_TriggerGrunts
+    ScriptEntry SpearPillar_CoordEvent_Grunts
     ScriptEntry SpearPillar_Cyrus
-    ScriptEntry SpearPillar_TriggerMarsJupiter
+    ScriptEntry SpearPillar_CoordEvent_MarsJupiter
     ScriptEntry SpearPillar_Grunts
     ScriptEntry SpearPillar_Jupiter
     ScriptEntry SpearPillar_Mars
@@ -78,7 +78,7 @@ SpearPillar_Unused:
 SpearPillar_Unused2:
     Return
 
-SpearPillar_TriggerGrunts:
+SpearPillar_CoordEvent_Grunts:
     LockAll
     ApplyMovement LOCALID_GRUNT_F, SpearPillar_Movement_GruntFWalkOnSpotEast
     ApplyMovement LOCALID_GRUNT_M, SpearPillar_Movement_GruntMWalkOnSpotWest
@@ -159,7 +159,7 @@ SpearPillar_Mars:
     NPCMessage SpearPillar_Text_SurprisedYouMadeIt
     End
 
-SpearPillar_TriggerMarsJupiter:
+SpearPillar_CoordEvent_MarsJupiter:
     LockAll
     Call SpearPillar_MarsJupiterWalkToPlayer
     Message SpearPillar_Text_GoThroughMeFirst

--- a/res/field/scripts/scripts_spear_pillar_distorted.s
+++ b/res/field/scripts/scripts_spear_pillar_distorted.s
@@ -3,7 +3,7 @@
 #include "res/field/events/events_spear_pillar_distorted.h"
 
 
-    ScriptEntry SpearPillarDistorted_OnFrameAfterWarp
+    ScriptEntry SpearPillarDistorted_OnFrame_AfterWarp
     ScriptEntry SpearPillarDistorted_Cynthia
     ScriptEntry SpearPillarDistorted_Jupiter
     ScriptEntry SpearPillarDistorted_Mars
@@ -13,7 +13,7 @@
     ScriptEntry SpearPillarDistorted_RiftPalkia
     ScriptEntryEnd
 
-SpearPillarDistorted_OnFrameAfterWarp:
+SpearPillarDistorted_OnFrame_AfterWarp:
     LockAll
     ClearFlag FLAG_HIDE_SPEAR_PILLAR_DISTORTED_MESPRIT
     AddObject LOCALID_MESPRIT

--- a/res/field/scripts/scripts_stark_mountain_outside.s
+++ b/res/field/scripts/scripts_stark_mountain_outside.s
@@ -4,20 +4,20 @@
 
 
     ScriptEntry StarkMountainOutside_OnTransition
-    ScriptEntry StarkMountainOutside_SignStarkMountain
-    ScriptEntry StarkMountainOutside_TriggerGrunts
-    ScriptEntry StarkMountainOutside_OnFrameLookerBuck
+    ScriptEntry StarkMountainOutside_SignboardStarkMountain
+    ScriptEntry StarkMountainOutside_CoordEvent_Grunts
+    ScriptEntry StarkMountainOutside_OnFrame_LookerBuck
     ScriptEntryEnd
 
 StarkMountainOutside_OnTransition:
     SetFlag FLAG_FIRST_ARRIVAL_STARK_MOUNTAIN_EXTERIOR
     End
 
-StarkMountainOutside_SignStarkMountain:
+StarkMountainOutside_SignboardStarkMountain:
     ShowLandmarkSign StarkMountainOutside_Text_SignStarkMountain
     End
 
-StarkMountainOutside_TriggerGrunts:
+StarkMountainOutside_CoordEvent_Grunts:
     LockAll
     ApplyMovement LOCALID_GRUNT_M_1, StarkMountainOutside_Movement_GruntM1Enter
     ApplyMovement LOCALID_GRUNT_M_2, StarkMountainOutside_Movement_GruntM2Enter
@@ -101,7 +101,7 @@ StarkMountainOutside_Movement_GruntM2EnterStarkMountain:
     SetInvisible
     EndMovement
 
-StarkMountainOutside_OnFrameLookerBuck:
+StarkMountainOutside_OnFrame_LookerBuck:
     LockAll
     Message StarkMountainOutside_Text_InhaledVolcanicAsh
     CloseMessage

--- a/res/field/scripts/scripts_stark_mountain_room_1.s
+++ b/res/field/scripts/scripts_stark_mountain_room_1.s
@@ -4,7 +4,7 @@
 
 
     ScriptEntry StarkMountainOutside_OnTransition
-    ScriptEntry StarkMountainOutside_OnFrameTeamGalactic
+    ScriptEntry StarkMountainOutside_OnFrame_TeamGalactic
     ScriptEntryEnd
 
 StarkMountainOutside_OnTransition:
@@ -12,7 +12,7 @@ StarkMountainOutside_OnTransition:
     SetFlag FLAG_HIDE_ROUTE_227_BUCK
     End
 
-StarkMountainOutside_OnFrameTeamGalactic:
+StarkMountainOutside_OnFrame_TeamGalactic:
     LockAll
     ApplyMovement LOCALID_MARS, StarkMountainRoom1_Movement_MarsWalkOnSpotSouth
     WaitMovement

--- a/res/field/scripts/scripts_stark_mountain_room_2.s
+++ b/res/field/scripts/scripts_stark_mountain_room_2.s
@@ -3,9 +3,9 @@
 #include "res/field/events/events_stark_mountain_room_2.h"
 
 
-    ScriptEntry StarkMountainRoom2_TriggerBuckStartFollowing
-    ScriptEntry StarkMountainRoom2_TriggerPlayerLeaveBuck
-    ScriptEntry StarkMountainRoom2_TriggerBuckLeavePlayer
+    ScriptEntry StarkMountainRoom2_CoordEvent_BuckStartFollowing
+    ScriptEntry StarkMountainRoom2_CoordEvent_PlayerLeaveBuck
+    ScriptEntry StarkMountainRoom2_CoordEvent_BuckLeavePlayer
     ScriptEntry StarkMountainRoom2_Unused4
     ScriptEntry StarkMountainRoom2_Unused5
     ScriptEntry StarkMountainRoom2_OnTransition
@@ -19,7 +19,7 @@ StarkMountainRoom2_ResetFollowerBuckState:
     SetVar VAR_STARK_MOUNTAIN_ROOM_2_FOLLOWER_BUCK_STATE, 0
     End
 
-StarkMountainRoom2_TriggerBuckStartFollowing:
+StarkMountainRoom2_CoordEvent_BuckStartFollowing:
     LockAll
     SetPlayerBike FALSE
     CallIfUnset FLAG_TALKED_TO_STARK_MOUNTAIN_ROOM_2_BUCK, StarkMountainRoom2_BuckEnterStartFollowing
@@ -84,7 +84,7 @@ StarkMountainRoom2_UnusedMovement2:
     WalkNormalNorth
     EndMovement
 
-StarkMountainRoom2_TriggerPlayerLeaveBuck:
+StarkMountainRoom2_CoordEvent_PlayerLeaveBuck:
     LockAll
     ApplyMovement LOCALID_BUCK, StarkMountainRoom2_Movement_BuckWalkOnSpotSouth2
     ApplyMovement LOCALID_PLAYER, StarkMountainRoom2_Movement_PlayerWalkOnSpotNorth
@@ -119,7 +119,7 @@ StarkMountainRoom2_Movement_BuckWalkOnSpotSouth2:
     WalkOnSpotNormalSouth
     EndMovement
 
-StarkMountainRoom2_TriggerBuckLeavePlayer:
+StarkMountainRoom2_CoordEvent_BuckLeavePlayer:
     LockAll
     ClearHasPartner
     SetMovementType LOCALID_BUCK, MOVEMENT_TYPE_LOOK_SOUTH

--- a/res/field/scripts/scripts_stark_mountain_room_3.s
+++ b/res/field/scripts/scripts_stark_mountain_room_3.s
@@ -7,7 +7,7 @@
     ScriptEntry StarkMountainRoom3_OnLoad
     ScriptEntry StarkMountainRoom3_Unused
     ScriptEntry StarkMountainRoom3_Heatran
-    ScriptEntry StarkMountainRoom3_OnFrameCharon
+    ScriptEntry StarkMountainRoom3_OnFrame_Charon
     ScriptEntryEnd
 
 StarkMountainRoom3_OnTransition:
@@ -130,7 +130,7 @@ StarkMountainRoom3_UnusedMovement6:
     WalkOnSpotNormalSouth
     EndMovement
 
-StarkMountainRoom3_OnFrameCharon:
+StarkMountainRoom3_OnFrame_Charon:
     LockAll
     Message StarkMountainRoom3_Text_MagmaStoneWillBeMine
     CloseMessage

--- a/res/field/scripts/scripts_sunyshore_city.s
+++ b/res/field/scripts/scripts_sunyshore_city.s
@@ -3,22 +3,22 @@
 #include "res/field/events/events_sunyshore_city.h"
 
 
-    ScriptEntry SunyshoreCity_OnFrameFlint
+    ScriptEntry SunyshoreCity_OnFrame_Flint
     ScriptEntry SunyshoreCity_Unused2
     ScriptEntry SunyshoreCity_Sailor2
     ScriptEntry SunyshoreCity_Sailor1
     ScriptEntry SunyshoreCity_Worker
     ScriptEntry SunyshoreCity_PokefanF
     ScriptEntry SunyshoreCity_PokemonBreederF
-    ScriptEntry SunyshoreCity_TriggerRivalAndJasmine
+    ScriptEntry SunyshoreCity_CoordEvent_RivalAndJasmine
     ScriptEntry SunyshoreCity_Jasmine
-    ScriptEntry SunyshoreCity_MapSign
-    ScriptEntry SunyshoreCity_GymSign
-    ScriptEntry SunyshoreCity_SignVistaLighthouse
-    ScriptEntry SunyshoreCity_SignSunyshoreMarket
-    ScriptEntry SunyshoreCity_SignJuliasHouse
-    ScriptEntry SunyshoreCity_SignBlank
-    ScriptEntry SunyshoreCity_SignPokemonRock
+    ScriptEntry SunyshoreCity_MapSignpost
+    ScriptEntry SunyshoreCity_GymSignpost
+    ScriptEntry SunyshoreCity_SignboardVistaLighthouse
+    ScriptEntry SunyshoreCity_SignboardSunyshoreMarket
+    ScriptEntry SunyshoreCity_SignboardJuliasHouse
+    ScriptEntry SunyshoreCity_SignboardBlank
+    ScriptEntry SunyshoreCity_SignboardPokemonRock
     ScriptEntry SunyshoreCity_UnusedSealMerchant
     ScriptEntry SunyshoreCity_Flint
     ScriptEntry SunyshoreCity_OnTransition
@@ -41,7 +41,7 @@ SunyshoreCity_SetFlintPositionAtGate:
     SetObjectEventDir LOCALID_FLINT, DIR_WEST
     End
 
-SunyshoreCity_TriggerRivalAndJasmine:
+SunyshoreCity_CoordEvent_RivalAndJasmine:
     LockAll
     ApplyMovement LOCALID_JASMINE, SunyshoreCity_Movement_JasmineNoticePlayer
     WaitMovement
@@ -446,7 +446,7 @@ SunyshoreCity_GiveWaterfall:
     Message SunyshoreCity_Text_ThatHMContainsWaterfall
     Return
 
-SunyshoreCity_OnFrameFlint:
+SunyshoreCity_OnFrame_Flint:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     GoToIfEq VAR_0x8005, 790, SunyshoreCity_FlintWalkToPlayerZ790
@@ -543,31 +543,31 @@ SunyshoreCity_PokemonBreederF:
     NPCMessage SunyshoreCity_Text_MajorPortTown
     End
 
-SunyshoreCity_MapSign:
+SunyshoreCity_MapSignpost:
     ShowMapSign SunyshoreCity_Text_MapSign
     End
 
-SunyshoreCity_GymSign:
+SunyshoreCity_GymSignpost:
     ShowScrollingSign SunyshoreCity_Text_SignPokemonGym
     End
 
-SunyshoreCity_SignVistaLighthouse:
+SunyshoreCity_SignboardVistaLighthouse:
     ShowLandmarkSign SunyshoreCity_Text_SignVistaLighthouse
     End
 
-SunyshoreCity_SignSunyshoreMarket:
+SunyshoreCity_SignboardSunyshoreMarket:
     ShowLandmarkSign SunyshoreCity_Text_SignSunyshoreMarket
     End
 
-SunyshoreCity_SignJuliasHouse:
+SunyshoreCity_SignboardJuliasHouse:
     ShowLandmarkSign SunyshoreCity_Text_SignJuliasHouse
     End
 
-SunyshoreCity_SignBlank:
+SunyshoreCity_SignboardBlank:
     ShowLandmarkSign SunyshoreCity_Text_SignBlank
     End
 
-SunyshoreCity_SignPokemonRock:
+SunyshoreCity_SignboardPokemonRock:
     ShowLandmarkSign SunyshoreCity_Text_SignPokemonRock
     End
 

--- a/res/field/scripts/scripts_survival_area.s
+++ b/res/field/scripts/scripts_survival_area.s
@@ -7,7 +7,7 @@
     ScriptEntry SurvivalArea_BattleGirl
     ScriptEntry SurvivalArea_RuinManiac
     ScriptEntry SurvivalArea_Cameraman
-    ScriptEntry SurvivalArea_MapSign
+    ScriptEntry SurvivalArea_MapSignpost
     ScriptEntry SurvivalArea_Buck
     ScriptEntry SurvivalArea_Door
     ScriptEntry SurvivalArea_OnTransition
@@ -62,7 +62,7 @@ SurvivalArea_AllSetToProduce:
     ReleaseAll
     End
 
-SurvivalArea_MapSign:
+SurvivalArea_MapSignpost:
     ShowMapSign SurvivalArea_Text_MapSign
     End
 

--- a/res/field/scripts/scripts_team_galactic_eterna_building_1f.s
+++ b/res/field/scripts/scripts_team_galactic_eterna_building_1f.s
@@ -6,9 +6,9 @@
 
     ScriptEntry TeamGalacticEternaBuilding1F_GruntM1
     ScriptEntry TeamGalacticEternaBuilding1F_GruntM2
-    ScriptEntry TeamGalacticEternaBuilding1F_Sign
+    ScriptEntry TeamGalacticEternaBuilding1F_BgSign
     ScriptEntry TeamGalacticEternaBuilding1F_Looker
-    ScriptEntry TeamGalacticEternaBuilding1F_OnFrameLooker
+    ScriptEntry TeamGalacticEternaBuilding1F_OnFrame_Looker
     ScriptEntry TeamGalacticEternaBuilding1F_WallBlockingRotomsRoom
     ScriptEntry TeamGalacticEternaBuilding1F_OnTransition
     ScriptEntryEnd
@@ -24,7 +24,7 @@ TeamGalacticEternaBuilding1F_GruntM2:
     NPCMessage TeamGalacticEternaBuilding1F_Text_AsAGroupTeamGalacticHasItsSightsSetOnTheStarsNotOnThisWorld
     End
 
-TeamGalacticEternaBuilding1F_Sign:
+TeamGalacticEternaBuilding1F_BgSign:
     EventMessage TeamGalacticEternaBuilding1F_Text_ThePathYouChoseLeadsToGlory
     End
 
@@ -32,7 +32,7 @@ TeamGalacticEternaBuilding1F_Looker:
     NPCMessage TeamGalacticEternaBuilding1F_Text_NowIHaveBeenConductingMyInvestigationIntoTeamGalactic
     End
 
-TeamGalacticEternaBuilding1F_OnFrameLooker:
+TeamGalacticEternaBuilding1F_OnFrame_Looker:
     LockAll
     ApplyMovement LOCALID_GRUNT_M_LOOKER, TeamGalacticEternaBuilding1F_Movement_LookerNoticeAndWalkToPlayer
     ApplyMovement LOCALID_PLAYER, TeamGalacticEternaBuilding1F_Movement_PlayerFaceLooker

--- a/res/field/scripts/scripts_team_galactic_eterna_building_2f.s
+++ b/res/field/scripts/scripts_team_galactic_eterna_building_2f.s
@@ -4,7 +4,7 @@
 
     ScriptEntry TeamGalacticEternaBuilding2F_GruntM
     ScriptEntry TeamGalacticEternaBuilding2F_GruntF
-    ScriptEntry TeamGalacticEternaBuilding2F_Sign
+    ScriptEntry TeamGalacticEternaBuilding2F_BgSign
     ScriptEntryEnd
 
 TeamGalacticEternaBuilding2F_GruntM:
@@ -15,7 +15,7 @@ TeamGalacticEternaBuilding2F_GruntF:
     NPCMessage TeamGalacticEternaBuilding2F_Text_WeAreConductingResearchOnNewFormsOfEnergy
     End
 
-TeamGalacticEternaBuilding2F_Sign:
+TeamGalacticEternaBuilding2F_BgSign:
     EventMessage TeamGalacticEternaBuilding2F_Text_LetUsMakeProgressTogether
     End
 

--- a/res/field/scripts/scripts_team_galactic_eterna_building_3f.s
+++ b/res/field/scripts/scripts_team_galactic_eterna_building_3f.s
@@ -3,14 +3,14 @@
 
 
     ScriptEntry TeamGalacticEternaBuilding3F_GruntM
-    ScriptEntry TeamGalacticEternaBuilding3F_Sign
+    ScriptEntry TeamGalacticEternaBuilding3F_BgSign
     ScriptEntryEnd
 
 TeamGalacticEternaBuilding3F_GruntM:
     NPCMessage TeamGalacticEternaBuilding3F_Text_OrdinaryPeopleLikeYouCantUnderstandTeamGalacticGrandDesigns
     End
 
-TeamGalacticEternaBuilding3F_Sign:
+TeamGalacticEternaBuilding3F_BgSign:
     EventMessage TeamGalacticEternaBuilding3F_Text_QuestionNotAndFollowThisPathTheRoadToSuccess
     End
 

--- a/res/field/scripts/scripts_team_galactic_eterna_building_4f.s
+++ b/res/field/scripts/scripts_team_galactic_eterna_building_4f.s
@@ -8,7 +8,7 @@
     ScriptEntry TeamGalacticEternaBuilding4F_Clefairy
     ScriptEntry TeamGalacticEternaBuilding4F_Buneary
     ScriptEntry TeamGalacticEternaBuilding4F_PokefanM
-    ScriptEntry TeamGalacticEternaBuilding4F_Sign
+    ScriptEntry TeamGalacticEternaBuilding4F_BgSign
     ScriptEntryEnd
 
 TeamGalacticEternaBuilding4F_OnLoad:
@@ -160,6 +160,6 @@ TeamGalacticEternaBuilding4F_ICantThankYouEnoughRightNowButCruiseByMyCycleShopOK
     ReleaseAll
     End
 
-TeamGalacticEternaBuilding4F_Sign:
+TeamGalacticEternaBuilding4F_BgSign:
     EventMessage TeamGalacticEternaBuilding4F_Text_WorkingForWorldPeace
     End

--- a/res/field/scripts/scripts_twinleaf_town.s
+++ b/res/field/scripts/scripts_twinleaf_town.s
@@ -4,14 +4,14 @@
 
 
     ScriptEntry TwinleafTown_OnTransition
-    ScriptEntry TwinleafTown_RivalThudTrigger
+    ScriptEntry TwinleafTown_CoordEvent_RivalThud
     ScriptEntry TwinleafTown_Guitarist
-    ScriptEntry TwinleafTown_RivalWasLookingForYouTrigger
+    ScriptEntry TwinleafTown_CoordEvent_RivalWasLookingForYou
     ScriptEntry TwinleafTown_Collector
     ScriptEntry TwinleafTown_BreederF
-    ScriptEntry TwinleafTown_MapSign
-    ScriptEntry TwinleafTown_LandmarkSignPlayerMailbox
-    ScriptEntry TwinleafTown_LandmarkSignRivalMailbox
+    ScriptEntry TwinleafTown_MapSignpost
+    ScriptEntry TwinleafTown_MailboxPlayer
+    ScriptEntry TwinleafTown_MailboxRival
     ScriptEntryEnd
 
 TwinleafTown_OnTransition:
@@ -71,7 +71,7 @@ TwinleafTown_RivalWentTearingOff:
     ReleaseAll
     End
 
-TwinleafTown_RivalWasLookingForYouTrigger:
+TwinleafTown_CoordEvent_RivalWasLookingForYou:
     LockAll
     ApplyMovement LOCALID_GUITARIST, TwinleafTown_Movement_GuitaristNoticePlayer
     WaitMovement
@@ -386,7 +386,7 @@ TwinleafTown_Movement_GuitaristWalkBackX115:
     WalkNormalSouth 2
     EndMovement
 
-TwinleafTown_RivalThudTrigger:
+TwinleafTown_CoordEvent_RivalThud:
     LockAll
     LoadDoorAnimation 3, 27, 9, 11, ANIMATION_TAG_DOOR_1
     PlayDoorOpenAnimation ANIMATION_TAG_DOOR_1
@@ -498,16 +498,16 @@ TwinleafTown_PokemonYouLookGoodTogether:
     ReleaseAll
     End
 
-TwinleafTown_MapSign:
+TwinleafTown_MapSignpost:
     ShowMapSign TwinleafTown_Text_MapSign
     End
 
-TwinleafTown_LandmarkSignPlayerMailbox:
+TwinleafTown_MailboxPlayer:
     BufferPlayerName 0
     ShowLandmarkSign TwinleafTown_Text_PlayerMailbox
     End
 
-TwinleafTown_LandmarkSignRivalMailbox:
+TwinleafTown_MailboxRival:
     BufferRivalName 0
     ShowLandmarkSign TwinleafTown_Text_RivalMailbox
     End

--- a/res/field/scripts/scripts_twinleaf_town_player_house_1f.s
+++ b/res/field/scripts/scripts_twinleaf_town_player_house_1f.s
@@ -7,7 +7,7 @@
     ScriptEntry TwinleafTownPlayerHouse1F_OnFrame_RivalAlreadyLeft
     ScriptEntry TwinleafTownPlayerHouse1F_OnFrame_CutsceneAfterRivalBattle
     ScriptEntry TwinleafTownPlayerHouse1F_Mom
-    ScriptEntry TwinleafTownPlayerHouse1F_DontGoIntoTheTallGrassTrigger
+    ScriptEntry TwinleafTownPlayerHouse1F_CoordEvent_DontGoIntoTheTallGrass
     ScriptEntry TwinleafTownPlayerHouse1F_RivalsMom
     ScriptEntry TwinleafTownPlayerHouse1F_TV
     ScriptEntry TwinleafTownPlayerHouse1F_Fridge
@@ -733,7 +733,7 @@ TwinleafTownPlayerHouse1F_Movement_PlayerWatchRivalsMomLeaveEast:
     WalkOnSpotNormalSouth
     EndMovement
 
-TwinleafTownPlayerHouse1F_DontGoIntoTheTallGrassTrigger:
+TwinleafTownPlayerHouse1F_CoordEvent_DontGoIntoTheTallGrass:
     LockAll
     GoTo TwinleafTownPlayerHouse1F_PlayerAndMomFaceEachOther
     End

--- a/res/field/scripts/scripts_twinleaf_town_player_house_2f.s
+++ b/res/field/scripts/scripts_twinleaf_town_player_house_2f.s
@@ -6,13 +6,13 @@
     ScriptEntry TwinleafTownPlayerHouse2F_Wii
     ScriptEntry TwinleafTownPlayerHouse2F_PC
     ScriptEntry TwinleafTownPlayerHouse2F_OnFrame_ConcludeSpecialProgram
-    ScriptEntry TwinleafTownPlayerHouse2F_ScrollingSign
+    ScriptEntry TwinleafTownPlayerHouse2F_ScrollingSignpost
     ScriptEntry TwinleafTownPlayerHouse2F_OnTransition
     ScriptEntry TwinleafTownPlayerHouse2F_TV
-    ScriptEntry TwinleafTownPlayerHouse2F_RivalTriggerNorth
-    ScriptEntry TwinleafTownPlayerHouse2F_RivalTriggerWest
-    ScriptEntry TwinleafTownPlayerHouse2F_RivalTriggerEast
-    ScriptEntry TwinleafTownPlayerHouse2F_RivalTriggerSouth
+    ScriptEntry TwinleafTownPlayerHouse2F_CoordEvent_RivalNorth
+    ScriptEntry TwinleafTownPlayerHouse2F_CoordEvent_RivalWest
+    ScriptEntry TwinleafTownPlayerHouse2F_CoordEvent_RivalEast
+    ScriptEntry TwinleafTownPlayerHouse2F_CoordEvent_RivalSouth
     ScriptEntryEnd
 
 TwinleafTownPlayerHouse2F_OnTransition:
@@ -49,7 +49,7 @@ TwinleafTownPlayerHouse2F_PC:
     ReleaseAll
     End
 
-TwinleafTownPlayerHouse2F_ScrollingSign:
+TwinleafTownPlayerHouse2F_ScrollingSignpost:
     ShowScrollingSign TwinleafTownPlayerHouse2F_Text_TheXButtonOpensTheMenu
     End
 
@@ -57,22 +57,22 @@ TwinleafTownPlayerHouse2F_TV:
     EventMessage TwinleafTownPlayerHouse2F_Text_MomBoughThisTVAsAGift
     End
 
-TwinleafTownPlayerHouse2F_RivalTriggerNorth:
+TwinleafTownPlayerHouse2F_CoordEvent_RivalNorth:
     SetVar VAR_MAP_LOCAL_0, 0
     GoTo TwinleafTownPlayerHouse2F_Rival
     End
 
-TwinleafTownPlayerHouse2F_RivalTriggerWest:
+TwinleafTownPlayerHouse2F_CoordEvent_RivalWest:
     SetVar VAR_MAP_LOCAL_0, 1
     GoTo TwinleafTownPlayerHouse2F_Rival
     End
 
-TwinleafTownPlayerHouse2F_RivalTriggerEast:
+TwinleafTownPlayerHouse2F_CoordEvent_RivalEast:
     SetVar VAR_MAP_LOCAL_0, 2
     GoTo TwinleafTownPlayerHouse2F_Rival
     End
 
-TwinleafTownPlayerHouse2F_RivalTriggerSouth:
+TwinleafTownPlayerHouse2F_CoordEvent_RivalSouth:
     SetVar VAR_MAP_LOCAL_0, 3
     GoTo TwinleafTownPlayerHouse2F_Rival
     End

--- a/res/field/scripts/scripts_unused_battle_park.s
+++ b/res/field/scripts/scripts_unused_battle_park.s
@@ -3,10 +3,10 @@
 #include "res/field/events/events_unused_battle_park.h"
 
 
-    ScriptEntry BattlePark_TriggerPalmerRival
+    ScriptEntry BattlePark_CoordEvent_PalmerRival
     ScriptEntry BattlePark_Unused2
-    ScriptEntry BattlePark_SignExchangeServiceCorner
-    ScriptEntry BattlePark_SignBattleTower
+    ScriptEntry BattlePark_SignboardExchangeServiceCorner
+    ScriptEntry BattlePark_SignboardBattleTower
     ScriptEntry BattlePark_Beauty
     ScriptEntry BattlePark_SchoolKidM
     ScriptEntry BattlePark_ExpertF
@@ -17,7 +17,7 @@
     ScriptEntry BattlePark_BlackBelt
     ScriptEntryEnd
 
-BattlePark_TriggerPalmerRival:
+BattlePark_CoordEvent_PalmerRival:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     CallIfEq VAR_0x8004, 23, BattlePark_SetPalmerRivalPositionX23
@@ -246,11 +246,11 @@ BattlePark_BlackBelt:
     NPCMessage BattlePark_Text_HookUpWithBeauty
     End
 
-BattlePark_SignExchangeServiceCorner:
+BattlePark_SignboardExchangeServiceCorner:
     ShowLandmarkSign BattlePark_Text_SignExchangeServiceCorner
     End
 
-BattlePark_SignBattleTower:
+BattlePark_SignboardBattleTower:
     ShowLandmarkSign BattlePark_Text_SignBattleTower
     End
 

--- a/res/field/scripts/scripts_valley_windworks_building.s
+++ b/res/field/scripts/scripts_valley_windworks_building.s
@@ -4,9 +4,9 @@
 
 
     ScriptEntry ValleyWindworksBuilding_OnTransition
-    ScriptEntry ValleyWindworksBuilding_OnFrameFirstEntry
+    ScriptEntry ValleyWindworksBuilding_OnFrame_FirstEntry
     ScriptEntry ValleyWindworksBuilding_GruntM
-    ScriptEntry ValleyWindworksBuilding_TriggerMars
+    ScriptEntry ValleyWindworksBuilding_CoordEvent_Mars
     ScriptEntry ValleyWindworksBuilding_ScientistPapa
     ScriptEntry ValleyWindworksBuilding_Twin
     ScriptEntry ValleyWindworksBuilding_PCWest
@@ -27,7 +27,7 @@ ValleyWindworksBuilding_SetLittleGirlAndScientistPapaPositions:
     SetObjectEventMovementType LOCALID_SCIENTIST_PAPA, MOVEMENT_TYPE_LOOK_SOUTH
     End
 
-ValleyWindworksBuilding_OnFrameFirstEntry:
+ValleyWindworksBuilding_OnFrame_FirstEntry:
     LockAll
     ApplyMovement LOCALID_GALACTIC_GRUNT_1, ValleyWindworksBuilding_Movement_GalacticGrunt1NoticePlayer
     WaitMovement
@@ -61,7 +61,7 @@ ValleyWindworksBuilding_GruntM:
     NPCMessage ValleyWindworksBuilding_Text_HumphJustYouWaitOurCommanderWillSmooshYou
     End
 
-ValleyWindworksBuilding_TriggerMars:
+ValleyWindworksBuilding_CoordEvent_Mars:
     LockAll
     GetPlayerMapPos VAR_0x8004, VAR_0x8005
     GoToIfEq VAR_0x8005, 6, ValleyWindworksBuilding_MarsNoticeAndWalkToPlayer

--- a/res/field/scripts/scripts_valley_windworks_outside.s
+++ b/res/field/scripts/scripts_valley_windworks_outside.s
@@ -7,10 +7,10 @@
     ScriptEntry ValleyWindworksOutside_OnLoad
     ScriptEntry ValleyWindworksOutside_GruntM
     ScriptEntry ValleyWindworksOutside_Door
-    ScriptEntry ValleyWindworksOutside_LandmarkSignValleyWindworks
+    ScriptEntry ValleyWindworksOutside_SignboardValleyWindworks
     ScriptEntry ValleyWindworksOutside_Drifloon
     ScriptEntry ValleyWindworksOutside_OnResume
-    ScriptEntry ValleyWindworksOutside_OnFrameLooker
+    ScriptEntry ValleyWindworksOutside_OnFrame_Looker
     ScriptEntryEnd
 
 ValleyWindworksOutside_OnResume:
@@ -130,7 +130,7 @@ ValleyWindworksOutside_AskOpenDoorEnd:
     ReleaseAll
     End
 
-ValleyWindworksOutside_LandmarkSignValleyWindworks:
+ValleyWindworksOutside_SignboardValleyWindworks:
     ShowLandmarkSign ValleyWindworksOutside_Text_ValleyWindworksEcologicalWindDrivenEnergy
     End
 
@@ -156,7 +156,7 @@ ValleyWindworksOutside_BlackOutDrifloon:
     ReleaseAll
     End
 
-ValleyWindworksOutside_OnFrameLooker:
+ValleyWindworksOutside_OnFrame_Looker:
     LockAll
     ApplyMovement LOCALID_LOOKER, ValleyWindworksOutside_Movement_LookerNoticeAndWalkToPlayer
     ApplyMovement LOCALID_PLAYER, ValleyWindworksOutside_Movement_PlayerFaceLookerWest

--- a/res/field/scripts/scripts_valor_lakefront.s
+++ b/res/field/scripts/scripts_valor_lakefront.s
@@ -9,9 +9,9 @@
     ScriptEntry ValorLakefront_CameramanSouth
     ScriptEntry ValorLakefront_Beauty
     ScriptEntry ValorLakefront_CameramanNorth
-    ScriptEntry ValorLakefront_SignSevenStarsRestaurant
+    ScriptEntry ValorLakefront_SignboardSevenStarsRestaurant
     ScriptEntry ValorLakefront_Collector
-    ScriptEntry ValorLakefront_TriggerBlockSunyshore
+    ScriptEntry ValorLakefront_CoordEvent_BlockSunyshore
     ScriptEntryEnd
 
 ValorLakefront_OnTransition:
@@ -505,7 +505,7 @@ ValorLakefront_Movement_WalkNorth:
     WalkNormalNorth
     EndMovement
 
-ValorLakefront_SignSevenStarsRestaurant:
+ValorLakefront_SignboardSevenStarsRestaurant:
     ShowLandmarkSign ValorLakefront_Text_SignSevenStarsRestaurant
     End
 
@@ -513,7 +513,7 @@ ValorLakefront_Collector:
     NPCMessage ValorLakefront_Text_SunyshoreHadBlackout2
     End
 
-ValorLakefront_TriggerBlockSunyshore:
+ValorLakefront_CoordEvent_BlockSunyshore:
     LockAll
     ApplyMovement LOCALID_COLLECTOR, ValorLakefront_Movement_CollectorExclamationMark
     WaitMovement

--- a/res/field/scripts/scripts_veilstone_city.s
+++ b/res/field/scripts/scripts_veilstone_city.s
@@ -12,26 +12,26 @@
     ScriptEntry VeilstoneCity_Roughneck2
     ScriptEntry VeilstoneCity_Lady
     ScriptEntry VeilstoneCity_BattleGirl2
-    ScriptEntry VeilstoneCity_TriggerGruntBlockWarehouse
+    ScriptEntry VeilstoneCity_CoordEvent_GruntBlockWarehouse
     ScriptEntry VeilstoneCity_GruntMWarehouseNorth
     ScriptEntry VeilstoneCity_GruntMWarehouseSouth
     ScriptEntry VeilstoneCity_GruntMStorageKey
     ScriptEntry VeilstoneCity_GruntMSoutheast
-    ScriptEntry VeilstoneCity_TriggerCrasherWake
+    ScriptEntry VeilstoneCity_CoordEvent_CrasherWake
     ScriptEntry VeilstoneCity_Counterpart
-    ScriptEntry VeilstoneCity_MapSign
-    ScriptEntry VeilstoneCity_GymSign
-    ScriptEntry VeilstoneCity_SignGalacticWarehouse
-    ScriptEntry VeilstoneCity_SignGalacticBuilding
-    ScriptEntry VeilstoneCity_SignDepartmentStore
-    ScriptEntry VeilstoneCity_SignGameCorner
-    ScriptEntry VeilstoneCity_SignPrizeExchange
-    ScriptEntry VeilstoneCity_SignLakeValor
+    ScriptEntry VeilstoneCity_MapSignpost
+    ScriptEntry VeilstoneCity_GymSignpost
+    ScriptEntry VeilstoneCity_SignboardGalacticWarehouse
+    ScriptEntry VeilstoneCity_SignboardGalacticBuilding
+    ScriptEntry VeilstoneCity_SignboardDepartmentStore
+    ScriptEntry VeilstoneCity_SignboardGameCorner
+    ScriptEntry VeilstoneCity_SignboardPrizeExchange
+    ScriptEntry VeilstoneCity_SignboardLakeValor
     ScriptEntry VeilstoneCity_DeoxysMeteoriteSpeed
     ScriptEntry VeilstoneCity_DeoxysMeteoriteDefense
     ScriptEntry VeilstoneCity_DeoxysMeteoriteAttack
     ScriptEntry VeilstoneCity_DeoxysMeteoriteNormal
-    ScriptEntry VeilstoneCity_OnFrameCounterpartNeedsHelp
+    ScriptEntry VeilstoneCity_OnFrame_CounterpartNeedsHelp
     ScriptEntry VeilstoneCity_Looker
     ScriptEntry VeilstoneCity_Guitarist3
     ScriptEntry VeilstoneCity_BattleGirl3
@@ -65,7 +65,7 @@ VeilstoneCity_SetLookerPositionAtGalacticBuilding:
     SetObjectEventDir LOCALID_LOOKER, DIR_NORTH
     Return
 
-VeilstoneCity_TriggerCrasherWake:
+VeilstoneCity_CoordEvent_CrasherWake:
     LockAll
     ApplyMovement LOCALID_COUNTERPART, VeilstoneCity_Movement_CounterpartNoticePlayerBeforeGym
     WaitMovement
@@ -991,7 +991,7 @@ VeilstoneCity_BattleGirl2:
     NPCMessage VeilstoneCity_Text_IBoughtANewParasol
     End
 
-VeilstoneCity_TriggerGruntBlockWarehouse:
+VeilstoneCity_CoordEvent_GruntBlockWarehouse:
     LockAll
     ApplyMovement LOCALID_GRUNT_M_WAREHOUSE_NORTH, VeilstoneCity_Grunt_FaceSouth
     ApplyMovement LOCALID_PLAYER, VeilstoneCity_Player_FaceNorth
@@ -1247,35 +1247,35 @@ VeilstoneCity_GruntMSoutheast:
     NPCMessage VeilstoneCity_Text_WeHaveHMFlyInWarehouse
     End
 
-VeilstoneCity_MapSign:
+VeilstoneCity_MapSignpost:
     ShowMapSign VeilstoneCity_Text_MapSign
     End
 
-VeilstoneCity_GymSign:
+VeilstoneCity_GymSignpost:
     ShowScrollingSign VeilstoneCity_Text_SignPokemonGym
     End
 
-VeilstoneCity_SignGalacticWarehouse:
+VeilstoneCity_SignboardGalacticWarehouse:
     ShowLandmarkSign VeilstoneCity_Text_SignGalacticWarehouse
     End
 
-VeilstoneCity_SignGalacticBuilding:
+VeilstoneCity_SignboardGalacticBuilding:
     ShowLandmarkSign VeilstoneCity_Text_SignGalacticVeilstoneBuilding
     End
 
-VeilstoneCity_SignDepartmentStore:
+VeilstoneCity_SignboardDepartmentStore:
     ShowLandmarkSign VeilstoneCity_Text_SignVeilstoneDepartmentStore
     End
 
-VeilstoneCity_SignGameCorner:
+VeilstoneCity_SignboardGameCorner:
     ShowLandmarkSign VeilstoneCity_Text_SignVeilstoneGameCorner
     End
 
-VeilstoneCity_SignPrizeExchange:
+VeilstoneCity_SignboardPrizeExchange:
     ShowLandmarkSign VeilstoneCity_Text_SignPrizeExchange
     End
 
-VeilstoneCity_SignLakeValor:
+VeilstoneCity_SignboardLakeValor:
     ShowLandmarkSign VeilstoneCity_Text_SignLakeValor
     End
 
@@ -1342,7 +1342,7 @@ VeilstoneCity_MeteoriteFromTheStars:
     ReleaseAll
     End
 
-VeilstoneCity_OnFrameCounterpartNeedsHelp:
+VeilstoneCity_OnFrame_CounterpartNeedsHelp:
     LockAll
     ApplyMovement LOCALID_COUNTERPART, VeilstoneCity_Movement_CounterpartNoticePlayerAfterGym
     WaitMovement

--- a/res/field/scripts/scripts_veilstone_city_galactic_warehouse.s
+++ b/res/field/scripts/scripts_veilstone_city_galactic_warehouse.s
@@ -4,10 +4,10 @@
 
 
     ScriptEntry VeilstoneCityGalacticWarehouse_GalacticHQDoor
-    ScriptEntry VeilstoneCityGalacticWarehouse_OnFrameEnterWithLooker
+    ScriptEntry VeilstoneCityGalacticWarehouse_OnFrame_EnterWithLooker
     ScriptEntry VeilstoneCityGalacticWarehouse_Looker
     ScriptEntry VeilstoneCityGalacticWarehouse_OnTransition
-    ScriptEntry VeilstoneCityGalacticWarehouse_TriggerLookerOpenDoor
+    ScriptEntry VeilstoneCityGalacticWarehouse_CoordEvent_LookerOpenDoor
     ScriptEntryEnd
 
 VeilstoneCityGalacticWarehouse_OnTransition:
@@ -71,7 +71,7 @@ VeilstoneCityGalacticWarehouse_Movement_GalacticHQDoorEastOpen:
     WalkFastEast
     EndMovement
 
-VeilstoneCityGalacticWarehouse_OnFrameEnterWithLooker:
+VeilstoneCityGalacticWarehouse_OnFrame_EnterWithLooker:
     LockAll
     ApplyMovement LOCALID_LOOKER, VeilstoneCityGalacticWarehouse_Movement_LookerWalkToDoor
     WaitMovement
@@ -135,7 +135,7 @@ VeilstoneCityGalacticWarehouse_Looker:
     NPCMessage VeilstoneCityGalacticWarehouse_Text_GalacticTransportedToPastoria
     End
 
-VeilstoneCityGalacticWarehouse_TriggerLookerOpenDoor:
+VeilstoneCityGalacticWarehouse_CoordEvent_LookerOpenDoor:
     LockAll
     SetObjectEventPos LOCALID_LOOKER, 8, 11
     SetObjectEventMovementType LOCALID_LOOKER, MOVEMENT_TYPE_LOOK_NORTH

--- a/res/field/scripts/scripts_veilstone_store_1f.s
+++ b/res/field/scripts/scripts_veilstone_store_1f.s
@@ -9,7 +9,7 @@
     ScriptEntry VeilstoneStore1F_Lady
     ScriptEntry VeilstoneStore1F_RightVendor
     ScriptEntry VeilstoneStore1F_LeftVendor
-    ScriptEntry VeilstoneStore1F_Sign
+    ScriptEntry VeilstoneStore1F_BgSign
     ScriptEntry VeilstoneStore1F_Directory
     ScriptEntry VeilstoneStore1F_Socialite
     ScriptEntryEnd
@@ -34,7 +34,7 @@ VeilstoneStore1F_LeftVendor:
     PokeMartSpecialtiesWithGreeting MART_SPECIALTIES_ID_VEILSTONE_1F_LEFT
     End
 
-VeilstoneStore1F_Sign:
+VeilstoneStore1F_BgSign:
     EventMessage VeilstoneStore1F_Text_DiscoverANewYou
     End
 

--- a/res/field/scripts/scripts_verity_lakefront.s
+++ b/res/field/scripts/scripts_verity_lakefront.s
@@ -4,7 +4,7 @@
 
     ScriptEntry VerityLakefront_OnLoad
     ScriptEntry VerityLakefront_OnTransition
-    ScriptEntry VerityLakefront_TriggerWereAtTheLake
+    ScriptEntry VerityLakefront_CoordEvent_WereAtTheLake
     ScriptEntry VerityLakefront_TrainerTipsSignpost
     ScriptEntryEnd
 
@@ -28,7 +28,7 @@ VerityLakefront_OnTransition:
     GoToIfSet FLAG_DEFEATED_COMMANDER_SATURN_VALOR_CAVERN, VerityLakefront_RemoveWarpsLakeVerityLowWater
     End
 
-VerityLakefront_TriggerWereAtTheLake:
+VerityLakefront_CoordEvent_WereAtTheLake:
     LockAll
     ApplyMovement LOCALID_FOLLOWER, VerityLakefront_Movement_RivalWalkOnSpotNorth
     ApplyMovement LOCALID_PLAYER, VerityLakefront_Movement_PlayerFaceRival

--- a/res/field/scripts/scripts_victory_road_1f_room_2.s
+++ b/res/field/scripts/scripts_victory_road_1f_room_2.s
@@ -3,9 +3,9 @@
 #include "res/field/events/events_victory_road_1f_room_2.h"
 
 
-    ScriptEntry VictoryRoad1FRoom2_TriggerStartFollowingMarley
-    ScriptEntry VictoryRoad1FRoom2_TriggerPlayerLeaveMarley
-    ScriptEntry VictoryRoad1FRoom2_TriggerMarleyLeavePlayer
+    ScriptEntry VictoryRoad1FRoom2_CoordEvent_StartFollowingMarley
+    ScriptEntry VictoryRoad1FRoom2_CoordEvent_PlayerLeaveMarley
+    ScriptEntry VictoryRoad1FRoom2_CoordEvent_MarleyLeavePlayer
     ScriptEntry VictoryRoad1FRoom2_OnTransition
     ScriptEntryEnd
 
@@ -17,7 +17,7 @@ VictoryRoad1FRoom2_ResetFollowerMarleyState:
     SetVar VAR_VICTORY_ROAD_1F_ROOM_2_FOLLOWER_MARLEY_STATE, 0
     End
 
-VictoryRoad1FRoom2_TriggerStartFollowingMarley:
+VictoryRoad1FRoom2_CoordEvent_StartFollowingMarley:
     LockAll
     SetPlayerBike FALSE
     ApplyMovement LOCALID_MARLEY, VictoryRoad1FRoom2_Movement_MarleyNoticePlayer
@@ -129,7 +129,7 @@ VictoryRoad1FRoom2_Movement_MarleyWalkToPlayerZ60:
     WalkNormalWest
     EndMovement
 
-VictoryRoad1FRoom2_TriggerPlayerLeaveMarley:
+VictoryRoad1FRoom2_CoordEvent_PlayerLeaveMarley:
     LockAll
     ApplyMovement LOCALID_PLAYER, VictoryRoad1FRoom2_Movement_PlayerWalkOnSpotEast
     ApplyMovement LOCALID_MARLEY, VictoryRoad1FRoom2_Movement_MarleyFaceWest
@@ -236,7 +236,7 @@ VictoryRoad1FRoom2_Movement_MarleyFaceWest:
     FaceWest
     EndMovement
 
-VictoryRoad1FRoom2_TriggerMarleyLeavePlayer:
+VictoryRoad1FRoom2_CoordEvent_MarleyLeavePlayer:
     LockAll
     ClearHasPartner
     SetMovementType LOCALID_MARLEY, MOVEMENT_TYPE_LOOK_NORTH

--- a/res/field/scripts/scripts_villa.s
+++ b/res/field/scripts/scripts_villa.s
@@ -19,10 +19,10 @@
     ScriptEntry Villa_Cynthia
     ScriptEntry Villa_Flint
     ScriptEntry Villa_MayleneAndCandice
-    ScriptEntry Villa_TriggerFantina
-    ScriptEntry Villa_TriggerCrasherWake
-    ScriptEntry Villa_TriggerCandice
-    ScriptEntry Villa_TriggerCynthia
+    ScriptEntry Villa_CoordEvent_Fantina
+    ScriptEntry Villa_CoordEvent_CrasherWake
+    ScriptEntry Villa_CoordEvent_Candice
+    ScriptEntry Villa_CoordEvent_Cynthia
     ScriptEntry Villa_Furniture_Table
     ScriptEntry Villa_Furniture_BigSofa
     ScriptEntry Villa_Furniture_SmallSofa
@@ -43,9 +43,9 @@
     ScriptEntry Villa_Furniture_Masterpiece
     ScriptEntry Villa_Furniture_TeaSet
     ScriptEntry Villa_Furniture_Chandelier
-    ScriptEntry Villa_OnFrameFirstEntry
+    ScriptEntry Villa_OnFrame_FirstEntry
     ScriptEntry Villa_SchoolKidM
-    ScriptEntry Villa_TriggerDontGoYet
+    ScriptEntry Villa_CoordEvent_DontGoYet
     ScriptEntry Villa_OrderForm
     ScriptEntryEnd
 
@@ -795,7 +795,7 @@ Villa_VisitorEnd:
     ReleaseAll
     End
 
-Villa_TriggerFantina:
+Villa_CoordEvent_Fantina:
     LockAll
     PlaySE SEQ_SE_DP_DOOR_OPEN
     ClearFlag FLAG_HIDE_VILLA_FANTINA
@@ -826,7 +826,7 @@ Villa_Movement_FantinaEnter:
     WalkNormalWest 3
     EndMovement
 
-Villa_TriggerCrasherWake:
+Villa_CoordEvent_CrasherWake:
     LockAll
     PlaySE SEQ_SE_DP_DOOR_OPEN
     ClearFlag FLAG_HIDE_VILLA_CRASHER_WAKE
@@ -855,7 +855,7 @@ Villa_Movement_PlayerWatchWakeEnter:
     WalkOnSpotNormalEast
     EndMovement
 
-Villa_TriggerCandice:
+Villa_CoordEvent_Candice:
     LockAll
     PlaySE SEQ_SE_DP_DOOR_OPEN
     ClearFlag FLAG_HIDE_VILLA_CANDICE
@@ -886,7 +886,7 @@ Villa_Movement_PlayerWatchCandiceEnter:
     WalkOnSpotNormalWest
     EndMovement
 
-Villa_TriggerCynthia:
+Villa_CoordEvent_Cynthia:
     LockAll
     PlaySE SEQ_SE_DP_DOOR_OPEN
     ClearFlag FLAG_HIDE_VILLA_CYNTHIA
@@ -1099,7 +1099,7 @@ Villa_Furniture_End:
     ReleaseAll
     End
 
-Villa_OnFrameFirstEntry:
+Villa_OnFrame_FirstEntry:
     LockAll
     SetVar VAR_VILLA_STATE, 1
     ShowMoney 21, 1
@@ -1534,7 +1534,7 @@ Villa_TryEnterFurnitureVisitor:
     CallIfEq VAR_0x8002, VILLA_FURNITURE_PIANO, Villa_EnterPianoCynthia
     Return
 
-Villa_TriggerDontGoYet:
+Villa_CoordEvent_DontGoYet:
     LockAll
     ApplyMovement LOCALID_SCHOOL_KID_M, Villa_Movement_SchoolKidMWalkOnSpotSouth
     WaitMovement

--- a/res/field/scripts/scripts_wayward_cave_1f.s
+++ b/res/field/scripts/scripts_wayward_cave_1f.s
@@ -6,7 +6,7 @@
     ScriptEntry WaywardCave1F_OnTransition
     ScriptEntry WaywardCave1F_Mira
     ScriptEntry WaywardCave1F_Unused
-    ScriptEntry WaywardCave1F_TriggerExit
+    ScriptEntry WaywardCave1F_CoordEvent_Exit
     ScriptEntryEnd
 
 WaywardCave1F_OnTransition:
@@ -79,7 +79,7 @@ WaywardCave1F_IncreaseFollowerMiraTimesTalked:
 WaywardCave1F_Unused:
     End
 
-WaywardCave1F_TriggerExit:
+WaywardCave1F_CoordEvent_Exit:
     LockAll
     ClearHasPartner
     SetMovementType LOCALID_MIRA, MOVEMENT_TYPE_LOOK_WEST


### PR DESCRIPTION
This PR fully standardizes the names of init, sign, and coord event script entries. The updated and now fully implemented standards are:
- `[Map]_On[Resume/Load/Transition]` - was already standardized, no need for a description because there is at most one per map
- `[Map]_OnFrame_[Description]` - added `_` for readability
- `[Map]_CoordEvent_[Description]` - was previously `[Map]_Trigger[Description]` or `[Map]_[Description]Trigger` but `_CoordEvent_` better reflects the usage and again improves readability with the added `_`
- `[Map]_[SignType]Description` where `[SignType]` is one of the below. I didn't add a `_` here, this could be added but feels more optional in this case.
   - `ArrowSignpost` - always fully `Signpost` instead of `Sign`
   - `TrainerTipsSignpost` - always fully include `Signpost` (previously sometimes left out)
   - `Signboard` - previously just denoted as `Sign`, `Signboard` reflects the local ids and graphic ids
   - `BgSign` - distinguishes that it's a bg event