### PR TITLE
Standardize dummy/unused script blocks/entries

### DIFF
--- a/res/field/scripts/scripts_amity_square.s
+++ b/res/field/scripts/scripts_amity_square.s
@@ -55,7 +55,7 @@
     ScriptEntry AmitySquare_Warp25
     ScriptEntry AmitySquare_Warp26
     ScriptEntry AmitySquare_Warp27
-    ScriptEntry AmitySquare_UnusedEntry45
+    ScriptEntry AmitySquare_Dummy45
     ScriptEntryEnd
 
 AmitySquare_OnTransition:
@@ -274,7 +274,7 @@ AmitySquare_Movement_WalkNorth:
     WalkNormalNorth
     EndMovement
 
-AmitySquare_UnusedMovement:
+AmitySquare_Movement_Unused:
     WalkFastestSouth 2
     FaceWest
     EndMovement
@@ -1325,7 +1325,7 @@ AmitySquare_SetPositionsWarp27:
     SetPosition LOCALID_FOLLOWER_MON, 33, 5, 7, DIR_SOUTH
     Return
 
-AmitySquare_UnusedEntry45:
+AmitySquare_Dummy45:
     LockAll
     SetVar VAR_AMITY_SQUARE_STATE, 0
     ReleaseAll

--- a/res/field/scripts/scripts_battle_arcade.s
+++ b/res/field/scripts/scripts_battle_arcade.s
@@ -503,13 +503,13 @@ BattleArcade_OnFrame_ChallengeEnded:
     GoTo BattleArcade_EndChallenge
     End
 
-BattleArcade_UnusedMovement:
+BattleArcade_Movement_Unused:
     WalkNormalNorth 2
     Delay8
     WalkNormalNorth
     EndMovement
 
-BattleArcade_UnusedMovement2:
+BattleArcade_Movement_Unused2:
     WalkNormalNorth 2
     Delay8
     WalkNormalNorth

--- a/res/field/scripts/scripts_battle_castle.s
+++ b/res/field/scripts/scripts_battle_castle.s
@@ -498,13 +498,13 @@ BattleCastle_OnFrame_ChallengeEnded:
     GoTo BattleCastle_EndChallenge
     End
 
-BattleCastle_UnusedMovement:
+BattleCastle_Movement_Unused:
     WalkNormalNorth 2
     Delay8
     WalkNormalNorth
     EndMovement
 
-BattleCastle_UnusedMovement2:
+BattleCastle_Movement_Unused2:
     WalkNormalNorth 2
     Delay8
     WalkNormalNorth

--- a/res/field/scripts/scripts_battle_factory.s
+++ b/res/field/scripts/scripts_battle_factory.s
@@ -456,13 +456,13 @@ BattleFactory_OnFrame_ChallengeEnded:
     End
 
     .balign 4, 0
-BattleFactory_UnusedMovement:
+BattleFactory_Movement_Unused:
     WalkNormalNorth 2
     Delay8
     WalkNormalNorth
     EndMovement
 
-BattleFactory_UnusedMovement2:
+BattleFactory_Movement_Unused2:
     WalkNormalNorth 2
     Delay8
     WalkNormalNorth

--- a/res/field/scripts/scripts_battle_frontier.s
+++ b/res/field/scripts/scripts_battle_frontier.s
@@ -3,7 +3,7 @@
 #include "res/field/events/events_battle_frontier.h"
 
 
-    ScriptEntry BattleFrontier_Unused1
+    ScriptEntry BattleFrontier_Dummy1
     ScriptEntry BattleFrontier_NinjaBoy
     ScriptEntry BattleFrontier_BlackBelt
     ScriptEntry BattleFrontier_Idol
@@ -26,7 +26,7 @@
     ScriptEntry BattleFrontier_Fisherman
     ScriptEntry BattleFrontier_TuberM
     ScriptEntry BattleFrontier_AttendantSouthwest
-    ScriptEntry BattleFrontier_Unused24
+    ScriptEntry BattleFrontier_ScratchOffCards_Unused
     ScriptEntry BattleFrontier_AttendantSoutheast
     ScriptEntry BattleFrontier_TrainerTipsSignpostBattleTower
     ScriptEntry BattleFrontier_TrainerTipsSignpostBattleHall
@@ -152,7 +152,7 @@ BattleFrontier_AttendantSouthwest:
     ReleaseAll
     End
 
-BattleFrontier_Unused24:
+BattleFrontier_ScratchOffCards_Unused:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     FacePlayer
@@ -275,7 +275,7 @@ BattleFrontier_Movement_PlayerEnterBattleFactory:
     WalkFastEast 6
     EndMovement
 
-BattleFrontier_Unused1:
+BattleFrontier_Dummy1:
     End
 
     .balign 4, 0

--- a/res/field/scripts/scripts_battle_hall.s
+++ b/res/field/scripts/scripts_battle_hall.s
@@ -626,13 +626,13 @@ BattleHall_OnFrame_ChallengeEnded:
     GoTo BattleHall_EndChallenge
     End
 
-BattleHall_UnusedMovement:
+BattleHall_Movement_Unused:
     WalkNormalNorth 2
     Delay8
     WalkNormalNorth
     EndMovement
 
-BattleHall_UnusedMovement2:
+BattleHall_Movement_Unused2:
     WalkNormalNorth 2
     Delay8
     WalkNormalNorth

--- a/res/field/scripts/scripts_battle_tower.s
+++ b/res/field/scripts/scripts_battle_tower.s
@@ -13,9 +13,9 @@
     ScriptEntry BattleTower_OnFrame_DidntSaveBeforeQuit
     ScriptEntry BattleTower_Teala
     ScriptEntry BattleTower_OnFrame_QuitBattleSalon
-    ScriptEntry BattleTower_Unused9
-    ScriptEntry BattleTower_Unused10
-    ScriptEntry BattleTower_Unused11
+    ScriptEntry BattleTower_Dummy9
+    ScriptEntry BattleTower_ResultsMachine0_Unused
+    ScriptEntry BattleTower_ResultsMachine1_Unused
     ScriptEntry BattleTower_MachineWiFiResults
     ScriptEntry BattleTower_MachineWiFiLeaders
     ScriptEntry BattleTower_ParasolLady
@@ -1117,7 +1117,7 @@ BattleTower_Movement_PlayerFaceEast:
     FaceEast
     EndMovement
 
-BattleTower_Unused10:
+BattleTower_ResultsMachine0_Unused:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     SetVar VAR_0x8000, 0
@@ -1125,7 +1125,7 @@ BattleTower_Unused10:
     Call BattleTower_ResultsMachine
     End
 
-BattleTower_Unused11:
+BattleTower_ResultsMachine1_Unused:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     SetVar VAR_0x8000, 0
@@ -1196,7 +1196,7 @@ BattleTower_SchoolKidM1:
     NPCMessage BattleTower_Text_ManyToughTrainers
     End
 
-BattleTower_Unused9:
+BattleTower_Dummy9:
     End
 
 BattleTower_Pikachu2:

--- a/res/field/scripts/scripts_battle_tower_battle_room.s
+++ b/res/field/scripts/scripts_battle_tower_battle_room.s
@@ -8,7 +8,7 @@
     ScriptEntry BattleTowerBattleRoom_OnTransition
     ScriptEntry BattleTowerBattleRoom_OnFrame_StartChallenge
     ScriptEntry BattleTowerBattleRoom_OnFrame_ResumeChallenge
-    ScriptEntry BattleTowerBattleRoom_Unused4
+    ScriptEntry BattleTowerBattleRoom_OpponentEnterAndBattle_Unused
     ScriptEntry BattleTowerBattleRoom_OnResume
     ScriptEntryEnd
 
@@ -29,7 +29,7 @@ BattleTowerBattleRoom_SetPlayerPositionForBattle:
     SetPosition LOCALID_BT_PLAYER, 5, 0, 6, DIR_EAST
     End
 
-BattleTowerBattleRoom_Unused4:
+BattleTowerBattleRoom_OpponentEnterAndBattle_Unused:
     SetVar VAR_BATTLE_TOWER_BATTLE_ROOM_LOAD_ACTION, 0
     PlaySE SEQ_SE_CONFIRM
     LockAll
@@ -300,7 +300,7 @@ BattleTowerBattleRoom_PalmerEnter:
     WaitMovement
     Return
 
-BattleTowerBattleRoom_UnusedMovement:
+BattleTowerBattleRoom_Movement_Unused:
     Delay4
     FaceWest
     WalkNormalWest 5

--- a/res/field/scripts/scripts_battle_tower_elevator.s
+++ b/res/field/scripts/scripts_battle_tower_elevator.s
@@ -106,7 +106,7 @@ BattleTowerElevator_Exit:
     WaitMovement
     Return
 
-BattleTowerElevator_UnusedMovement:
+BattleTowerElevator_Movement_Unused:
     WalkNormalNorth 2
     FaceEast
     WalkNormalEast

--- a/res/field/scripts/scripts_canalave_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_canalave_city_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry CanalaveCityPokecenter2F_UnusedEntry1
+    ScriptEntry CanalaveCityPokecenter2F_Dummy1
     ScriptEntryEnd
 
-CanalaveCityPokecenter2F_UnusedEntry1:
+CanalaveCityPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_canalave_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_canalave_city_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry CanalaveCityPokecenterB1F_UnusedEntry1
+    ScriptEntry CanalaveCityPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-CanalaveCityPokecenterB1F_UnusedEntry1:
+CanalaveCityPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_canalave_city_west_house.s
+++ b/res/field/scripts/scripts_canalave_city_west_house.s
@@ -1,7 +1,7 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry CanalaveCityWestHouse_Unused
+    ScriptEntry CanalaveCityWestHouse_Dummy1
     ScriptEntry CanalaveCityWestHouse_OnTransition
     ScriptEntryEnd
 
@@ -15,7 +15,7 @@ CanalaveCityWestHouse_HideReporter:
     SetFlag FLAG_HIDE_CANALAVE_CITY_WEST_HOUSE_REPORTER
     End
 
-CanalaveCityWestHouse_Unused:
+CanalaveCityWestHouse_Dummy1:
     End
 
     .balign 4, 0

--- a/res/field/scripts/scripts_celestic_town.s
+++ b/res/field/scripts/scripts_celestic_town.s
@@ -169,12 +169,12 @@ CelesticTown_Movement_PlayerWatchElderEnterNorth:
     WalkOnSpotNormalEast
     EndMovement
 
-CelesticTown_UnusedMovement:
+CelesticTown_Movement_Unused:
     Delay8 8
     WalkOnSpotNormalSouth
     EndMovement
 
-CelesticTown_UnusedMovement2:
+CelesticTown_Movement_Unused2:
     Delay8 9
     WalkOnSpotNormalSouth
     EndMovement

--- a/res/field/scripts/scripts_celestic_town_cave.s
+++ b/res/field/scripts/scripts_celestic_town_cave.s
@@ -171,7 +171,7 @@ CelesticTownCave_PlayerElderFaceEachOtherX9South:
     Return
 
 CelesticTownCave_Unused:
-    ApplyMovement LOCALID_PLAYER, CelesticTownCave_UnusedMovement
+    ApplyMovement LOCALID_PLAYER, CelesticTownCave_Movement_Unused
     ApplyMovement LOCALID_ELDER, CelesticTownCave_Movement_ElderWalkOnSpotWest
     WaitMovement
     Return
@@ -190,7 +190,7 @@ CelesticTownCave_PlayerElderFaceEachOtherX10South:
     Return
 
 CelesticTownCave_Unused2:
-    ApplyMovement LOCALID_PLAYER, CelesticTownCave_UnusedMovement2
+    ApplyMovement LOCALID_PLAYER, CelesticTownCave_Movement_Unused2
     ApplyMovement LOCALID_ELDER, CelesticTownCave_Movement_ElderWalkOnSpotWest
     WaitMovement
     Return
@@ -303,7 +303,7 @@ CelesticTownCave_Movement_PlayerWalkNorthOnSpotEast:
     WalkOnSpotNormalEast
     EndMovement
 
-CelesticTownCave_UnusedMovement:
+CelesticTownCave_Movement_Unused:
     WalkNormalNorth 2
     WalkOnSpotNormalEast
     EndMovement
@@ -319,7 +319,7 @@ CelesticTownCave_Movement_PlayerWalkNorthOnSpotWest:
     WalkOnSpotNormalWest
     EndMovement
 
-CelesticTownCave_UnusedMovement2:
+CelesticTownCave_Movement_Unused2:
     WalkNormalNorth 2
     WalkOnSpotNormalWest
     EndMovement

--- a/res/field/scripts/scripts_celestic_town_northwest_house.s
+++ b/res/field/scripts/scripts_celestic_town_northwest_house.s
@@ -2,13 +2,13 @@
 #include "res/text/bank/celestic_town_northwest_house.h"
 
 
-    ScriptEntry CelesticTownNorthwestHouse_Unused
+    ScriptEntry CelesticTownNorthwestHouse_Vendor_Unused
     ScriptEntry CelesticTownNorthwestHouse_ExpertF
     ScriptEntry CelesticTownNorthwestHouse_ExpertM
     ScriptEntry CelesticTownNorthwestHouse_GymGuide
     ScriptEntryEnd
 
-CelesticTownNorthwestHouse_Unused:
+CelesticTownNorthwestHouse_Vendor_Unused:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     FacePlayer

--- a/res/field/scripts/scripts_celestic_town_pokecenter_2f.s
+++ b/res/field/scripts/scripts_celestic_town_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry CelesticCityPokecenter2F_UnusedEntry1
+    ScriptEntry CelesticCityPokecenter2F_Dummy1
     ScriptEntryEnd
 
-CelesticCityPokecenter2F_UnusedEntry1:
+CelesticCityPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_celestic_town_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_celestic_town_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry CelesticCityPokecenterB1F_UnusedEntry1
+    ScriptEntry CelesticCityPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-CelesticCityPokecenterB1F_UnusedEntry1:
+CelesticCityPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_common.s
+++ b/res/field/scripts/scripts_common.s
@@ -33,11 +33,11 @@
     ScriptEntry CommonScript_2004 @ 0x7D4
     ScriptEntry CommonScript_SaveAndStoreResult @ 0x7D5
     ScriptEntry CommonScript_SaveGame  @ 0x7D6
-    ScriptEntry CommonScript_EmptyScript2007 @ 0x7D7
+    ScriptEntry CommonScript_Dummy2007 @ 0x7D7
     ScriptEntry CommonScript_HoneyTree @ 0x7D8
     ScriptEntry CommonScript_ObtainPoketchApp @ 0x7D9
-    ScriptEntry CommonScript_EmptyScript2010 @ 0x7DA
-    ScriptEntry CommonScript_EmptyScript2011 @ 0x7DB
+    ScriptEntry CommonScript_Dummy2010 @ 0x7DA
+    ScriptEntry CommonScript_Dummy2011 @ 0x7DB
     ScriptEntry CommonScript_SendToUndergroundPC @ 0x7DC
     ScriptEntry CommonScript_ObtainUndergroundTrap @ 0x7DD
     ScriptEntry CommonScript_ObtainUndergroundSphere @ 0x7DE
@@ -48,9 +48,9 @@
     ScriptEntry CommonScript_VendorGreetingGeneric @ 0x7E3
     ScriptEntry CommonScript_PlayerHouseBlackOutRecover @ 0x7E4
     ScriptEntry CommonScript_PokecenterBlackOutRecover @ 0x7E5
-    ScriptEntry CommonScript_EmptyScript2022 @ 0x7E6
+    ScriptEntry CommonScript_Dummy2022 @ 0x7E6
     ScriptEntry CommonScript_2023 @ 0x7E7
-    ScriptEntry CommonScript_EmptyScript2024 @ 0x7E8
+    ScriptEntry CommonScript_Dummy2024 @ 0x7E8
     ScriptEntry CommonScript_Geonet @ 0x7E9
     ScriptEntry CommonScript_2026 @ 0x7EA
     ScriptEntry CommonScript_Vent @ 0x7EB
@@ -63,7 +63,7 @@
     ScriptEntry CommonScript_ImpossibleToSave @ 0x7F2
     ScriptEntry CommonScript_BlockPokecenterBasement @ 0x7F3
     ScriptEntry CommonScript_ObtainContestBackdropWaitForConfirm @ 0x7F4
-    ScriptEntry CommonScript_EmptyScript2037 @ 0x7F5
+    ScriptEntry CommonScript_Dummy2037 @ 0x7F5
     ScriptEntry CommonScript_PlateObtainedEngraving @ 0x7F6
     ScriptEntry CommonScript_TryUseAzureFlute @ 0x7F7
     ScriptEntry CommonScript_SetCounterpartBGM @ 0x7F8
@@ -86,10 +86,10 @@
     ScriptEntry CommonScript_GriseousOrbCouldNotBeRemoved @ 0x809
     ScriptEntryEnd
 
-CommonScript_EmptyScript2010:
+CommonScript_Dummy2010:
     End
 
-CommonScript_EmptyScript2007:
+CommonScript_Dummy2007:
     End
 
 CommonScript_PokecenterNurse:
@@ -682,7 +682,7 @@ CommonScript_ObtainedPoketchAlarmClock:
     Message CommonStrings_Text_ObtainedPoketchAlarmClock
     Return
 
-CommonScript_EmptyScript2011:
+CommonScript_Dummy2011:
     End
 
 CommonScript_SendToUndergroundPC:
@@ -1148,7 +1148,7 @@ CommonScript_PCFadeOut:
     UnloadAnimation ANIMATION_TAG_PC
     Return
 
-CommonScript_EmptyScript2022:
+CommonScript_Dummy2022:
     End
 
 CommonScript_2023:
@@ -1344,11 +1344,11 @@ CommonScript_Movement_NurseTurnToMachine:
     FaceWest
     EndMovement
 
-CommonScript_UnusedMovement:
+CommonScript_Movement_Unused:
     FaceNorth
     EndMovement
 
-CommonScript_UnusedMovement2:
+CommonScript_Movement_Unused2:
     FaceEast
     EndMovement
 
@@ -1357,7 +1357,7 @@ CommonScript_Movement_NurseTurnToPlayer:
     FaceSouth
     EndMovement
 
-CommonScript_EmptyScript2024:
+CommonScript_Dummy2024:
     End
 
 CommonScript_Geonet:
@@ -1515,7 +1515,7 @@ CommonScript_Engraving8PlatesObtained:
     Message CommonStrings_Text_Engraving8PlatesObtained
     Return
 
-CommonScript_EmptyScript2037:
+CommonScript_Dummy2037:
     End
 
 CommonScript_TryUseAzureFlute:

--- a/res/field/scripts/scripts_contest_hall_lobby.s
+++ b/res/field/scripts/scripts_contest_hall_lobby.s
@@ -127,7 +127,7 @@ ContestHallLobby_Movement_MomFaceKeira:
     WalkOnSpotNormalEast
     EndMovement
 
-ContestHallLobby_UnusedMovement:
+ContestHallLobby_Movement_Unused:
     WalkOnSpotNormalEast
     EndMovement
 
@@ -136,15 +136,15 @@ ContestHallLobby_Movement_MomFacePlayer:
     WalkOnSpotNormalSouth
     EndMovement
 
-ContestHallLobby_UnusedMovement2:
+ContestHallLobby_Movement_Unused2:
     WalkNormalWest 8
     EndMovement
 
-ContestHallLobby_UnusedMovement3:
+ContestHallLobby_Movement_Unused3:
     WalkNormalNorth 6
     EndMovement
 
-ContestHallLobby_UnusedMovement4:
+ContestHallLobby_Movement_Unused4:
     WalkNormalEast 8
     EndMovement
 

--- a/res/field/scripts/scripts_contest_hall_stage_ongoing_contest.s
+++ b/res/field/scripts/scripts_contest_hall_stage_ongoing_contest.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry ContestHallStageOngoingContest_UnusedEntry1
+    ScriptEntry ContestHallStageOngoingContest_Dummy1
     ScriptEntryEnd
 
-ContestHallStageOngoingContest_UnusedEntry1:
+ContestHallStageOngoingContest_Dummy1:
     End

--- a/res/field/scripts/scripts_contests.s
+++ b/res/field/scripts/scripts_contests.s
@@ -13,11 +13,11 @@
 
 
     ScriptEntry Contests_LobbyOnFrameExitContestHall @ 0x2648
-    ScriptEntry Contests_EmptyScript9801 @ 0x2649
+    ScriptEntry Contests_Dummy9801 @ 0x2649
     ScriptEntry Contests_OngoingContestOnTransition @ 0x264A
     ScriptEntry Contests_LobbyOnTransition @ 0x264B
     ScriptEntry Contests_OngoingContestOnResume @ 0x264C
-    ScriptEntry Contests_UnusedEntry9805 @ 0x264D
+    ScriptEntry Contests_Dummy9805 @ 0x264D
     ScriptEntry Contests_ReceptionistOfficialContest @ 0x264E
     ScriptEntry Contests_ReceptionistLinkContest @ 0x264F
     ScriptEntry Contests_ReceptionistPracticeContest @ 0x2650
@@ -121,7 +121,7 @@ Contests_Movement_PlayerWalkToOfficialReceptionist:
     WalkOnSpotFastNorth
     EndMovement
 
-Contests_EmptyScript9801:
+Contests_Dummy9801:
     End
 
 Contests_OngoingContestOnTransition:
@@ -171,7 +171,7 @@ Contests_HidePlayer:
     HideObject LOCALID_PLAYER
     Return
 
-Contests_UnusedEntry9805:
+Contests_Dummy9805:
     NPCMessage ContestCommon_Text_Dummy0
     End
 
@@ -948,7 +948,7 @@ Contests_Movement_PlayerWalkToPracticeContestDoor:
     WalkNormalNorth 3
     EndMovement
 
-Contests_UnusedMovement:
+Contests_Movement_Unused:
     Delay4
     FaceEast
     Delay4

--- a/res/field/scripts/scripts_distortion_world_b4f.s
+++ b/res/field/scripts/scripts_distortion_world_b4f.s
@@ -2,12 +2,12 @@
 
 
     ScriptEntry DistortionWorldB4F_OnTransition
-    ScriptEntry DistortionWorldB4F_UnusedEntry2
+    ScriptEntry DistortionWorldB4F_Dummy2
     ScriptEntryEnd
 
 DistortionWorldB4F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-DistortionWorldB4F_UnusedEntry2:
+DistortionWorldB4F_Dummy2:
     End

--- a/res/field/scripts/scripts_distortion_world_b5f.s
+++ b/res/field/scripts/scripts_distortion_world_b5f.s
@@ -2,12 +2,12 @@
 
 
     ScriptEntry DistortionWorldB5F_OnTransition
-    ScriptEntry DistortionWorldB5F_UnusedEntry2
+    ScriptEntry DistortionWorldB5F_Dummy2
     ScriptEntryEnd
 
 DistortionWorldB5F_OnTransition:
     InitPersistedMapFeaturesForDistortionWorld
     End
 
-DistortionWorldB5F_UnusedEntry2:
+DistortionWorldB5F_Dummy2:
     End

--- a/res/field/scripts/scripts_empty.s
+++ b/res/field/scripts/scripts_empty.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry Empty_UnusedEntry1
+    ScriptEntry Empty_Dummy1
     ScriptEntryEnd
 
-Empty_UnusedEntry1:
+Empty_Dummy1:
     End

--- a/res/field/scripts/scripts_eterna_city.s
+++ b/res/field/scripts/scripts_eterna_city.s
@@ -10,7 +10,7 @@
     ScriptEntry EternaCity_GruntM3
     ScriptEntry EternaCity_PokemonBreederM
     ScriptEntry EternaCity_PokemonBreederF1
-    ScriptEntry EternaCity_Unused7
+    ScriptEntry EternaCity_RatherFetching_Unused
     ScriptEntry EternaCity_BugCatcher1
     ScriptEntry EternaCity_AceTrainerF
     ScriptEntry EternaCity_ExpertM
@@ -57,7 +57,7 @@ EternaCity_PokemonBreederM:
     NPCMessage EternaCity_Text_IfYoureVisitingEternaYouNeedToGetYourselfABicycle
     End
 
-EternaCity_Unused7:
+EternaCity_RatherFetching_Unused:
     NPCMessage EternaCity_Text_OhYourPokemonAreRatherFetching
     End
 
@@ -504,7 +504,7 @@ EternaCity_Movement_PokemonBreederFBlockExitSouthX307:
     WalkNormalEast 4
     EndMovement
 
-EternaCity_UnusedMovement:
+EternaCity_Movement_Unused:
     WalkOnSpotFastEast
     EndMovement
 

--- a/res/field/scripts/scripts_eterna_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_eterna_city_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry EternaCityPokecenterB1F_UnusedEntry1
+    ScriptEntry EternaCityPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-EternaCityPokecenterB1F_UnusedEntry1:
+EternaCityPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_eterna_forest.s
+++ b/res/field/scripts/scripts_eterna_forest.s
@@ -5,8 +5,8 @@
     ScriptEntry EternaForest_CoordEvent_StartFollowingCheryl
     ScriptEntry EternaForest_CoordEvent_PlayerLeaveCheryl
     ScriptEntry EternaForest_CoordEvent_CherylLeavePlayer
-    ScriptEntry EternaForest_Unused4
-    ScriptEntry EternaForest_Unused5
+    ScriptEntry EternaForest_Dummy4
+    ScriptEntry EternaForest_Dummy5
     ScriptEntry EternaForest_BugCatcher
     ScriptEntry EternaForest_Gardenia
     ScriptEntry EternaForest_SignboardEternaForest
@@ -321,13 +321,13 @@ EternaForest_Movement_PlayerWatchCherylWalkToExitX39:
     WalkOnSpotNormalEast
     EndMovement
 
-EternaForest_Unused4:
+EternaForest_Dummy4:
     LockAll
     BufferPlayerName 0
     ReleaseAll
     End
 
-EternaForest_Unused5:
+EternaForest_Dummy5:
     LockAll
     BufferPlayerName 0
     ReleaseAll

--- a/res/field/scripts/scripts_eterna_forest_outside.s
+++ b/res/field/scripts/scripts_eterna_forest_outside.s
@@ -3,8 +3,8 @@
 
 
     ScriptEntry EternaForestOutside_OnTransition
-    ScriptEntry EternaForestOutside_Unused2
-    ScriptEntry EternaForestOutside_Unused3
+    ScriptEntry EternaForestOutside_Dummy2
+    ScriptEntry EternaForestOutside_Dummy3
     ScriptEntry EternaForestOutside_PokemonBreederF
     ScriptEntryEnd
 
@@ -34,10 +34,10 @@ EternaForestOutside_ICollectBerriesAndTradeThemForAccessoriesInFloaromaTown:
     ReleaseAll
     End
 
-EternaForestOutside_Unused2:
+EternaForestOutside_Dummy2:
     ShowLandmarkSign EternaForestOutside_Text_Dummy2
     End
 
-EternaForestOutside_Unused3:
+EternaForestOutside_Dummy3:
     ShowScrollingSign EternaForestOutside_Text_Dummy3
     End

--- a/res/field/scripts/scripts_field_moves.s
+++ b/res/field/scripts/scripts_field_moves.s
@@ -9,7 +9,7 @@
     ScriptEntry FieldMoves_Water
     ScriptEntry FieldMoves_Fog_Unused
     ScriptEntry FieldMoves_Waterfall
-    ScriptEntry FieldMoves_Dummy
+    ScriptEntry FieldMoves_Dummy8
     ScriptEntry FieldMoves_UseCutFromMenu
     ScriptEntry FieldMoves_UseRockSmashFromMenu
     ScriptEntry FieldMoves_UseStrengthFromMenu
@@ -460,7 +460,7 @@ FieldMoves_UseWaterfallFromMenu:
     ReleaseAll
     End
 
-FieldMoves_Dummy:
+FieldMoves_Dummy8:
     End
 
     .balign 4, 0

--- a/res/field/scripts/scripts_fight_area.s
+++ b/res/field/scripts/scripts_fight_area.s
@@ -219,7 +219,7 @@ FightArea_Movement_RivalNoticePlayer:
     EmoteExclamationMark
     EndMovement
 
-FightArea_UnusedMovement:
+FightArea_Movement_Unused:
     WalkNormalWest
     EndMovement
 
@@ -251,7 +251,7 @@ FightArea_Movement_RivalGetPushedBack:
     UnlockDir
     EndMovement
 
-FightArea_UnusedMovement2:
+FightArea_Movement_Unused2:
     EmoteExclamationMark
     EndMovement
 
@@ -331,7 +331,7 @@ FightArea_Movement_PlayerWatchRivalLeave:
     WalkOnSpotNormalSouth
     EndMovement
 
-FightArea_UnusedMovement3:
+FightArea_Movement_Unused3:
     Delay8
     WalkOnSpotNormalNorth
     EndMovement
@@ -383,11 +383,11 @@ FightArea_Movement_BuckLeave:
     WalkNormalSouth 8
     EndMovement
 
-FightArea_UnusedMovement4:
+FightArea_Movement_Unused4:
     WalkOnSpotNormalWest
     EndMovement
 
-FightArea_UnusedMovement5:
+FightArea_Movement_Unused5:
     WalkNormalEast 10
     EndMovement
 

--- a/res/field/scripts/scripts_fight_area_mart.s
+++ b/res/field/scripts/scripts_fight_area_mart.s
@@ -3,7 +3,7 @@
 
 
     ScriptEntry FightAreaMart_CommonVendor
-    ScriptEntry FightAreaMart_Unused
+    ScriptEntry FightAreaMart_Dummy2
     ScriptEntry FightAreaMart_Socialite
     ScriptEntry FightAreaMart_Clown
     ScriptEntryEnd
@@ -12,7 +12,7 @@ FightAreaMart_CommonVendor:
     PokeMartCommonWithGreeting
     End
 
-FightAreaMart_Unused:
+FightAreaMart_Dummy2:
     End
 
 FightAreaMart_Socialite:

--- a/res/field/scripts/scripts_fight_area_pokecenter_2f.s
+++ b/res/field/scripts/scripts_fight_area_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry FightAreaPokecenter2F_UnusedEntry1
+    ScriptEntry FightAreaPokecenter2F_Dummy1
     ScriptEntryEnd
 
-FightAreaPokecenter2F_UnusedEntry1:
+FightAreaPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_fight_area_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_fight_area_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry FightAreaPokecenterB1F_UnusedEntry1
+    ScriptEntry FightAreaPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-FightAreaPokecenterB1F_UnusedEntry1:
+FightAreaPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_floaroma_meadow.s
+++ b/res/field/scripts/scripts_floaroma_meadow.s
@@ -5,10 +5,10 @@
 
     ScriptEntry FloaromaMeadow_OnTransition
     ScriptEntry FloaromaMeadow_CoordEvent_Grunts
-    ScriptEntry FloaromaMeadow_UnusedGrunt
-    ScriptEntry FloaromaMeadow_UnusedGrunt
+    ScriptEntry FloaromaMeadow_Grunt_Unused
+    ScriptEntry FloaromaMeadow_Grunt_Unused
     ScriptEntry FloaromaMeadow_PokefanM
-    ScriptEntry FloaromaMeadow_UnusedArrowSignpost
+    ScriptEntry FloaromaMeadow_Dummy6
     ScriptEntry FloaromaMeadow_ItemWorksKey
     ScriptEntryEnd
 
@@ -52,11 +52,11 @@ FloaromaMeadow_Movement_GruntWestWalkOnSpotSouth:
     WalkOnSpotNormalSouth
     EndMovement
 
-FloaromaMeadow_UnusedMovement:
+FloaromaMeadow_Movement_Unused:
     WalkNormalNorth 9
     EndMovement
 
-FloaromaMeadow_UnusedMovement2:
+FloaromaMeadow_Movement_Unused2:
     WalkNormalNorth 9
     EndMovement
 
@@ -151,7 +151,7 @@ FloaromaMeadow_Unused:
     ReleaseAll
     End
 
-FloaromaMeadow_UnusedGrunt:
+FloaromaMeadow_Grunt_Unused:
     End
 
 FloaromaMeadow_PokefanM:
@@ -228,7 +228,7 @@ FloaromaMeadow_OopsyYouDontHaveEnoughMoney:
     ReleaseAll
     End
 
-FloaromaMeadow_UnusedArrowSignpost:
+FloaromaMeadow_Dummy6:
     ShowArrowSign FloaromaMeadow_Text_Dummy18
     End
 

--- a/res/field/scripts/scripts_floaroma_town_pokecenter_2f.s
+++ b/res/field/scripts/scripts_floaroma_town_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry FloaromaPokecenter2F_UnusedEntry1
+    ScriptEntry FloaromaPokecenter2F_Dummy1
     ScriptEntryEnd
 
-FloaromaPokecenter2F_UnusedEntry1:
+FloaromaPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_floaroma_town_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_floaroma_town_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry FloaromaPokecenterB1F_UnusedEntry1
+    ScriptEntry FloaromaPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-FloaromaPokecenterB1F_UnusedEntry1:
+FloaromaPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_follower_partners.s
+++ b/res/field/scripts/scripts_follower_partners.s
@@ -3,10 +3,10 @@
 
 
     ScriptEntry FollowerPartners_Rival
-    ScriptEntry FollowerPartners_UnusedEntry9701
+    ScriptEntry FollowerPartners_DummyFollower_Unused
     ScriptEntry FollowerPartners_Cheryl
     ScriptEntry FollowerPartners_Buck
-    ScriptEntry FollowerPartners_Mira
+    ScriptEntry FollowerPartners_Mira_Unused
     ScriptEntry FollowerPartners_Marley
     ScriptEntryEnd
 
@@ -85,29 +85,29 @@ FollowerPartners_Rival_IncreaseTimesTalked:
     ReleaseAll
     End
 
-FollowerPartners_UnusedEntry9701:
+FollowerPartners_DummyFollower_Unused:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     FacePlayer
-    GoToIfGe VAR_FOLLOWER_UNUSED_TIMES_TALKED, 2, FollowerPartners_UnusedFollowerTalkedGe2Times
-    GoToIfEq VAR_FOLLOWER_UNUSED_TIMES_TALKED, 1, FollowerPartners_UnusedFollowerTalked1Time
+    GoToIfGe VAR_FOLLOWER_UNUSED_TIMES_TALKED, 2, FollowerPartners_DummyFollowerTalkedGe2Times_Unused
+    GoToIfEq VAR_FOLLOWER_UNUSED_TIMES_TALKED, 1, FollowerPartners_DummyFollowerTalked1Time_Unused
     BufferRivalName 0
-    GoTo FollowerPartners_UnusedFollowerTalked0Times
+    GoTo FollowerPartners_DummyFollowerTalked0Times_Unused
     End
 
-FollowerPartners_UnusedFollowerTalkedGe2Times:
+FollowerPartners_DummyFollowerTalkedGe2Times_Unused:
     BufferRivalName 0
     WaitButton
     CloseMessage
     ReleaseAll
     End
 
-FollowerPartners_UnusedFollowerTalked1Time:
+FollowerPartners_DummyFollowerTalked1Time_Unused:
     BufferRivalName 0
-    GoTo FollowerPartners_UnusedFollowerTalked0Times
+    GoTo FollowerPartners_DummyFollowerTalked0Times_Unused
     End
 
-FollowerPartners_UnusedFollowerTalked0Times:
+FollowerPartners_DummyFollowerTalked0Times_Unused:
     WaitButton
     CloseMessage
     AddVar VAR_FOLLOWER_UNUSED_TIMES_TALKED, 1
@@ -181,23 +181,23 @@ FollowerPartners_Buck_IncreaseTimesTalked:
     ReleaseAll
     End
 
-FollowerPartners_Mira:
+FollowerPartners_Mira_Unused:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     FacePlayer
-    GoToIfGe VAR_FOLLOWER_MIRA_TIMES_TALKED, 2, FollowerPartners_Mira_IWillTryLikeYou
-    GoToIfEq VAR_FOLLOWER_MIRA_TIMES_TALKED, 1, FollowerPartners_Mira_EasyToGetConfused
+    GoToIfGe VAR_FOLLOWER_MIRA_TIMES_TALKED, 2, FollowerPartners_Mira_IWillTryLikeYou_Unused
+    GoToIfEq VAR_FOLLOWER_MIRA_TIMES_TALKED, 1, FollowerPartners_Mira_EasyToGetConfused_Unused
     BufferPlayerName 0
     Message FollowerPartners_Text_Mira_ILikeHelpfulMoves
-    GoTo FollowerPartners_Mira_IncreaseTimesTalked
+    GoTo FollowerPartners_Mira_IncreaseTimesTalked_Unused
     End
 
-FollowerPartners_Mira_EasyToGetConfused:
+FollowerPartners_Mira_EasyToGetConfused_Unused:
     Message FollowerPartners_Text_Mira_EasyToGetConfused
-    GoTo FollowerPartners_Mira_IncreaseTimesTalked
+    GoTo FollowerPartners_Mira_IncreaseTimesTalked_Unused
     End
 
-FollowerPartners_Mira_IWillTryLikeYou:
+FollowerPartners_Mira_IWillTryLikeYou_Unused:
     BufferPlayerName 0
     Message FollowerPartners_Text_Mira_IWillTryLikeYou
     WaitButton
@@ -205,7 +205,7 @@ FollowerPartners_Mira_IWillTryLikeYou:
     ReleaseAll
     End
 
-FollowerPartners_Mira_IncreaseTimesTalked:
+FollowerPartners_Mira_IncreaseTimesTalked_Unused:
     AddVar VAR_FOLLOWER_MIRA_TIMES_TALKED, 1
     WaitButton
     CloseMessage

--- a/res/field/scripts/scripts_fullmoon_island_forest.s
+++ b/res/field/scripts/scripts_fullmoon_island_forest.s
@@ -3,11 +3,11 @@
 #include "res/field/events/events_fullmoon_island_forest.h"
 
 
-    ScriptEntry FullmoonIslandForest_Unused
+    ScriptEntry FullmoonIslandForest_Dummy1
     ScriptEntry FullmoonIslandForest_Cresselia
     ScriptEntryEnd
 
-FullmoonIslandForest_Unused:
+FullmoonIslandForest_Dummy1:
     End
 
 FullmoonIslandForest_Cresselia:

--- a/res/field/scripts/scripts_galactic_hq_control_room.s
+++ b/res/field/scripts/scripts_galactic_hq_control_room.s
@@ -9,9 +9,9 @@
     ScriptEntry GalacticHQControlRoom_MachineUxie
     ScriptEntry GalacticHQControlRoom_MachineMesprit
     ScriptEntry GalacticHQControlRoom_MachineAzelf
-    ScriptEntry GalacticHQControlRoom_Unused7
-    ScriptEntry GalacticHQControlRoom_Unused8
-    ScriptEntry GalacticHQControlRoom_Unused9
+    ScriptEntry GalacticHQControlRoom_Dummy7
+    ScriptEntry GalacticHQControlRoom_Dummy8
+    ScriptEntry GalacticHQControlRoom_Dummy9
     ScriptEntry GalacticHQControlRoom_Button
     ScriptEntry GalacticHQControlRoom_Uxie
     ScriptEntry GalacticHQControlRoom_Mesprit
@@ -161,13 +161,13 @@ GalacticHQControlRoom_AzelfWasSealedInside:
     ReleaseAll
     End
 
-GalacticHQControlRoom_Unused7:
+GalacticHQControlRoom_Dummy7:
     End
 
-GalacticHQControlRoom_Unused8:
+GalacticHQControlRoom_Dummy8:
     End
 
-GalacticHQControlRoom_Unused9:
+GalacticHQControlRoom_Dummy9:
     End
 
 GalacticHQControlRoom_Button:

--- a/res/field/scripts/scripts_global_terminal_1f.s
+++ b/res/field/scripts/scripts_global_terminal_1f.s
@@ -4,8 +4,8 @@
 #include "constants/map_object.h"
 
 
-    ScriptEntry GlobalTerminal1F_Unused1
-    ScriptEntry GlobalTerminal1F_Unused2
+    ScriptEntry GlobalTerminal1F_Dummy1
+    ScriptEntry GlobalTerminal1F_Dummy2
     ScriptEntry GlobalTerminal1F_ReceptionistGTS
     ScriptEntry GlobalTerminal1F_Collector
     ScriptEntry GlobalTerminal1F_BugCatcher
@@ -72,7 +72,7 @@ GlobalTerminal1F_Movement_PlayerExitGTSRoom:
     WalkNormalSouth
     EndMovement
 
-GlobalTerminal1F_UnusedMovement:
+GlobalTerminal1F_Movement_Unused:
     WalkNormalSouth
     EndMovement
 
@@ -81,10 +81,10 @@ GlobalTerminal1F_Movement_PlayerWalkSouth:
     WalkNormalSouth 2
     EndMovement
 
-GlobalTerminal1F_Unused1:
+GlobalTerminal1F_Dummy1:
     End
 
-GlobalTerminal1F_Unused2:
+GlobalTerminal1F_Dummy2:
     End
 
 GlobalTerminal1F_ReceptionistGTS:

--- a/res/field/scripts/scripts_global_terminal_2f.s
+++ b/res/field/scripts/scripts_global_terminal_2f.s
@@ -2,7 +2,7 @@
 #include "res/text/bank/global_terminal_2f.h"
 
 
-    ScriptEntry GlobalTerminal2F_Unused1
+    ScriptEntry GlobalTerminal2F_Dummy1
     ScriptEntry GlobalTerminal2F_Artist
     ScriptEntry GlobalTerminal2F_Hiker
     ScriptEntry GlobalTerminal2F_BattleGirl
@@ -62,7 +62,7 @@ GlobalTerminal2F_BgSignWarp3F:
     EventMessage GlobalTerminal2F_Text_WarpsTo3F
     End
 
-GlobalTerminal2F_Unused1:
+GlobalTerminal2F_Dummy1:
     End
 
 GlobalTerminal2F_BoxDataMachine:

--- a/res/field/scripts/scripts_global_terminal_3f.s
+++ b/res/field/scripts/scripts_global_terminal_3f.s
@@ -2,7 +2,7 @@
 #include "res/text/bank/global_terminal_3f.h"
 
 
-    ScriptEntry GlobalTerminal3F_Unused1
+    ScriptEntry GlobalTerminal3F_Dummy1
     ScriptEntry GlobalTerminal3F_Youngster
     ScriptEntry GlobalTerminal3F_SchoolKidF
     ScriptEntry GlobalTerminal3F_AceTrainerM
@@ -61,7 +61,7 @@ GlobalTerminal3F_BgSignWarp2F:
     EventMessage GlobalTerminal3F_Text_WarpsTo2F
     End
 
-GlobalTerminal3F_Unused1:
+GlobalTerminal3F_Dummy1:
     End
 
 GlobalTerminal3F_BattleVideosMachine:

--- a/res/field/scripts/scripts_hearthome_city.s
+++ b/res/field/scripts/scripts_hearthome_city.s
@@ -145,7 +145,7 @@ HearthomeCity_ThisIsTheContestHall:
     ReleaseAll
     End
 
-HearthomeCity_UnusedMovement:
+HearthomeCity_Movement_Unused:
     EmoteExclamationMark
     Delay16
     EndMovement
@@ -517,7 +517,7 @@ HearthomeCity_Movement_BunearyEnter:
     WalkFastWest 9
     EndMovement
 
-HearthomeCity_UnusedMovement2:
+HearthomeCity_Movement_Unused2:
     WalkFastEast 8
     EndMovement
 

--- a/res/field/scripts/scripts_hearthome_city_northeast_house_1f.s
+++ b/res/field/scripts/scripts_hearthome_city_northeast_house_1f.s
@@ -9,7 +9,7 @@
     ScriptEntry HearthomeCityNortheastHouse1F_Twin
     ScriptEntry HearthomeCityNortheastHouse1F_SchoolKidM
     ScriptEntry HearthomeCityNortheastHouse1F_Lass
-    ScriptEntry HearthomeCityNortheastHouse1F_Unused
+    ScriptEntry HearthomeCityNortheastHouse1F_Dummy8
     ScriptEntry HearthomeCityNortheastHouse1F_Pikachu
     ScriptEntryEnd
 
@@ -41,7 +41,7 @@ HearthomeCityNortheastHouse1F_Lass:
     NPCMessage HearthomeCityNortheastHouse1F_Text_WowYoureAPokemonTrainer
     End
 
-HearthomeCityNortheastHouse1F_Unused:
+HearthomeCityNortheastHouse1F_Dummy8:
     NPCMessage HearthomeCityNortheastHouse1F_Text_Dummy7
     End
 

--- a/res/field/scripts/scripts_hearthome_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_hearthome_city_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry HearthomeCityPokecenter2F_UnusedEntry1
+    ScriptEntry HearthomeCityPokecenter2F_Dummy1
     ScriptEntryEnd
 
-HearthomeCityPokecenter2F_UnusedEntry1:
+HearthomeCityPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_hearthome_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_hearthome_city_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry HearthomeCityPokecenterB1F_UnusedEntry1
+    ScriptEntry HearthomeCityPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-HearthomeCityPokecenterB1F_UnusedEntry1:
+HearthomeCityPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_iron_island_b2f_left_room.s
+++ b/res/field/scripts/scripts_iron_island_b2f_left_room.s
@@ -8,9 +8,9 @@
     ScriptEntry IronIslandB2FLeftRoom_CoordEvent_PlatformLift
     ScriptEntry IronIslandB2FLeftRoom_CoordEvent_StartFollowingRiley
     ScriptEntry IronIslandB2FLeftRoom_CoordEvent_PlayerLeaveRiley
-    ScriptEntry IronIslandB2FLeftRoom_Unused5
-    ScriptEntry IronIslandB2FLeftRoom_Unused6
-    ScriptEntry IronIslandB2FLeftRoom_Unused7
+    ScriptEntry IronIslandB2FLeftRoom_Dummy5
+    ScriptEntry IronIslandB2FLeftRoom_Dummy6
+    ScriptEntry IronIslandB2FLeftRoom_Dummy7
     ScriptEntry IronIslandB2FLeftRoom_Riley
     ScriptEntry IronIslandB2FLeftRoom_CoordEvent_Grunts
     ScriptEntryEnd
@@ -143,7 +143,7 @@ IronIslandB2FLeftRoom_Movement_RileyWalkBackZ3:
     WalkNormalWest
     EndMovement
 
-IronIslandB2FLeftRoom_Unused5:
+IronIslandB2FLeftRoom_Dummy5:
     End
 
 IronIslandB2FLeftRoom_CoordEvent_Grunts:
@@ -207,12 +207,12 @@ IronIslandB2FLeftRoom_PlayerRileyWalkToGruntsZ41:
     WaitMovement
     Return
 
-IronIslandB2FLeftRoom_UnusedMovement6:
+IronIslandB2FLeftRoom_Unused:
     ApplyMovement LOCALID_RILEY, IronIslandB2FLeftRoom_Movement_Unused6
     WaitMovement
     Return
 
-IronIslandB2FLeftRoom_UnusedMovement7:
+IronIslandB2FLeftRoom_Unused2:
     ApplyMovement LOCALID_RILEY, IronIslandB2FLeftRoom_Movement_Unused7
     WaitMovement
     Return
@@ -381,10 +381,10 @@ IronIslandB2FLeftRoom_Movement_PlayerWalkToGruntMSouth:
     WalkNormalWest
     EndMovement
 
-IronIslandB2FLeftRoom_Unused6:
+IronIslandB2FLeftRoom_Dummy6:
     End
 
-IronIslandB2FLeftRoom_Unused7:
+IronIslandB2FLeftRoom_Dummy7:
     End
 
 IronIslandB2FLeftRoom_Riley:

--- a/res/field/scripts/scripts_iron_island_b3f.s
+++ b/res/field/scripts/scripts_iron_island_b3f.s
@@ -3,7 +3,7 @@
 
     ScriptEntry IronIslandB3F_OnTransition
     ScriptEntry IronIslandB3F_CoordEvent_PlatformLift
-    ScriptEntry IronIslandB3F_Unused
+    ScriptEntry IronIslandB3F_Dummy3
     ScriptEntry IronIslandB3F_OnLoad
     ScriptEntryEnd
 
@@ -37,7 +37,7 @@ IronIslandB3F_ResetIronRuinsState:
     SetVar VAR_IRON_RUINS_STATE, 0
     Return
 
-IronIslandB3F_Unused:
+IronIslandB3F_Dummy3:
     End
 
     .balign 4, 0

--- a/res/field/scripts/scripts_jubilife_city.s
+++ b/res/field/scripts/scripts_jubilife_city.s
@@ -1068,14 +1068,14 @@ JubilifeCity_Movement_PlayerWatchCounterpartAndProfRowanLeave:
     WalkOnSpotNormalSouth
     EndMovement
 
-JubilifeCity_UnusedMovement:
+JubilifeCity_Movement_Unused:
     Delay8
     WalkOnSpotNormalEast
     Delay8
     WalkOnSpotNormalSouth
     EndMovement
 
-JubilifeCity_UnusedMovement2:
+JubilifeCity_Movement_Unused2:
     Delay8
     WalkOnSpotNormalWest
     Delay8
@@ -1109,12 +1109,12 @@ JubilifeCity_Movement_CounterpartLeaveAfterGalacticBattle:
     WalkNormalSouth 9
     EndMovement
 
-JubilifeCity_UnusedMovement3:
+JubilifeCity_Movement_Unused3:
     WalkNormalEast
     WalkNormalSouth 9
     EndMovement
 
-JubilifeCity_UnusedMovement4:
+JubilifeCity_Movement_Unused4:
     WalkNormalWest
     WalkOnSpotNormalEast
     WalkNormalEast
@@ -1167,11 +1167,11 @@ JubilifeCity_Movement_ProfRowanLeave:
     WalkNormalSouth 9
     EndMovement
 
-JubilifeCity_UnusedMovement5:
+JubilifeCity_Movement_Unused5:
     WalkNormalSouth 9
     EndMovement
 
-JubilifeCity_UnusedMovement6:
+JubilifeCity_Movement_Unused6:
     WalkOnSpotNormalWest
     WalkNormalWest
     WalkNormalSouth 9
@@ -1187,23 +1187,23 @@ JubilifeCity_Movement_ProfRowanWalkOnSpotWest2:
     WalkOnSpotNormalWest
     EndMovement
 
-JubilifeCity_UnusedMovement7:
+JubilifeCity_Movement_Unused7:
     WalkOnSpotNormalWest
     EndMovement
 
-JubilifeCity_UnusedMovement8:
+JubilifeCity_Movement_Unused8:
     WalkOnSpotNormalWest
     EndMovement
 
-JubilifeCity_UnusedMovement9:
+JubilifeCity_Movement_Unused9:
     WalkOnSpotNormalWest
     EndMovement
 
-JubilifeCity_UnusedMovement10:
+JubilifeCity_Movement_Unused10:
     WalkOnSpotNormalWest
     EndMovement
 
-JubilifeCity_UnusedMovement11:
+JubilifeCity_Movement_Unused11:
     WalkOnSpotNormalWest
     EndMovement
 

--- a/res/field/scripts/scripts_jubilife_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_jubilife_city_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry JubilifeCityPokecenter2F_UnusedEntry1
+    ScriptEntry JubilifeCityPokecenter2F_Dummy1
     ScriptEntryEnd
 
-JubilifeCityPokecenter2F_UnusedEntry1:
+JubilifeCityPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_jubilife_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_jubilife_city_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry JubilifeCityPokecenterB1F_UnusedEntry1
+    ScriptEntry JubilifeCityPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-JubilifeCityPokecenterB1F_UnusedEntry1:
+JubilifeCityPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_jubilife_tv_1f.s
+++ b/res/field/scripts/scripts_jubilife_tv_1f.s
@@ -2,13 +2,13 @@
 #include "res/text/bank/jubilife_tv_1f.h"
 
 
-    ScriptEntry JubilifeTV1F_Unused1
+    ScriptEntry JubilifeTV1F_Dummy1
     ScriptEntry JubilifeTV1F_GymGuide
-    ScriptEntry JubilifeTV1F_Unused2
+    ScriptEntry JubilifeTV1F_Dummy3
     ScriptEntry JubilifeTV1F_AceTrainerSnowF
     ScriptEntry JubilifeTV1F_Beauty
     ScriptEntry JubilifeTV1F_MiddleAgedMan
-    ScriptEntry JubilifeTV1F_Unused3
+    ScriptEntry JubilifeTV1F_Dummy7
     ScriptEntry JubilifeTV1F_OnTransition
     ScriptEntry JubilifeTV1F_AceTrainerM
     ScriptEntryEnd
@@ -16,14 +16,14 @@
 JubilifeTV1F_OnTransition:
     End
 
-JubilifeTV1F_Unused1:
+JubilifeTV1F_Dummy1:
     End
 
 JubilifeTV1F_GymGuide:
     NPCMessage JubilifeTV1F_Text_WhyDontYouTryDressingUpYourPokemonNow
     End
 
-JubilifeTV1F_Unused2:
+JubilifeTV1F_Dummy3:
     End
 
 JubilifeTV1F_AceTrainerSnowF:
@@ -185,7 +185,7 @@ JubilifeTV1F_MiddleAgedMan:
     NPCMessage JubilifeTV1F_Text_ImGoingToGetCommercialsShownOnTV
     End
 
-JubilifeTV1F_Unused3:
+JubilifeTV1F_Dummy7:
     End
 
 JubilifeTV1F_AceTrainerM:

--- a/res/field/scripts/scripts_lake_valor.s
+++ b/res/field/scripts/scripts_lake_valor.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry LakeValor_UnusedEntry1
+    ScriptEntry LakeValor_Dummy1
     ScriptEntryEnd
 
-LakeValor_UnusedEntry1:
+LakeValor_Dummy1:
     End

--- a/res/field/scripts/scripts_lake_verity.s
+++ b/res/field/scripts/scripts_lake_verity.s
@@ -236,11 +236,11 @@ LakeVerity_BlackOut:
     End
 
     .balign 4, 0
-LakeVerity_UnusedMovement:
+LakeVerity_Movement_Unused:
     WalkOnSpotNormalNorth
     EndMovement
 
-LakeVerity_UnusedMovement2:
+LakeVerity_Movement_Unused2:
     WalkNormalNorth 3
     EndMovement
 

--- a/res/field/scripts/scripts_lake_verity_low_water.s
+++ b/res/field/scripts/scripts_lake_verity_low_water.s
@@ -8,8 +8,8 @@
     ScriptEntry LakeVerityLowWater_OnFrame_Cyrus
     ScriptEntry LakeVerityLowWater_ProfRowan
     ScriptEntry LakeVerityLowWater_Counterpart
-    ScriptEntry LakeVerityLowWater_UnusedEntry6
-    ScriptEntry LakeVerityLowWater_UnusedEntry7
+    ScriptEntry LakeVerityLowWater_Dummy6
+    ScriptEntry LakeVerityLowWater_Dummy7
     ScriptEntryEnd
 
 LakeVerityLowWater_OnTransition:
@@ -126,11 +126,11 @@ LakeVerityLowWater_Movement_PanBackToPlayer:
     WalkNormalSouth 9
     EndMovement
 
-LakeVerityLowWater_UnusedMovement:
+LakeVerityLowWater_Movement_Unused:
     WalkOnSpotNormalEast
     EndMovement
 
-LakeVerityLowWater_UnusedMovement2:
+LakeVerityLowWater_Movement_Unused2:
     WalkOnSpotNormalSouth
     Delay8 2
     WalkOnSpotNormalEast
@@ -149,29 +149,29 @@ LakeVerityLowWater_Movement_CyrusLeave:
     SetInvisible
     EndMovement
 
-LakeVerityLowWater_UnusedMovement3:
+LakeVerityLowWater_Movement_Unused3:
     Delay8
     WalkOnSpotNormalWest
     EndMovement
 
-LakeVerityLowWater_UnusedMovement4:
+LakeVerityLowWater_Movement_Unused4:
     WalkOnSpotNormalWest
     EndMovement
 
-LakeVerityLowWater_UnusedMovement5:
+LakeVerityLowWater_Movement_Unused5:
     WalkNormalSouth 4
     WalkNormalWest 2
     WalkNormalSouth 5
     EndMovement
 
-LakeVerityLowWater_UnusedMovement6:
+LakeVerityLowWater_Movement_Unused6:
     WalkNormalWest
     WalkNormalSouth 5
     WalkNormalWest
     WalkNormalSouth 3
     EndMovement
 
-LakeVerityLowWater_UnusedMovement7:
+LakeVerityLowWater_Movement_Unused7:
     WalkNormalSouth
     WalkOnSpotNormalWest
     Delay4
@@ -183,19 +183,19 @@ LakeVerityLowWater_UnusedMovement7:
     Delay8
     EndMovement
 
-LakeVerityLowWater_UnusedMovement8:
+LakeVerityLowWater_Movement_Unused8:
     WalkNormalSouth 3
     SetInvisible
     EndMovement
 
-LakeVerityLowWater_UnusedMovement9:
+LakeVerityLowWater_Movement_Unused9:
     WalkNormalNorth 4
     WalkNormalEast 2
     WalkNormalNorth 4
     WalkOnSpotNormalWest
     EndMovement
 
-LakeVerityLowWater_UnusedMovement10:
+LakeVerityLowWater_Movement_Unused10:
     WalkOnSpotNormalSouth
     Delay8
     WalkOnSpotFastEast
@@ -254,40 +254,40 @@ LakeVerityLowWater_Movement_RivalLeave:
     WalkFastSouth 2
     EndMovement
 
-LakeVerityLowWater_UnusedMovement11:
+LakeVerityLowWater_Movement_Unused11:
     WalkOnSpotNormalEast
     EndMovement
 
-LakeVerityLowWater_UnusedMovement12:
+LakeVerityLowWater_Movement_Unused12:
     WalkOnSpotFastEast
     EndMovement
 
-LakeVerityLowWater_UnusedMovement13:
+LakeVerityLowWater_Movement_Unused13:
     WalkOnSpotNormalSouth
     EndMovement
 
-LakeVerityLowWater_UnusedMovement14:
+LakeVerityLowWater_Movement_Unused14:
     Delay8 7
     WalkNormalEast
     WalkOnSpotNormalWest
     EndMovement
 
-LakeVerityLowWater_UnusedMovement15:
+LakeVerityLowWater_Movement_Unused15:
     Delay4
     WalkOnSpotNormalSouth
     EndMovement
 
-LakeVerityLowWater_UnusedMovement16:
+LakeVerityLowWater_Movement_Unused16:
     WalkNormalWest
     WalkNormalSouth
     WalkOnSpotNormalWest
     EndMovement
 
-LakeVerityLowWater_UnusedMovement17:
+LakeVerityLowWater_Movement_Unused17:
     WalkOnSpotFastSouth
     EndMovement
 
-LakeVerityLowWater_UnusedMovement18:
+LakeVerityLowWater_Movement_Unused18:
     WalkNormalSouth
     WalkNormalWest
     WalkNormalSouth 3
@@ -329,11 +329,11 @@ LakeVerityLowWater_Movement_PlayerWatchRivalLeave:
     WalkOnSpotNormalSouth
     EndMovement
 
-LakeVerityLowWater_UnusedMovement19:
+LakeVerityLowWater_Movement_Unused19:
     WalkOnSpotNormalSouth
     EndMovement
 
-LakeVerityLowWater_UnusedMovement20:
+LakeVerityLowWater_Movement_Unused20:
     Delay8 5
     WalkOnSpotNormalSouth
     Delay8 2
@@ -341,25 +341,25 @@ LakeVerityLowWater_UnusedMovement20:
     WalkOnSpotNormalNorth
     EndMovement
 
-LakeVerityLowWater_UnusedMovement21:
+LakeVerityLowWater_Movement_Unused21:
     WalkOnSpotNormalSouth
     EndMovement
 
-LakeVerityLowWater_UnusedMovement22:
+LakeVerityLowWater_Movement_Unused22:
     Delay8
     WalkOnSpotNormalSouth
     EndMovement
 
-LakeVerityLowWater_UnusedMovement23:
+LakeVerityLowWater_Movement_Unused23:
     Delay8
     WalkOnSpotNormalEast
     EndMovement
 
-LakeVerityLowWater_UnusedMovement24:
+LakeVerityLowWater_Movement_Unused24:
     WalkOnSpotNormalNorth
     EndMovement
 
-LakeVerityLowWater_UnusedMovement25:
+LakeVerityLowWater_Movement_Unused25:
     Delay8
     WalkOnSpotNormalSouth
     WalkNormalSouth 4
@@ -368,11 +368,11 @@ LakeVerityLowWater_UnusedMovement25:
     SetInvisible
     EndMovement
 
-LakeVerityLowWater_UnusedMovement26:
+LakeVerityLowWater_Movement_Unused26:
     WalkFastNorth 6
     EndMovement
 
-LakeVerityLowWater_UnusedMovement27:
+LakeVerityLowWater_Movement_Unused27:
     WalkFastWest 7
     EndMovement
 
@@ -421,10 +421,10 @@ LakeVerityLowWater_CloseMessage:
     ReleaseAll
     End
 
-LakeVerityLowWater_UnusedEntry6:
+LakeVerityLowWater_Dummy6:
     End
 
-LakeVerityLowWater_UnusedEntry7:
+LakeVerityLowWater_Dummy7:
     End
 
     .balign 4, 0

--- a/res/field/scripts/scripts_mt_coronet_1f_north_room_2.s
+++ b/res/field/scripts/scripts_mt_coronet_1f_north_room_2.s
@@ -1,7 +1,7 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry MtCoronet1FNorthRoom2_Unused
+    ScriptEntry MtCoronet1FNorthRoom2_Dummy1
     ScriptEntry MtCoronet1FNorthRoom2_OnTransition
     ScriptEntry MtCoronet1FNorthRoom2_OnLoad
     ScriptEntryEnd
@@ -31,7 +31,7 @@ MtCoronet1FNorthRoom2_RemoveWarpIcebergRuinsWithoutRegice:
     SetWarpEventPos 2, 17, 16
     End
 
-MtCoronet1FNorthRoom2_Unused:
+MtCoronet1FNorthRoom2_Dummy1:
     End
 
     .balign 4, 0

--- a/res/field/scripts/scripts_oreburgh_city_east_house_2f.s
+++ b/res/field/scripts/scripts_oreburgh_city_east_house_2f.s
@@ -4,7 +4,7 @@
 
     ScriptEntry OreburghCityEastHouse2F_Gentleman
     ScriptEntry OreburghCityEastHouse2F_Youngster
-    ScriptEntry OreburghCityEastHouse2F_Unused
+    ScriptEntry OreburghCityEastHouse2F_Dummy3
     ScriptEntry OreburghCityEastHouse2F_ScientistM
     ScriptEntryEnd
 
@@ -39,7 +39,7 @@ OreburghCityEastHouse2F_BagIsFull:
     ReleaseAll
     End
 
-OreburghCityEastHouse2F_Unused:
+OreburghCityEastHouse2F_Dummy3:
     End
 
 OreburghCityEastHouse2F_ScientistM:

--- a/res/field/scripts/scripts_oreburgh_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_oreburgh_city_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry OreburghCityPokecenter2F_UnusedEntry1
+    ScriptEntry OreburghCityPokecenter2F_Dummy1
     ScriptEntryEnd
 
-OreburghCityPokecenter2F_UnusedEntry1:
+OreburghCityPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_oreburgh_mine_b2f.s
+++ b/res/field/scripts/scripts_oreburgh_mine_b2f.s
@@ -17,7 +17,7 @@ OreburghMineB2F_Roark:
     GoTo OreburghMineB2F_RoarkTurnBackEast
 
 OreburghMineB2F_Unused:
-    ApplyMovement LOCALID_ROARK, OreburghMineB2F_UnusedMovement2
+    ApplyMovement LOCALID_ROARK, OreburghMineB2F_Movement_Unused2
     WaitMovement
     GoTo OreburghMineB2F_RoarkUseRockSmash
 
@@ -41,8 +41,8 @@ OreburghMineB2F_WaitRockSmash:
     GoTo OreburghMineB2F_RoarkLeave
 
 OreburghMineB2F_Unused2:
-    ApplyMovement 0, OreburghMineB2F_UnusedMovement
-    ApplyMovement LOCALID_PLAYER, OreburghMineB2F_UnusedMovement3
+    ApplyMovement 0, OreburghMineB2F_Movement_Unused
+    ApplyMovement LOCALID_PLAYER, OreburghMineB2F_Movement_Unused3
     WaitMovement
     GoTo OreburghMineB2F_RemoveRoark
 
@@ -59,7 +59,7 @@ OreburghMineB2F_RemoveRoark:
     End
 
     .balign 4, 0
-OreburghMineB2F_UnusedMovement:
+OreburghMineB2F_Movement_Unused:
     WalkNormalNorth
     WalkNormalEast 10
     EndMovement
@@ -69,7 +69,7 @@ OreburghMineB2F_Movement_RoarkLeave:
     WalkNormalEast 10
     EndMovement
 
-OreburghMineB2F_UnusedMovement2:
+OreburghMineB2F_Movement_Unused2:
     Delay8 2
     WalkOnSpotNormalNorth
     Delay8 4
@@ -82,7 +82,7 @@ OreburghMineB2F_Movement_RoarkTurnBackEast:
     Delay8 4
     EndMovement
 
-OreburghMineB2F_UnusedMovement3:
+OreburghMineB2F_Movement_Unused3:
     Delay8
     WalkOnSpotNormalNorth
     Delay8 2

--- a/res/field/scripts/scripts_pal_park_lobby.s
+++ b/res/field/scripts/scripts_pal_park_lobby.s
@@ -9,7 +9,7 @@
     ScriptEntry PalParkLobby_OnTransition
     ScriptEntry PalParkLobby_Worker
     ScriptEntry PalParkLobby_OnFrame_TallyScore
-    ScriptEntry PalParkLobby_RecordUnused
+    ScriptEntry PalParkLobby_Record_Unused
     ScriptEntry PalParkLobby_Daughter
     ScriptEntry PalParkLobby_Dad
     ScriptEntry PalParkLobby_ShowWatcherBoy
@@ -290,7 +290,7 @@ PalParkLobby_Movement_PlayerLeaveCounter:
     WalkNormalSouth 4
     EndMovement
 
-PalParkLobby_RecordUnused:
+PalParkLobby_Record_Unused:
     NPCMessage PalParkLobby_Text_CurrentRecordHolder
     End
 

--- a/res/field/scripts/scripts_pastoria_city.s
+++ b/res/field/scripts/scripts_pastoria_city.s
@@ -190,7 +190,7 @@ PastoriaCity_RemoveGruntM:
     End
 
     .balign 4, 0
-PastoriaCity_UnusedMovement:
+PastoriaCity_Movement_Unused:
     WalkOnSpotNormalWest
     EndMovement
 
@@ -200,7 +200,7 @@ PastoriaCity_Movement_PlayerWatchGruntMLeaveWest:
     WalkOnSpotNormalEast
     EndMovement
 
-PastoriaCity_UnusedMovement2:
+PastoriaCity_Movement_Unused2:
     WalkOnSpotNormalNorth
     WalkOnSpotNormalEast
     EndMovement
@@ -215,54 +215,54 @@ PastoriaCity_Movement_PlayerWatchGruntMLeaveNorth:
     WalkOnSpotNormalEast
     EndMovement
 
-PastoriaCity_UnusedMovement3:
+PastoriaCity_Movement_Unused3:
     WalkOnSpotNormalSouth
     WalkOnSpotNormalEast
     EndMovement
 
-PastoriaCity_UnusedMovement4:
+PastoriaCity_Movement_Unused4:
     WalkOnSpotNormalSouth
     WalkOnSpotNormalEast
     EndMovement
 
-PastoriaCity_UnusedMovement5:
+PastoriaCity_Movement_Unused5:
     WalkOnSpotNormalNorth
     WalkOnSpotNormalEast
     EndMovement
 
-PastoriaCity_UnusedMovement6:
+PastoriaCity_Movement_Unused6:
     WalkOnSpotNormalSouth
     WalkOnSpotNormalEast
     EndMovement
 
-PastoriaCity_UnusedMovement7:
+PastoriaCity_Movement_Unused7:
     WalkFastEast 9
     EndMovement
 
-PastoriaCity_UnusedMovement8:
+PastoriaCity_Movement_Unused8:
     WalkFastEast 7
     EndMovement
 
-PastoriaCity_UnusedMovement9:
+PastoriaCity_Movement_Unused9:
     WalkFastSouth
     WalkFastEast 8
     EndMovement
 
-PastoriaCity_UnusedMovement10:
+PastoriaCity_Movement_Unused10:
     WalkFastNorth
     WalkFastEast 8
     EndMovement
 
-PastoriaCity_UnusedMovement11:
+PastoriaCity_Movement_Unused11:
     EmoteExclamationMark
     EndMovement
 
-PastoriaCity_UnusedMovement12:
+PastoriaCity_Movement_Unused12:
     WalkFastSouth
     WalkFastEast 10
     EndMovement
 
-PastoriaCity_UnusedMovement13:
+PastoriaCity_Movement_Unused13:
     WalkFastEast 10
     EndMovement
 
@@ -279,25 +279,25 @@ PastoriaCity_Movement_GruntMLeaveNorthSouthEast:
     WalkOnSpotFastEast
     EndMovement
 
-PastoriaCity_UnusedMovement14:
+PastoriaCity_Movement_Unused14:
     WalkFastSouth
     WalkFastEast 2
     WalkOnSpotFastEast
     EndMovement
 
-PastoriaCity_UnusedMovement15:
+PastoriaCity_Movement_Unused15:
     WalkFastSouth
     WalkFastEast 4
     WalkOnSpotFastEast
     EndMovement
 
-PastoriaCity_UnusedMovement16:
+PastoriaCity_Movement_Unused16:
     WalkFastNorth
     WalkFastEast 3
     WalkOnSpotFastEast
     EndMovement
 
-PastoriaCity_UnusedMovement17:
+PastoriaCity_Movement_Unused17:
     WalkFastSouth
     WalkFastEast 3
     WalkOnSpotFastEast
@@ -818,11 +818,11 @@ PastoriaCity_Movement_RivalWalkOnSpotNorth:
     WalkOnSpotFastNorth
     EndMovement
 
-PastoriaCity_UnusedMovement18:
+PastoriaCity_Movement_Unused18:
     WalkFastSouth 3
     EndMovement
 
-PastoriaCity_UnusedMovement19:
+PastoriaCity_Movement_Unused19:
     WalkOnSpotFastNorth
     EndMovement
 
@@ -876,7 +876,7 @@ PastoriaCity_Movement_CrasherWakeWalkOnSpotNorth:
     WalkOnSpotNormalNorth
     EndMovement
 
-PastoriaCity_UnusedMovement20:
+PastoriaCity_Movement_Unused20:
     WalkOnSpotNormalSouth
     EndMovement
 

--- a/res/field/scripts/scripts_pastoria_city_observatory_gate_1f.s
+++ b/res/field/scripts/scripts_pastoria_city_observatory_gate_1f.s
@@ -256,12 +256,12 @@ PastoriaCityObservatoryGate1F_Movement_CowgirlWalkToPlayer:
     WalkOnSpotNormalNorth
     EndMovement
 
-PastoriaCityObservatoryGate1F_UnusedMovement:
+PastoriaCityObservatoryGate1F_Movement_Unused:
     WalkNormalWest
     WalkOnSpotNormalEast
     EndMovement
 
-PastoriaCityObservatoryGate1F_UnusedMovement2:
+PastoriaCityObservatoryGate1F_Movement_Unused2:
     WalkNormalEast
     WalkOnSpotNormalWest
     EndMovement

--- a/res/field/scripts/scripts_pastoria_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_pastoria_city_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry PastoriaCityPokecenterB1F_UnusedEntry1
+    ScriptEntry PastoriaCityPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-PastoriaCityPokecenterB1F_UnusedEntry1:
+PastoriaCityPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_pokemon_center_2f_common.s
+++ b/res/field/scripts/scripts_pokemon_center_2f_common.s
@@ -8,12 +8,12 @@
     ScriptEntry PokemonCenter2FCommon_AttendantColosseum
     ScriptEntry _051E
     ScriptEntry PokemonCenter2FCommon_AttendantUnionRoom
-    ScriptEntry PokemonCenter2FCommon_UnusedScript9004
-    ScriptEntry PokemonCenter2FCommon_UnusedScript9005
-    ScriptEntry PokemonCenter2FCommon_UnusedScript9006
-    ScriptEntry PokemonCenter2FCommon_UnusedScript9007
-    ScriptEntry PokemonCenter2FCommon_UnusedScript9008
-    ScriptEntry PokemonCenter2FCommon_UnusedScript9009
+    ScriptEntry PokemonCenter2FCommon_Dummy9004
+    ScriptEntry PokemonCenter2FCommon_Dummy9005
+    ScriptEntry PokemonCenter2FCommon_Dummy9006
+    ScriptEntry PokemonCenter2FCommon_Dummy9007
+    ScriptEntry PokemonCenter2FCommon_Dummy9008
+    ScriptEntry PokemonCenter2FCommon_Dummy9009
     ScriptEntry _06A0
     ScriptEntry PokemonCenter2FCommon_AttendantSignTrainerCard
     ScriptEntry PokemonCenter2FCommon_OnFrame_ExitColosseum
@@ -442,22 +442,22 @@ PokemonCenter2FCommon_GriseousOrbCouldNotBeRemoved:
     Common_GriseousOrbCouldNotBeRemoved
     End
 
-PokemonCenter2FCommon_UnusedScript9004:
+PokemonCenter2FCommon_Dummy9004:
     End
 
-PokemonCenter2FCommon_UnusedScript9005:
+PokemonCenter2FCommon_Dummy9005:
     End
 
-PokemonCenter2FCommon_UnusedScript9006:
+PokemonCenter2FCommon_Dummy9006:
     End
 
-PokemonCenter2FCommon_UnusedScript9007:
+PokemonCenter2FCommon_Dummy9007:
     End
 
-PokemonCenter2FCommon_UnusedScript9008:
+PokemonCenter2FCommon_Dummy9008:
     End
 
-PokemonCenter2FCommon_UnusedScript9009:
+PokemonCenter2FCommon_Dummy9009:
     End
 
 _06A0:

--- a/res/field/scripts/scripts_pokemon_league_hallway_to_hall_of_fame.s
+++ b/res/field/scripts/scripts_pokemon_league_hallway_to_hall_of_fame.s
@@ -123,7 +123,7 @@ PokemonLeagueHallwayToHallOfFame_Movement_PlayerFaceCynthia:
     WalkOnSpotNormalEast
     EndMovement
 
-PokemonLeagueElevatorToHallOfFame_UnusedMovement:
+PokemonLeagueElevatorToHallOfFame_Movement_Unused:
     WalkOnSpotNormalEast
     EndMovement
 

--- a/res/field/scripts/scripts_pokemon_league_north_pokecenter_2f.s
+++ b/res/field/scripts/scripts_pokemon_league_north_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry PokemonLeagueNorthPokecenter2F_UnusedEntry1
+    ScriptEntry PokemonLeagueNorthPokecenter2F_Dummy1
     ScriptEntryEnd
 
-PokemonLeagueNorthPokecenter2F_UnusedEntry1:
+PokemonLeagueNorthPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_pokemon_league_north_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_pokemon_league_north_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry PokemonLeagueNorthPokecenterB1F_UnusedEntry1
+    ScriptEntry PokemonLeagueNorthPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-PokemonLeagueNorthPokecenterB1F_UnusedEntry1:
+PokemonLeagueNorthPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_pokemon_league_south_pokecenter_1f.s
+++ b/res/field/scripts/scripts_pokemon_league_south_pokecenter_1f.s
@@ -4,8 +4,8 @@
 
 
     ScriptEntry PokemonLeagueSouthPokecenter1F_Nurse
-    ScriptEntry PokemonLeagueSouthPokecenter1F_UnusedVendor2
-    ScriptEntry PokemonLeagueSouthPokecenter1F_UnusedVendor3
+    ScriptEntry PokemonLeagueSouthPokecenter1F_VendorCommon_Unused
+    ScriptEntry PokemonLeagueSouthPokecenter1F_VendorSpecial_Unused
     ScriptEntry PokemonLeagueSouthPokecenter1F_OnTransition
     ScriptEntry PokemonLeagueSouthPokecenter1F_Pokefan
     ScriptEntry PokemonLeagueSouthPokecenter1F_AceTrainer
@@ -19,11 +19,11 @@ PokemonLeagueSouthPokecenter1F_Nurse:
     Common_CallPokecenterNurse LOCALID_LEAGUE_SOUTH_NURSE
     End
 
-PokemonLeagueSouthPokecenter1F_UnusedVendor2:
+PokemonLeagueSouthPokecenter1F_VendorCommon_Unused:
     PokeMartCommonWithGreeting
     End
 
-PokemonLeagueSouthPokecenter1F_UnusedVendor3:
+PokemonLeagueSouthPokecenter1F_VendorSpecial_Unused:
     PokeMartSpecialtiesWithGreeting MART_SPECIALTIES_ID_POKEMON_LEAGUE
     End
 

--- a/res/field/scripts/scripts_pokemon_league_south_pokecenter_2f.s
+++ b/res/field/scripts/scripts_pokemon_league_south_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry PokemonLeagueSouthPokecenter2F_UnusedEntry1
+    ScriptEntry PokemonLeagueSouthPokecenter2F_Dummy1
     ScriptEntryEnd
 
-PokemonLeagueSouthPokecenter2F_UnusedEntry1:
+PokemonLeagueSouthPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_pokemon_league_south_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_pokemon_league_south_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry PokemonLeagueSouthPokecenterB1F_UnusedEntry1
+    ScriptEntry PokemonLeagueSouthPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-PokemonLeagueSouthPokecenterB1F_UnusedEntry1:
+PokemonLeagueSouthPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_pokemon_mansion.s
+++ b/res/field/scripts/scripts_pokemon_mansion.s
@@ -344,7 +344,7 @@ PokemonMansion_Movement_MaidTrophyGardenFaceSouth:
     FaceSouth
     EndMovement
 
-PokemonMansion_UnusedMovement:
+PokemonMansion_Movement_Unused:
     FaceEast
     EndMovement
 

--- a/res/field/scripts/scripts_resort_area_pokecenter_2f.s
+++ b/res/field/scripts/scripts_resort_area_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry ResortAreaPokecenter2F_UnusedEntry1
+    ScriptEntry ResortAreaPokecenter2F_Dummy1
     ScriptEntryEnd
 
-ResortAreaPokecenter2F_UnusedEntry1:
+ResortAreaPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_resort_area_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_resort_area_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry ResortAreaPokecenterB1F_UnusedEntry1
+    ScriptEntry ResortAreaPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-ResortAreaPokecenterB1F_UnusedEntry1:
+ResortAreaPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_route_201.s
+++ b/res/field/scripts/scripts_route_201.s
@@ -490,7 +490,7 @@ Route201_Movement_RivalWalkToPlayer:
     WalkOnSpotNormalSouth
     EndMovement
 
-Route201_UnusedMovement:
+Route201_Movement_Unused:
     WalkNormalEast
     EndMovement
 
@@ -565,7 +565,7 @@ Route201_Movement_RivalMoveAwayForProfRowan:
     WalkOnSpotNormalEast
     EndMovement
 
-Route201_UnusedMovement2:
+Route201_Movement_Unused2:
     Delay8
     WalkOnSpotFastEast
     EndMovement
@@ -912,23 +912,23 @@ Route201_Movement_PlayerWalkBackNorthToBriefcase:
     WalkNormalNorth
     EndMovement
 
-Route201_UnusedMovement3:
+Route201_Movement_Unused3:
     WalkNormalNorth
     EndMovement
 
-Route201_UnusedMovement4:
+Route201_Movement_Unused4:
     WalkNormalNorth
     EndMovement
 
-Route201_UnusedMovement5:
+Route201_Movement_Unused5:
     WalkNormalWest
     EndMovement
 
-Route201_UnusedMovement6:
+Route201_Movement_Unused6:
     WalkNormalWest
     EndMovement
 
-Route201_UnusedMovement7:
+Route201_Movement_Unused7:
     WalkNormalWest
     EndMovement
 
@@ -1086,7 +1086,7 @@ _0D80:
     WalkOnSpotNormalWest
     EndMovement
 
-Route201_UnusedMovement8:
+Route201_Movement_Unused8:
     WalkOnSpotNormalWest
     EndMovement
 

--- a/res/field/scripts/scripts_route_202.s
+++ b/res/field/scripts/scripts_route_202.s
@@ -497,7 +497,7 @@ Route202_Movement_CounterpartWalkOnSpotNorthToFacePlayer:
     WalkOnSpotNormalNorth
     EndMovement
 
-Route202_UnusedMovement:
+Route202_Movement_Unused:
     WalkOnSpotNormalEast
     EndMovement
 
@@ -506,12 +506,12 @@ Route202_Movement_CounterpartWalkOnSpotWestToFacePlayer:
     WalkOnSpotNormalWest
     EndMovement
 
-Route202_UnusedMovement2:
+Route202_Movement_Unused2:
     Delay8
     WalkOnSpotNormalWest
     EndMovement
 
-Route202_UnusedMovement3:
+Route202_Movement_Unused3:
     Delay8
     WalkOnSpotNormalSouth
     EndMovement
@@ -536,7 +536,7 @@ Route202_Movement_PlayerWalkOnSpotWestToFaceCounterpart:
     WalkOnSpotNormalWest
     EndMovement
 
-Route202_UnusedMovement4:
+Route202_Movement_Unused4:
     WalkOnSpotNormalEast
     EndMovement
 

--- a/res/field/scripts/scripts_route_207.s
+++ b/res/field/scripts/scripts_route_207.s
@@ -6,7 +6,7 @@
 
     ScriptEntry Route207_OnTransition
     ScriptEntry Route207_CoordEvent_Counterpart
-    ScriptEntry Route207_Unused
+    ScriptEntry Route207_Dummy3
     ScriptEntry Route207_CyclistM
     ScriptEntry Route207_ArrowSignpostMtCoronet
     ScriptEntry Route207_ArrowSignpostOreburghCity
@@ -111,12 +111,12 @@ Route207_Movement_PlayerFaceCounterpart:
     WalkOnSpotNormalWest
     EndMovement
 
-Route207_UnusedMovement:
+Route207_Movement_Unused:
     Delay8 8
     WalkOnSpotNormalWest
     EndMovement
 
-Route207_UnusedMovement2:
+Route207_Movement_Unused2:
     Delay8 1
     WalkOnSpotNormalNorth
     EndMovement
@@ -137,7 +137,7 @@ Route207_Movement_CounterpartLeave:
     WalkNormalWest 8
     EndMovement
 
-Route207_Unused:
+Route207_Dummy3:
     NPCMessage Route207_Text_Dummy8
     End
 

--- a/res/field/scripts/scripts_route_209_gate_to_hearthome_city.s
+++ b/res/field/scripts/scripts_route_209_gate_to_hearthome_city.s
@@ -123,7 +123,7 @@ Route209GateToHearthomeCity_RivalLeaveZ9:
     Return
 
     .balign 4, 0
-Route209GateToHearthomeCity_UnusedMovement:
+Route209GateToHearthomeCity_Movement_Unused:
     WalkFastWest 4
     EmoteExclamationMark
     EndMovement

--- a/res/field/scripts/scripts_route_210_south.s
+++ b/res/field/scripts/scripts_route_210_south.s
@@ -4,7 +4,7 @@
 
 
     ScriptEntry Route210South_Psyduck
-    ScriptEntry Route210South_Unused
+    ScriptEntry Route210South_Dummy2
     ScriptEntry Route210South_AceTrainerF
     ScriptEntry Route210South_SignboardCafeCabin
     ScriptEntry Route210South_ArrowSignpostSolaceonTown
@@ -202,21 +202,21 @@ Route210South_Movement_PlayerWalkOnSpotSouth:
     WalkOnSpotNormalSouth
     EndMovement
 
-Route210South_UnusedMovement:
+Route210South_Movement_Unused:
     Delay8
     WalkOnSpotNormalEast
     Delay8
     WalkOnSpotNormalNorth
     EndMovement
 
-Route210South_UnusedMovement2:
+Route210South_Movement_Unused2:
     Delay8
     WalkOnSpotNormalWest
     Delay8
     WalkOnSpotNormalNorth
     EndMovement
 
-Route210South_Unused:
+Route210South_Dummy2:
     NPCMessage Route210South_Text_Dummy6
     End
 

--- a/res/field/scripts/scripts_route_211_west.s
+++ b/res/field/scripts/scripts_route_211_west.s
@@ -2,12 +2,12 @@
 #include "res/text/bank/route_211_west.h"
 
 
-    ScriptEntry Route211West_Unused
+    ScriptEntry Route211West_Dummy1
     ScriptEntry Route211West_ArrowSignpostMtCoronet
     ScriptEntry Route211West_ArrowSignpostEternaCity
     ScriptEntryEnd
 
-Route211West_Unused:
+Route211West_Dummy1:
     NPCMessage Route211West_Text_Dummy0
     End
 

--- a/res/field/scripts/scripts_route_215.s
+++ b/res/field/scripts/scripts_route_215.s
@@ -2,7 +2,7 @@
 #include "res/text/bank/route_215.h"
 
 
-    ScriptEntry Route215_Unused
+    ScriptEntry Route215_Dummy1
     ScriptEntry Route215_BlackBelt
     ScriptEntry Route215_ArrowSignpostWest
     ScriptEntry Route215_ArrowSignpostVeilstoneCity
@@ -32,7 +32,7 @@ Route215_SetJoggersNoBattle:
     SetFlag FLAG_HIDE_ROUTE_215_JOGGER_CRAIG
     End
 
-Route215_Unused:
+Route215_Dummy1:
     NPCMessage Route215_Text_Dummy0
     End
 

--- a/res/field/scripts/scripts_route_216.s
+++ b/res/field/scripts/scripts_route_216.s
@@ -2,12 +2,12 @@
 #include "res/text/bank/route_216.h"
 
 
-    ScriptEntry Route216_Unused
+    ScriptEntry Route216_CantRideBike_Unused
     ScriptEntry Route216_ArrowSignpostMtCoronet
     ScriptEntry Route216_SignboardSnowboundLodge
     ScriptEntryEnd
 
-Route216_Unused:
+Route216_CantRideBike_Unused:
     NPCMessage Route216_Text_CantRideBikeOnSnow
     End
 

--- a/res/field/scripts/scripts_route_222_west_house.s
+++ b/res/field/scripts/scripts_route_222_west_house.s
@@ -4,10 +4,10 @@
 
     ScriptEntry Route222WestHouse_OnTransition
     ScriptEntry Route222WestHouse_Pikachu
-    ScriptEntry Route222WestHouse_Unused3
-    ScriptEntry Route222WestHouse_Unused4
-    ScriptEntry Route222WestHouse_Unused5
-    ScriptEntry Route222WestHouse_Unused6
+    ScriptEntry Route222WestHouse_Pikachu3_Unused
+    ScriptEntry Route222WestHouse_Pikachu4_Unused
+    ScriptEntry Route222WestHouse_Pikachu5_Unused
+    ScriptEntry Route222WestHouse_Pikachu6_Unused
     ScriptEntry Route222WestHouse_PokefanM
     ScriptEntryEnd
 
@@ -19,19 +19,19 @@ Route222WestHouse_Pikachu:
     PokemonCryAndMessage SPECIES_PIKACHU, Route222WestHouse_Text_PikachuCryPikachuu
     End
 
-Route222WestHouse_Unused3:
+Route222WestHouse_Pikachu3_Unused:
     PokemonCryAndMessage SPECIES_PIKACHU, Route222WestHouse_Text_PikachuCryPikaah
     End
 
-Route222WestHouse_Unused4:
+Route222WestHouse_Pikachu4_Unused:
     PokemonCryAndMessage SPECIES_PIKACHU, Route222WestHouse_Text_PikachuCryPikaPika
     End
 
-Route222WestHouse_Unused5:
+Route222WestHouse_Pikachu5_Unused:
     PokemonCryAndMessage SPECIES_PIKACHU, Route222WestHouse_Text_PikachuCryPiPikachu
     End
 
-Route222WestHouse_Unused6:
+Route222WestHouse_Pikachu6_Unused:
     PokemonCryAndMessage SPECIES_PIKACHU, Route222WestHouse_Text_PikachuCryPiiKaahchu
     End
 

--- a/res/field/scripts/scripts_route_224.s
+++ b/res/field/scripts/scripts_route_224.s
@@ -303,7 +303,7 @@ Route224_Movement_ProfOakLookAround:
     Delay16
     EndMovement
 
-Route224_UnusedMovement:
+Route224_Movement_Unused:
     WalkOnSpotNormalSouth
     EndMovement
 

--- a/res/field/scripts/scripts_route_227.s
+++ b/res/field/scripts/scripts_route_227.s
@@ -86,7 +86,7 @@ Route227_Movement_PlayerWatchRivalLeave:
     WalkOnSpotNormalSouth
     EndMovement
 
-Route227_UnusedMovement:
+Route227_Movement_Unused:
     WalkOnSpotNormalNorth
     EndMovement
 
@@ -98,7 +98,7 @@ Route227_Movement_PlayerWalkWestWatchWakeLeave:
     WalkOnSpotNormalSouth
     EndMovement
 
-Route227_UnusedMovement2:
+Route227_Movement_Unused2:
     Delay8
     WalkOnSpotNormalWest
     Delay4
@@ -131,7 +131,7 @@ Route227_Movement_RivalLeave:
     WalkFastSouth 9
     EndMovement
 
-Route227_UnusedMovement3:
+Route227_Movement_Unused3:
     WalkFastSouth 9
     EndMovement
 
@@ -151,12 +151,12 @@ Route227_Movement_WakeWalkOnSpotSouth:
     WalkOnSpotNormalSouth
     EndMovement
 
-Route227_UnusedMovement4:
+Route227_Movement_Unused4:
     Delay8
     WalkOnSpotNormalEast
     EndMovement
 
-Route227_UnusedMovement5:
+Route227_Movement_Unused5:
     WalkOnSpotNormalSouth
     EndMovement
 
@@ -166,7 +166,7 @@ Route227_Movement_WakeLeave:
     WalkNormalSouth 9
     EndMovement
 
-Route227_UnusedMovement6:
+Route227_Movement_Unused6:
     WalkNormalSouth 9
     EndMovement
 
@@ -216,7 +216,7 @@ Route227_Movement_PlayerFaceBuck:
     FaceNorth
     EndMovement
 
-Route227_UnusedMovement7:
+Route227_Movement_Unused7:
     Delay8
     WalkOnSpotNormalEast
     EndMovement

--- a/res/field/scripts/scripts_sandgem_town.s
+++ b/res/field/scripts/scripts_sandgem_town.s
@@ -9,7 +9,7 @@
     ScriptEntry SandgemTown_Youngster
     ScriptEntry SandgemTown_PokemonBreederM
     ScriptEntry SandgemTown_PokemonBreederF
-    ScriptEntry SandgemTown_Unused
+    ScriptEntry SandgemTown_RowansComeBack_Unused
     ScriptEntry SandgemTown_MapSignpost
     ScriptEntry SandgemTown_SignboardPokemonResearchLab
     ScriptEntry SandgemTown_SignboardCounterpartMailbox
@@ -323,12 +323,12 @@ SandgemTown_Movement_PlayerFaceCounterpartZ843:
     FaceSouth
     EndMovement
 
-SandgemTown_UnusedMovement:
+SandgemTown_Movement_Unused:
     Delay8 3
     WalkOnSpotNormalSouth
     EndMovement
 
-SandgemTown_UnusedMovement2:
+SandgemTown_Movement_Unused2:
     WalkNormalEast 4
     WalkNormalNorth 2
     EndMovement
@@ -674,7 +674,7 @@ SandgemTown_PokemonBreederF:
     NPCMessage SandgemTown_Text_IdBetterSaveThis
     End
 
-SandgemTown_Unused:
+SandgemTown_RowansComeBack_Unused:
     NPCMessage SandgemTown_Text_ProfessorRowansComeBackToTown
     End
 

--- a/res/field/scripts/scripts_sandgem_town_mart.s
+++ b/res/field/scripts/scripts_sandgem_town_mart.s
@@ -3,7 +3,7 @@
 
 
     ScriptEntry SandgemTownMart_CommonVendor
-    ScriptEntry SandgemTownMart_Dummy
+    ScriptEntry SandgemTownMart_Dummy2
     ScriptEntry SandgemTownMart_Breeder
     ScriptEntry SandgemTownMart_SchoolBoy
     ScriptEntryEnd
@@ -12,7 +12,7 @@ SandgemTownMart_CommonVendor:
     PokeMartCommonWithGreeting 0
     End
 
-SandgemTownMart_Dummy:
+SandgemTownMart_Dummy2:
     End
 
 SandgemTownMart_Breeder:

--- a/res/field/scripts/scripts_sandgem_town_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_sandgem_town_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry SandgemTownPokecenterB1F_UnusedEntry1
+    ScriptEntry SandgemTownPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-SandgemTownPokecenterB1F_UnusedEntry1:
+SandgemTownPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_sandgem_town_pokemon_research_lab.s
+++ b/res/field/scripts/scripts_sandgem_town_pokemon_research_lab.s
@@ -6,16 +6,16 @@
     ScriptEntry SandgemTownLab_OnTransition
     ScriptEntry SandgemTownLab_OnFrame_GetPokedex
     ScriptEntry SandgemTownLab_ProfRowan
-    ScriptEntry SandgemTownLab_UnusedEntry4
+    ScriptEntry SandgemTownLab_Dummy4
     ScriptEntry SandgemTownLab_ScientistM
     ScriptEntry SandgemTownLab_ScientistF
-    ScriptEntry SandgemTownLab_UnusedEntry7
+    ScriptEntry SandgemTownLab_Dummy7
     ScriptEntry SandgemTownLab_BookshelfAdventureRuleNo1
     ScriptEntry SandgemTownLab_BookshelfAdventureRuleNo2
     ScriptEntry SandgemTownLab_BookshelfBooks
     ScriptEntry SandgemTownLab_BookshelfReferenceMaterial
     ScriptEntry SandgemTownLab_PC
-    ScriptEntry SandgemTownLab_UnusedEntry13
+    ScriptEntry SandgemTownLab_ResearchMaterials_Unused
     ScriptEntry SandgemTownLab_Refrigerator
     ScriptEntry SandgemTownLab_OnFrame_ReturnedFromDistortionWorld
     ScriptEntryEnd
@@ -123,7 +123,7 @@ SandgemTownLab_Movement_CounterpartTurnOnSpot:
     WalkOnSpotNormalSouth
     EndMovement
 
-SandgemTownLab_UnusedEntry4:
+SandgemTownLab_Dummy4:
     End
 
 SandgemTownLab_OnFrame_GetPokedex:
@@ -314,7 +314,7 @@ SandgemTownLab_CounterpartLeave:
     End
 
     .balign 4, 0
-SandgemTownPokemonResearchLab_UnusedMovement:
+SandgemTownPokemonResearchLab_Movement_Unused:
     WalkOnSpotNormalSouth
     EndMovement
 
@@ -441,7 +441,7 @@ SandgemTownLab_HearingWhatWasHappeningGaveMeShivers:
     ReleaseAll
     End
 
-SandgemTownLab_UnusedEntry7:
+SandgemTownLab_Dummy7:
     End
 
 SandgemTownLab_BookshelfAdventureRuleNo1:
@@ -465,7 +465,7 @@ SandgemTownLab_PC:
     EventMessage SandgemTownLab_Text_PlayerCheckedThePC
     End
 
-SandgemTownLab_UnusedEntry13:
+SandgemTownLab_ResearchMaterials_Unused:
     EventMessage SandgemTownLab_Text_ResearchMaterialsAreCarefullyTuckedAway
     End
 
@@ -629,7 +629,7 @@ SandgemTownLab_Movement_ProfRowanTurnOnSpot:
     WalkOnSpotNormalSouth
     EndMovement
 
-SandgemTownPokemonResearchLab_UnusedMovement2:
+SandgemTownPokemonResearchLab_Movement_Unused2:
     WalkOnSpotNormalWest
     EndMovement
 

--- a/res/field/scripts/scripts_snowpoint_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_snowpoint_city_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry SnowpointCityPokecenter2F_UnusedEntry1
+    ScriptEntry SnowpointCityPokecenter2F_Dummy1
     ScriptEntryEnd
 
-SnowpointCityPokecenter2F_UnusedEntry1:
+SnowpointCityPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_snowpoint_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_snowpoint_city_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry SnowpointCityPokecenterB1F_UnusedEntry1
+    ScriptEntry SnowpointCityPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-SnowpointCityPokecenterB1F_UnusedEntry1:
+SnowpointCityPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_solaceon_town_pokecenter_2f.s
+++ b/res/field/scripts/scripts_solaceon_town_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry SolaceonTownPokecenter2F_UnusedEntry1
+    ScriptEntry SolaceonTownPokecenter2F_Dummy1
     ScriptEntryEnd
 
-SolaceonTownPokecenter2F_UnusedEntry1:
+SolaceonTownPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_solaceon_town_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_solaceon_town_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry SolaceonTownPokecenterB1F_UnusedEntry1
+    ScriptEntry SolaceonTownPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-SolaceonTownPokecenterB1F_UnusedEntry1:
+SolaceonTownPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_spear_pillar.s
+++ b/res/field/scripts/scripts_spear_pillar.s
@@ -326,20 +326,20 @@ SpearPillar_PlayerRivalFaceEachOtherX32:
     Return
 
 SpearPillar_Unused3:
-    ApplyMovement LOCALID_JUPITER, SpearPillar_UnusedMovement
-    ApplyMovement LOCALID_MARS, SpearPillar_UnusedMovement2
+    ApplyMovement LOCALID_JUPITER, SpearPillar_Movement_Unused
+    ApplyMovement LOCALID_MARS, SpearPillar_Movement_Unused2
     WaitMovement
     Return
 
     .balign 4, 0
-SpearPillar_UnusedMovement:
+SpearPillar_Movement_Unused:
     FaceEast
     LockDir
     WalkSlowWest
     UnlockDir
     EndMovement
 
-SpearPillar_UnusedMovement2:
+SpearPillar_Movement_Unused2:
     FaceWest
     LockDir
     WalkSlowEast

--- a/res/field/scripts/scripts_stark_mountain_outside.s
+++ b/res/field/scripts/scripts_stark_mountain_outside.s
@@ -58,7 +58,7 @@ StarkMountainOutside_Movement_GruntM1WalkToEntrance:
     WalkNormalNorth
     EndMovement
 
-StarkMountainOutside_UnusedMovement:
+StarkMountainOutside_Movement_Unused:
     WalkOnSpotNormalWest
     EndMovement
 

--- a/res/field/scripts/scripts_stark_mountain_room_2.s
+++ b/res/field/scripts/scripts_stark_mountain_room_2.s
@@ -6,8 +6,8 @@
     ScriptEntry StarkMountainRoom2_CoordEvent_BuckStartFollowing
     ScriptEntry StarkMountainRoom2_CoordEvent_PlayerLeaveBuck
     ScriptEntry StarkMountainRoom2_CoordEvent_BuckLeavePlayer
-    ScriptEntry StarkMountainRoom2_Unused4
-    ScriptEntry StarkMountainRoom2_Unused5
+    ScriptEntry StarkMountainRoom2_Dummy4
+    ScriptEntry StarkMountainRoom2_Dummy5
     ScriptEntry StarkMountainRoom2_OnTransition
     ScriptEntryEnd
 
@@ -71,7 +71,7 @@ StarkMountainRoom2_Movement_BuckEnter:
     WalkNormalNorth 8
     EndMovement
 
-StarkMountainRoom2_UnusedMovement:
+StarkMountainRoom2_Movement_Unused:
     WalkNormalNorth
     EndMovement
 
@@ -80,7 +80,7 @@ StarkMountainRoom2_Movement_PlayerWalkOnSpotSouth:
     WalkOnSpotNormalSouth
     EndMovement
 
-StarkMountainRoom2_UnusedMovement2:
+StarkMountainRoom2_Movement_Unused2:
     WalkNormalNorth
     EndMovement
 
@@ -187,11 +187,11 @@ StarkMountainRoom2_Movement_BuckEnterRoom3:
     WalkNormalNorth
     EndMovement
 
-StarkMountainRoom2_Unused4:
+StarkMountainRoom2_Dummy4:
     NPCMessage StarkMountainRoom2_Text_Dummy6
     End
 
-StarkMountainRoom2_Unused5:
+StarkMountainRoom2_Dummy5:
     NPCMessage StarkMountainRoom2_Text_Dummy7
     End
 

--- a/res/field/scripts/scripts_stark_mountain_room_3.s
+++ b/res/field/scripts/scripts_stark_mountain_room_3.s
@@ -5,7 +5,7 @@
 
     ScriptEntry StarkMountainRoom3_OnTransition
     ScriptEntry StarkMountainRoom3_OnLoad
-    ScriptEntry StarkMountainRoom3_Unused
+    ScriptEntry StarkMountainRoom3_Buck_Unused
     ScriptEntry StarkMountainRoom3_Heatran
     ScriptEntry StarkMountainRoom3_OnFrame_Charon
     ScriptEntryEnd
@@ -45,7 +45,7 @@ StarkMountainRoom3_RemoveHeatran:
     ClearFlag FLAG_MAP_LOCAL
     End
 
-StarkMountainRoom3_UnusedMovement:
+StarkMountainRoom3_Movement_Unused:
     WalkNormalWest
     WalkOnSpotNormalEast
     WalkOnSpotNormalSouth
@@ -56,16 +56,16 @@ StarkMountainRoom3_Movement_BuckWalkOnSpotNorth:
     WalkOnSpotNormalNorth
     EndMovement
 
-StarkMountainRoom3_UnusedMovement2:
+StarkMountainRoom3_Movement_Unused2:
     WalkOnSpotNormalNorth
     EndMovement
 
-StarkMountainRoom3_UnusedMovement3:
+StarkMountainRoom3_Movement_Unused3:
     Delay8
     WalkNormalSouth 9
     EndMovement
 
-StarkMountainRoom3_Unused:
+StarkMountainRoom3_Buck_Unused:
     BufferPlayerName 1
     NPCMessage StarkMountainRoom3_Text_ThatWasWicked
     End
@@ -117,15 +117,15 @@ StarkMountainRoom3_UnlockVSSeekerLvl5:
     SetFlag FLAG_UNLOCKED_VS_SEEKER_LVL_5
     Return
 
-StarkMountainRoom3_UnusedMovement4:
+StarkMountainRoom3_Movement_Unused4:
     WalkNormalNorth 6
     EndMovement
 
-StarkMountainRoom3_UnusedMovement5:
+StarkMountainRoom3_Movement_Unused5:
     WalkNormalSouth 6
     EndMovement
 
-StarkMountainRoom3_UnusedMovement6:
+StarkMountainRoom3_Movement_Unused6:
     Delay8 4
     WalkOnSpotNormalSouth
     EndMovement

--- a/res/field/scripts/scripts_sunyshore_city.s
+++ b/res/field/scripts/scripts_sunyshore_city.s
@@ -4,7 +4,7 @@
 
 
     ScriptEntry SunyshoreCity_OnFrame_Flint
-    ScriptEntry SunyshoreCity_Unused2
+    ScriptEntry SunyshoreCity_Dummy2
     ScriptEntry SunyshoreCity_Sailor2
     ScriptEntry SunyshoreCity_Sailor1
     ScriptEntry SunyshoreCity_Worker
@@ -19,7 +19,7 @@
     ScriptEntry SunyshoreCity_SignboardJuliasHouse
     ScriptEntry SunyshoreCity_SignboardBlank
     ScriptEntry SunyshoreCity_SignboardPokemonRock
-    ScriptEntry SunyshoreCity_UnusedSealMerchant
+    ScriptEntry SunyshoreCity_SealMerchant_Unused
     ScriptEntry SunyshoreCity_Flint
     ScriptEntry SunyshoreCity_OnTransition
     ScriptEntryEnd
@@ -519,7 +519,7 @@ SunyshoreCity_Movement_FlintLeave:
     WalkNormalEast 9
     EndMovement
 
-SunyshoreCity_Unused2:
+SunyshoreCity_Dummy2:
     NPCMessage SunyshoreCity_Text_Dummy14
     End
 
@@ -571,7 +571,7 @@ SunyshoreCity_SignboardPokemonRock:
     ShowLandmarkSign SunyshoreCity_Text_SignPokemonRock
     End
 
-SunyshoreCity_UnusedSealMerchant:
+SunyshoreCity_SealMerchant_Unused:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     FacePlayer
@@ -579,44 +579,44 @@ SunyshoreCity_UnusedSealMerchant:
     CloseMessageWithoutErasing
     GetDayOfWeek VAR_RESULT
     SetVar VAR_0x8008, VAR_RESULT
-    GoToIfEq VAR_0x8008, DAY_OF_WEEK_SUNDAY, SunyshoreCity_UnusedSealMerchantSunday
-    GoToIfEq VAR_0x8008, DAY_OF_WEEK_MONDAY, SunyshoreCity_UnusedSealMerchantMonday
-    GoToIfEq VAR_0x8008, DAY_OF_WEEK_TUESDAY, SunyshoreCity_UnusedSealMerchantTuesday
-    GoToIfEq VAR_0x8008, DAY_OF_WEEK_WEDNESDAY, SunyshoreCity_UnusedSealMerchantWednesday
-    GoToIfEq VAR_0x8008, DAY_OF_WEEK_THURSDAY, SunyshoreCity_UnusedSealMerchantThursday
-    GoToIfEq VAR_0x8008, DAY_OF_WEEK_FRIDAY, SunyshoreCity_UnusedSealMerchantFriday
-    GoToIfEq VAR_0x8008, DAY_OF_WEEK_SATURDAY, SunyshoreCity_UnusedSealMerchantSaturday
+    GoToIfEq VAR_0x8008, DAY_OF_WEEK_SUNDAY, SunyshoreCity_SealMerchantSunday_Unused
+    GoToIfEq VAR_0x8008, DAY_OF_WEEK_MONDAY, SunyshoreCity_SealMerchantMonday_Unused
+    GoToIfEq VAR_0x8008, DAY_OF_WEEK_TUESDAY, SunyshoreCity_SealMerchantTuesday_Unused
+    GoToIfEq VAR_0x8008, DAY_OF_WEEK_WEDNESDAY, SunyshoreCity_SealMerchantWednesday_Unused
+    GoToIfEq VAR_0x8008, DAY_OF_WEEK_THURSDAY, SunyshoreCity_SealMerchantThursday_Unused
+    GoToIfEq VAR_0x8008, DAY_OF_WEEK_FRIDAY, SunyshoreCity_SealMerchantFriday_Unused
+    GoToIfEq VAR_0x8008, DAY_OF_WEEK_SATURDAY, SunyshoreCity_SealMerchantSaturday_Unused
     End
 
-SunyshoreCity_UnusedSealMerchantSunday:
+SunyshoreCity_SealMerchantSunday_Unused:
     PokeMartSeal MART_SEAL_ID_SUNYSHORE_MONDAY
-    GoTo SunyshoreCity_UnusedSealMerchantEnd
+    GoTo SunyshoreCity_SealMerchantEnd_Unused
 
-SunyshoreCity_UnusedSealMerchantMonday:
+SunyshoreCity_SealMerchantMonday_Unused:
     PokeMartSeal MART_SEAL_ID_SUNYSHORE_TUESDAY
-    GoTo SunyshoreCity_UnusedSealMerchantEnd
+    GoTo SunyshoreCity_SealMerchantEnd_Unused
 
-SunyshoreCity_UnusedSealMerchantTuesday:
+SunyshoreCity_SealMerchantTuesday_Unused:
     PokeMartSeal MART_SEAL_ID_SUNYSHORE_WEDNESDAY
-    GoTo SunyshoreCity_UnusedSealMerchantEnd
+    GoTo SunyshoreCity_SealMerchantEnd_Unused
 
-SunyshoreCity_UnusedSealMerchantWednesday:
+SunyshoreCity_SealMerchantWednesday_Unused:
     PokeMartSeal MART_SEAL_ID_SUNYSHORE_THURSDAY
-    GoTo SunyshoreCity_UnusedSealMerchantEnd
+    GoTo SunyshoreCity_SealMerchantEnd_Unused
 
-SunyshoreCity_UnusedSealMerchantThursday:
+SunyshoreCity_SealMerchantThursday_Unused:
     PokeMartSeal MART_SEAL_ID_SUNYSHORE_FRIDAY
-    GoTo SunyshoreCity_UnusedSealMerchantEnd
+    GoTo SunyshoreCity_SealMerchantEnd_Unused
 
-SunyshoreCity_UnusedSealMerchantFriday:
+SunyshoreCity_SealMerchantFriday_Unused:
     PokeMartSeal MART_SEAL_ID_SUNYSHORE_SATURDAY
-    GoTo SunyshoreCity_UnusedSealMerchantEnd
+    GoTo SunyshoreCity_SealMerchantEnd_Unused
 
-SunyshoreCity_UnusedSealMerchantSaturday:
+SunyshoreCity_SealMerchantSaturday_Unused:
     PokeMartSeal MART_SEAL_ID_SUNYSHORE_SUNDAY
-    GoTo SunyshoreCity_UnusedSealMerchantEnd
+    GoTo SunyshoreCity_SealMerchantEnd_Unused
 
-SunyshoreCity_UnusedSealMerchantEnd:
+SunyshoreCity_SealMerchantEnd_Unused:
     ReleaseAll
     End
 

--- a/res/field/scripts/scripts_sunyshore_city_gym_room_2.s
+++ b/res/field/scripts/scripts_sunyshore_city_gym_room_2.s
@@ -5,7 +5,7 @@
     ScriptEntry SunyshoreGymRoom2_Init
     ScriptEntry SunyshoreGymRoom2_BottomButton
     ScriptEntry SunyshoreGymRoom2_TopButtons
-    ScriptEntry SunyshoreGymRoom2_Empty
+    ScriptEntry SunyshoreGymRoom2_Dummy4
     ScriptEntryEnd
 
 SunyshoreGymRoom2_Init:
@@ -21,7 +21,7 @@ SunyshoreGymRoom2_TopButtons:
     PressSunyshoreGymButton SUNYSHORE_GYM_BUTTON_REVERSE
     End
 
-SunyshoreGymRoom2_Empty:
+SunyshoreGymRoom2_Dummy4:
     End
 
     .balign 4, 0

--- a/res/field/scripts/scripts_sunyshore_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_sunyshore_city_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry SunyshoreCityPokecenter2F_UnusedEntry1
+    ScriptEntry SunyshoreCityPokecenter2F_Dummy1
     ScriptEntryEnd
 
-SunyshoreCityPokecenter2F_UnusedEntry1:
+SunyshoreCityPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_sunyshore_city_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_sunyshore_city_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry SunyshoreCityPokecenterB1F_UnusedEntry1
+    ScriptEntry SunyshoreCityPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-SunyshoreCityPokecenterB1F_UnusedEntry1:
+SunyshoreCityPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_sunyshore_market.s
+++ b/res/field/scripts/scripts_sunyshore_market.s
@@ -8,10 +8,10 @@
     ScriptEntry SunyshoreMarket_Sailor
     ScriptEntry SunyshoreMarket_SealShop
     ScriptEntry SunyshoreMarket_PokefanM
-    ScriptEntry SunyshoreMarket_Dummy
+    ScriptEntry SunyshoreMarket_Dummy5
     ScriptEntry SunyshoreMarket_BattleGirl
 
-SunyshoreMarket_Dummy:
+SunyshoreMarket_Dummy5:
     End
 
 SunyshoreMarket_EffortRibbonWoman:

--- a/res/field/scripts/scripts_survival_area_mart.s
+++ b/res/field/scripts/scripts_survival_area_mart.s
@@ -3,7 +3,7 @@
 
 
     ScriptEntry SurvivalAreaMart_CommonVendor
-    ScriptEntry SurvivalAreaMart_Unused
+    ScriptEntry SurvivalAreaMart_Dummy2
     ScriptEntry SurvivalAreaMart_Hiker
     ScriptEntry SurvivalAreaMart_AceTrainerF
     ScriptEntryEnd
@@ -12,7 +12,7 @@ SurvivalAreaMart_CommonVendor:
     PokeMartCommonWithGreeting
     End
 
-SurvivalAreaMart_Unused:
+SurvivalAreaMart_Dummy2:
     End
 
 SurvivalAreaMart_Hiker:

--- a/res/field/scripts/scripts_survival_area_pokecenter_2f.s
+++ b/res/field/scripts/scripts_survival_area_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry SurvivalAreaPokecenter2F_UnusedEntry1
+    ScriptEntry SurvivalAreaPokecenter2F_Dummy1
     ScriptEntryEnd
 
-SurvivalAreaPokecenter2F_UnusedEntry1:
+SurvivalAreaPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_survival_area_pokecenter_b1f.s
+++ b/res/field/scripts/scripts_survival_area_pokecenter_b1f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry SurvivalAreaPokecenterB1F_UnusedEntry1
+    ScriptEntry SurvivalAreaPokecenterB1F_Dummy1
     ScriptEntryEnd
 
-SurvivalAreaPokecenterB1F_UnusedEntry1:
+SurvivalAreaPokecenterB1F_Dummy1:
     End

--- a/res/field/scripts/scripts_team_galactic_eterna_building_4f.s
+++ b/res/field/scripts/scripts_team_galactic_eterna_building_4f.s
@@ -100,7 +100,7 @@ TeamGalacticEternaBuilding4F_Movement_PokefanMWalkToPlayerNorth:
     WalkNormalNorth
     EndMovement
 
-TeamGalacticEternaBuilding4F_UnusedMovement:
+TeamGalacticEternaBuilding4F_Movement_Unused:
     Delay8
     WalkNormalEast 2
     WalkOnSpotNormalNorth
@@ -124,13 +124,13 @@ TeamGalacticEternaBuilding4F_Movement_PlayerFacePokefanM:
     WalkOnSpotNormalSouth
     EndMovement
 
-TeamGalacticEternaBuilding4F_UnusedMovement2:
+TeamGalacticEternaBuilding4F_Movement_Unused2:
     WalkOnSpotNormalWest
     Delay4
     WalkOnSpotNormalSouth
     EndMovement
 
-TeamGalacticEternaBuilding4F_UnusedMovement3:
+TeamGalacticEternaBuilding4F_Movement_Unused3:
     WalkOnSpotNormalWest
     EndMovement
 

--- a/res/field/scripts/scripts_trainers_school.s
+++ b/res/field/scripts/scripts_trainers_school.s
@@ -6,12 +6,12 @@
 
     ScriptEntry TrainersSchool_Rival
     ScriptEntry TrainersSchool_AceTrainerF
-    ScriptEntry TrainersSchool_Unused3
+    ScriptEntry TrainersSchool_Dummy3
     ScriptEntry TrainersSchool_Youngster1
     ScriptEntry TrainersSchool_Youngster2
     ScriptEntry TrainersSchool_Lass
-    ScriptEntry TrainersSchool_Unused7
-    ScriptEntry TrainersSchool_Unused8
+    ScriptEntry TrainersSchool_Dummy7
+    ScriptEntry TrainersSchool_Dummy8
     ScriptEntry TrainersSchool_SchoolKidHarrison
     ScriptEntry TrainersSchool_SchoolKidChristine
     ScriptEntry TrainersSchool_Blackboard
@@ -110,7 +110,7 @@ TrainersSchool_AceTrainerF:
     NPCMessage TrainersSchool_Text_DevelopAtOwnPace
     End
 
-TrainersSchool_Unused3:
+TrainersSchool_Dummy3:
     End
 
 TrainersSchool_Youngster1:
@@ -125,10 +125,10 @@ TrainersSchool_Lass:
     NPCMessage TrainersSchool_Text_PokemonUseItems
     End
 
-TrainersSchool_Unused7:
+TrainersSchool_Dummy7:
     End
 
-TrainersSchool_Unused8:
+TrainersSchool_Dummy8:
     End
 
 TrainersSchool_SchoolKidHarrison:

--- a/res/field/scripts/scripts_trophy_garden.s
+++ b/res/field/scripts/scripts_trophy_garden.s
@@ -1,14 +1,14 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry TrophyGarden_Unused1
+    ScriptEntry TrophyGarden_SetFlagFirstArrival_Unused
     ScriptEntryEnd
 
-TrophyGarden_Unused1:
+TrophyGarden_SetFlagFirstArrival_Unused:
     SetFlag FLAG_FIRST_ARRIVAL_TROPHY_GARDEN
     End
 
-TrophyGarden_Unused2:
+TrophyGarden_Unused:
     End
 
     .balign 4, 0

--- a/res/field/scripts/scripts_tv_reporter_interviews.s
+++ b/res/field/scripts/scripts_tv_reporter_interviews.s
@@ -2,18 +2,18 @@
 #include "res/text/bank/tv_reporter_interviews.h"
 
 
-    ScriptEntry TVReporterInterviews_UnusedEntry10150
+    ScriptEntry TVReporterInterviews_Interview1_Unused
     ScriptEntry TVReporterInterviews_BattleTower
-    ScriptEntry TVReporterInterviews_UnusedEntry10152
+    ScriptEntry TVReporterInterviews_Interview3_Unused
     ScriptEntry TVReporterInterviews_HearthomeCityPokemonFanClub
-    ScriptEntry TVReporterInterviews_UnusedEntry10154
+    ScriptEntry TVReporterInterviews_Interview5_Unused
     ScriptEntry TVReporterInterviews_PoketchCo1F
     ScriptEntry TVReporterInterviews_ContestHallLobby
-    ScriptEntry TVReporterInterviews_UnusedEntry10157
+    ScriptEntry TVReporterInterviews_Interview8_Unused
     ScriptEntry TVReporterInterviews_JubilifeTV2F
     ScriptEntry TVReporterInterviews_CanalaveCityWestHouse
     ScriptEntry TVReporterInterviews_PoffinHouse
-    ScriptEntry TVReporterInterviews_UnusedEntry10161
+    ScriptEntry TVReporterInterviews_Interview12_Unused
     ScriptEntry TVReporterInterviews_HearthomeCityGates
     ScriptEntry TVReporterInterviews_BattleHall
     ScriptEntry TVReporterInterviews_Route214GateToVeilstoneCity
@@ -23,7 +23,7 @@
     ScriptEntry TVReporterInterviews_BattleFrontier
     ScriptEntryEnd
 
-TVReporterInterviews_UnusedEntry10150:
+TVReporterInterviews_Interview1_Unused:
     SetVar VAR_0x8000, TV_PROGRAM_SEGMENT_INTERVIEW_UNUSED_01
     GoTo TVReporterInterviews_AskDoInterview
 
@@ -31,7 +31,7 @@ TVReporterInterviews_BattleTower:
     SetVar VAR_0x8000, TV_PROGRAM_SEGMENT_BATTLE_TOWER_CORNER
     GoTo TVReporterInterviews_AskDoInterview
 
-TVReporterInterviews_UnusedEntry10152:
+TVReporterInterviews_Interview3_Unused:
     SetVar VAR_0x8000, TV_PROGRAM_SEGMENT_INTERVIEW_UNUSED_03
     GoTo TVReporterInterviews_AskDoInterview
 
@@ -39,7 +39,7 @@ TVReporterInterviews_HearthomeCityPokemonFanClub:
     SetVar VAR_0x8000, TV_PROGRAM_SEGMENT_YOUR_POKEMON_CORNER
     GoTo TVReporterInterviews_AskDoInterview
 
-TVReporterInterviews_UnusedEntry10154:
+TVReporterInterviews_Interview5_Unused:
     SetVar VAR_0x8000, TV_PROGRAM_SEGMENT_INTERVIEW_UNUSED_05
     GoTo TVReporterInterviews_AskDoInterview
 
@@ -51,7 +51,7 @@ TVReporterInterviews_ContestHallLobby:
     SetVar VAR_0x8000, TV_PROGRAM_SEGMENT_CONTEST_HALL
     GoTo TVReporterInterviews_AskDoInterview
 
-TVReporterInterviews_UnusedEntry10157:
+TVReporterInterviews_Interview8_Unused:
     SetVar VAR_0x8000, TV_PROGRAM_SEGMENT_INTERVIEW_UNUSED_08
     GoTo TVReporterInterviews_AskDoInterview
 
@@ -67,7 +67,7 @@ TVReporterInterviews_PoffinHouse:
     SetVar VAR_0x8000, TV_PROGRAM_SEGMENT_THREE_CHEERS_FOR_POFFIN_CORNER
     GoTo TVReporterInterviews_AskDoInterview
 
-TVReporterInterviews_UnusedEntry10161:
+TVReporterInterviews_Interview12_Unused:
     SetVar VAR_0x8000, TV_PROGRAM_SEGMENT_INTERVIEW_UNUSED_12
     GoTo TVReporterInterviews_AskDoInterview
 

--- a/res/field/scripts/scripts_underground.s
+++ b/res/field/scripts/scripts_underground.s
@@ -48,10 +48,10 @@ Underground_PutRoarkNextToPlayer:
 
 Underground_TrapsVendor_Unused:
     UndergroundNPCMessage UndergroundNPCs_Text_IllTradeYouSomething
-    GoTo Underground_TrapsVendorShopMenu_Dummy
+    GoTo Underground_TrapsVendorShopMenu_Unused
     End
 
-Underground_TrapsVendorShopMenu_Dummy:
+Underground_TrapsVendorShopMenu_Unused:
     Dummy19E 1, VAR_RESULT
     SetVar VAR_0x8004, VAR_RESULT
     SetVar VAR_0x8008, VAR_RESULT
@@ -85,7 +85,7 @@ Underground_VendorSeeYou_Unused:
 Underground_TrapsVendorNeedAnythingElse_Unused:
     WaitABPress
     UndergroundNPCMessage UndergroundNPCs_Text_DoYouNeedAnythingElse
-    GoTo Underground_TrapsVendorShopMenu_Dummy
+    GoTo Underground_TrapsVendorShopMenu_Unused
     End
 
 Underground_TrapsVendorWaitABPress_Unused:
@@ -100,10 +100,10 @@ Underground_VendorClose_Unused:
 
 Underground_GoodsVendor_Unused:
     UndergroundNPCMessage UndergroundNPCs_Text_IllTradeYouSomething
-    GoTo Underground_GoodsVendorShopMenu_Dummy
+    GoTo Underground_GoodsVendorShopMenu_Unused
     End
 
-Underground_GoodsVendorShopMenu_Dummy:
+Underground_GoodsVendorShopMenu_Unused:
     Dummy19E 0, VAR_RESULT
     SetVar VAR_0x8004, VAR_RESULT
     SetVar VAR_0x8008, VAR_RESULT
@@ -137,7 +137,7 @@ Underground_GoodsVendorWaitABPress_Unused:
 Underground_GoodsVendorNeedAnythingElse_Unused:
     WaitABPress
     UndergroundNPCMessage UndergroundNPCs_Text_DoYouNeedAnythingElse
-    GoTo Underground_GoodsVendorShopMenu_Dummy
+    GoTo Underground_GoodsVendorShopMenu_Unused
     End
 
 Underground_TreasuresVendor_Unused:
@@ -188,7 +188,7 @@ Underground_RoarkIntro:
     End
 
     .balign 4, 0
-Underground_UnusedMovement:
+Underground_Movement_Unused:
     Delay8
     WalkOnSpotNormalEast
     EndMovement

--- a/res/field/scripts/scripts_union_room.s
+++ b/res/field/scripts/scripts_union_room.s
@@ -8,7 +8,7 @@
     ScriptEntry UnionRoom_OnResume
     ScriptEntry UnionRoom_Player
     ScriptEntry UnionRoom_PlayerContactedYou
-    ScriptEntry UnionRoom_UnusedEntry6
+    ScriptEntry UnionRoom_Dummy6
     ScriptEntry UnionRoom_PlayerBusy
     ScriptEntry UnionRoom_Teala
     ScriptEntryEnd
@@ -409,7 +409,7 @@ UnionRoom_OtherPlayerDeclinedTrade:
     GoTo UnionRoom_OtherPlayerDeclinedEnd
     End
 
-UnionRoom_UnusedDecline:
+UnionRoom_Declined_Unused:
     GetUnionRoomMessage UR_MSG_DECLINED_UNUSED, VAR_RESULT
     MessageVar VAR_RESULT
     WaitTime 30, VAR_RESULT
@@ -720,7 +720,7 @@ UnionRoom_InitCommFieldCmd:
     FadeScreenIn
     Return
 
-UnionRoom_UnusedEntry6:
+UnionRoom_Dummy6:
     NPCMessage UnionRoom_Text_Dummy207
     End
 

--- a/res/field/scripts/scripts_unused_battle_park.s
+++ b/res/field/scripts/scripts_unused_battle_park.s
@@ -4,7 +4,7 @@
 
 
     ScriptEntry BattlePark_CoordEvent_PalmerRival
-    ScriptEntry BattlePark_Unused2
+    ScriptEntry BattlePark_Rival_Unused
     ScriptEntry BattlePark_SignboardExchangeServiceCorner
     ScriptEntry BattlePark_SignboardBattleTower
     ScriptEntry BattlePark_Beauty
@@ -210,7 +210,7 @@ BattlePark_Movement_PalmerRivalLeaveEast:
     WalkFastNorth 8
     EndMovement
 
-BattlePark_Unused2:
+BattlePark_Rival_Unused:
     NPCMessage BattlePark_Text_MeasureUpForMyQuest
     End
 

--- a/res/field/scripts/scripts_unused_battle_park_exchange_service_corner.s
+++ b/res/field/scripts/scripts_unused_battle_park_exchange_service_corner.s
@@ -39,34 +39,34 @@ BattleParkExchangeServiceCorner_PokeMartFrontierLeft:
     ReleaseAll
     End
 
-BattleParkExchangeServiceCorner_Unused:
+BattleParkExchangeServiceCorner_PrizeExchange_Unused:
     PlaySE SEQ_SE_CONFIRM
     LockAll
     FacePlayer
     ShowBattlePoints 21, 1
     Message BattleParkExchangeServiceCorner_Text_ExchangeBPForItems
-BattleParkExchangeServiceCorner_UnusedWhichPrize:
+BattleParkExchangeServiceCorner_WhichPrize_Unused:
     Message BattleParkExchangeServiceCorner_Text_ExchangeBPForWhichPrize
-    Call BattleParkExchangeServiceCorner_UnusedInitPrizeMenu
-    GoToIfEq VAR_RESULT, -2, BattleParkExchangeServiceCorner_UnusedThanksForVisiting
-    GoToIfEq VAR_RESULT, VAR_MAP_LOCAL_1, BattleParkExchangeServiceCorner_UnusedThanksForVisiting
+    Call BattleParkExchangeServiceCorner_InitPrizeMenu_Unused
+    GoToIfEq VAR_RESULT, -2, BattleParkExchangeServiceCorner_ThanksForVisiting_Unused
+    GoToIfEq VAR_RESULT, VAR_MAP_LOCAL_1, BattleParkExchangeServiceCorner_ThanksForVisiting_Unused
     SetVar VAR_MAP_LOCAL_3, VAR_RESULT
     GetExchangeServiceCornerItemAndCost VAR_MAP_LOCAL_0, VAR_MAP_LOCAL_3, VAR_0x8000, VAR_0x8001
-    CallIfEq VAR_MAP_LOCAL_0, 0, BattleParkExchangeServiceCorner_UnusedYouveChosenThisItem
-    CallIfEq VAR_MAP_LOCAL_0, 1, BattleParkExchangeServiceCorner_UnusedYouveChosenThisTM
+    CallIfEq VAR_MAP_LOCAL_0, 0, BattleParkExchangeServiceCorner_YouveChosenThisItem_Unused
+    CallIfEq VAR_MAP_LOCAL_0, 1, BattleParkExchangeServiceCorner_YouveChosenThisTM_Unused
     ShowYesNoMenu VAR_RESULT
-    GoToIfEq VAR_RESULT, MENU_NO, BattleParkExchangeServiceCorner_UnusedWhichPrize
+    GoToIfEq VAR_RESULT, MENU_NO, BattleParkExchangeServiceCorner_WhichPrize_Unused
     CheckBattlePoints VAR_0x8001, VAR_RESULT
-    GoToIfEq VAR_RESULT, FALSE, BattleParkExchangeServiceCorner_UnusedNotEnoughBP
+    GoToIfEq VAR_RESULT, FALSE, BattleParkExchangeServiceCorner_NotEnoughBP_Unused
     CanFitItem VAR_0x8000, 1, VAR_RESULT
-    GoToIfEq VAR_RESULT, FALSE, BattleParkExchangeServiceCorner_UnusedNoRoomForItem
+    GoToIfEq VAR_RESULT, FALSE, BattleParkExchangeServiceCorner_NoRoomForItem_Unused
     Message BattleParkExchangeServiceCorner_Text_HereIsYourPrize
     AddItem VAR_0x8000, 1, VAR_RESULT
     RemoveBattlePoints VAR_0x8001
     UpdateBPDisplay
-    GoTo BattleParkExchangeServiceCorner_UnusedWhichPrize
+    GoTo BattleParkExchangeServiceCorner_WhichPrize_Unused
 
-BattleParkExchangeServiceCorner_UnusedThanksForVisiting:
+BattleParkExchangeServiceCorner_ThanksForVisiting_Unused:
     Message BattleParkExchangeServiceCorner_Text_ThanksForVisiting
     WaitButton
     CloseMessage
@@ -74,37 +74,37 @@ BattleParkExchangeServiceCorner_UnusedThanksForVisiting:
     ReleaseAll
     End
 
-BattleParkExchangeServiceCorner_UnusedYouveChosenThisItem:
+BattleParkExchangeServiceCorner_YouveChosenThisItem_Unused:
     BufferItemName 0, VAR_0x8000
     Message BattleParkExchangeServiceCorner_Text_YouveChosenThisItem
     Return
 
-BattleParkExchangeServiceCorner_UnusedYouveChosenThisTM:
+BattleParkExchangeServiceCorner_YouveChosenThisTM_Unused:
     BufferItemName 0, VAR_0x8000
     BufferTMHMMoveName 1, VAR_0x8000
     Message BattleParkExchangeServiceCorner_Text_YouveChosenThisTM
     Return
 
-BattleParkExchangeServiceCorner_UnusedNotEnoughBP:
+BattleParkExchangeServiceCorner_NotEnoughBP_Unused:
     Message BattleParkExchangeServiceCorner_Text_NotEnoughBP
-    GoTo BattleParkExchangeServiceCorner_UnusedWhichPrize
+    GoTo BattleParkExchangeServiceCorner_WhichPrize_Unused
 
-BattleParkExchangeServiceCorner_UnusedNoRoomForItem:
+BattleParkExchangeServiceCorner_NoRoomForItem_Unused:
     BufferItemName 0, VAR_0x8000
     Message BattleParkExchangeServiceCorner_Text_NoRoomForItem
-    GoTo BattleParkExchangeServiceCorner_UnusedWhichPrize
+    GoTo BattleParkExchangeServiceCorner_WhichPrize_Unused
 
-BattleParkExchangeServiceCorner_UnusedInitPrizeMenu:
+BattleParkExchangeServiceCorner_InitPrizeMenu_Unused:
     SetVar VAR_0x8008, 0
     SetVar VAR_0x8009, 0
     InitGlobalTextListMenu 1, 1, 0, VAR_RESULT
-BattleParkExchangeServiceCorner_UnusedAddPrizeMenuEntries:
+BattleParkExchangeServiceCorner_AddPrizeMenuEntries_Unused:
     GetExchangeServiceCornerItemAndCost VAR_MAP_LOCAL_0, VAR_0x8008, VAR_0x8000, VAR_0x8001
     BufferItemName 0, VAR_0x8000
     BufferVarPaddingDigits 1, VAR_0x8001, PADDING_MODE_SPACES, 3
     AddListMenuEntry MenuEntries_Text_UnusedPrizeExchange_Prize, VAR_0x8008
     AddVar VAR_0x8008, 1
-    GoToIfLt VAR_0x8008, VAR_MAP_LOCAL_1, BattleParkExchangeServiceCorner_UnusedAddPrizeMenuEntries
+    GoToIfLt VAR_0x8008, VAR_MAP_LOCAL_1, BattleParkExchangeServiceCorner_AddPrizeMenuEntries_Unused
     AddListMenuEntry MenuEntries_Text_UnusedPrizeExchange_NoThanks, VAR_0x8008
     ShowListMenu
     Return

--- a/res/field/scripts/scripts_unused_battle_park_gate_to_fight_area.s
+++ b/res/field/scripts/scripts_unused_battle_park_gate_to_fight_area.s
@@ -1,19 +1,19 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry BattleParkGateToFightArea_Unused1
+    ScriptEntry BattleParkGateToFightArea_Dummy1
     ScriptEntry BattleParkGateToFightArea_Maid2
     ScriptEntry BattleParkGateToFightArea_Maid1
     ScriptEntry BattleParkGateToFightArea_Maid5
     ScriptEntry BattleParkGateToFightArea_Maid3And4
     ScriptEntry BattleParkGateToFightArea_Collector
-    ScriptEntry BattleParkGateToFightArea_Unused7
+    ScriptEntry BattleParkGateToFightArea_Dummy7
     ScriptEntryEnd
 
-BattleParkGateToFightArea_Unused7:
+BattleParkGateToFightArea_Dummy7:
     End
 
-BattleParkGateToFightArea_Unused1:
+BattleParkGateToFightArea_Dummy1:
     End
 
 BattleParkGateToFightArea_Maid2:

--- a/res/field/scripts/scripts_unused_gate_between_eterna_city_route_206.s
+++ b/res/field/scripts/scripts_unused_gate_between_eterna_city_route_206.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry GateBetweenEternaCityRoute206_UnusedEntry1
+    ScriptEntry GateBetweenEternaCityRoute206_Dummy1
     ScriptEntryEnd
 
-GateBetweenEternaCityRoute206_UnusedEntry1:
+GateBetweenEternaCityRoute206_Dummy1:
     End

--- a/res/field/scripts/scripts_unused_jubilife_city_house_1.s
+++ b/res/field/scripts/scripts_unused_jubilife_city_house_1.s
@@ -2,10 +2,10 @@
 #include "res/text/bank/unused_jubilife_city_house_1.h"
 
 
-    ScriptEntry JubilifeCityHouse1_UnusedEntry1
+    ScriptEntry JubilifeCityHouse1_Dummy1
     ScriptEntryEnd
 
-JubilifeCityHouse1_UnusedEntry1:
+JubilifeCityHouse1_Dummy1:
     NPCMessage JubilifeCityHouse1_Text_Dummy0
     End
 

--- a/res/field/scripts/scripts_unused_jubilife_city_house_2.s
+++ b/res/field/scripts/scripts_unused_jubilife_city_house_2.s
@@ -2,10 +2,10 @@
 #include "res/text/bank/unused_jubilife_city_house_2.h"
 
 
-    ScriptEntry JubilifeCityHouse2_UnusedEntry1
+    ScriptEntry JubilifeCityHouse2_Dummy1
     ScriptEntryEnd
 
-JubilifeCityHouse2_UnusedEntry1:
+JubilifeCityHouse2_Dummy1:
     NPCMessage JubilifeCityHouse2_Text_Dummy0
     End
 

--- a/res/field/scripts/scripts_unused_jubilife_city_house_3.s
+++ b/res/field/scripts/scripts_unused_jubilife_city_house_3.s
@@ -2,14 +2,14 @@
 #include "res/text/bank/unused_jubilife_city_house_3.h"
 
 
-    ScriptEntry JubilifeCityHouse3_UnusedEntry1
-    ScriptEntry JubilifeCityHouse3_UnusedEntry2
+    ScriptEntry JubilifeCityHouse3_Dummy1
+    ScriptEntry JubilifeCityHouse3_Dummy2
     ScriptEntryEnd
 
-JubilifeCityHouse3_UnusedEntry1:
+JubilifeCityHouse3_Dummy1:
     NPCMessage JubilifeCityHouse3_Text_Dummy0
     End
 
-JubilifeCityHouse3_UnusedEntry2:
+JubilifeCityHouse3_Dummy2:
     NPCMessage JubilifeCityHouse3_Text_Dummy1
     End

--- a/res/field/scripts/scripts_unused_jubilife_city_house_4.s
+++ b/res/field/scripts/scripts_unused_jubilife_city_house_4.s
@@ -2,10 +2,10 @@
 #include "res/text/bank/unused_jubilife_city_house_4.h"
 
 
-    ScriptEntry JubilifeCityHouse4_UnusedEntry1
+    ScriptEntry JubilifeCityHouse4_Dummy1
     ScriptEntryEnd
 
-JubilifeCityHouse4_UnusedEntry1:
+JubilifeCityHouse4_Dummy1:
     NPCMessage JubilifeCityHouse4_Text_Dummy0
     End
 

--- a/res/field/scripts/scripts_unused_resort_area_mart.s
+++ b/res/field/scripts/scripts_unused_resort_area_mart.s
@@ -2,14 +2,14 @@
 
 
     ScriptEntry ResortAreaMart_CashierF
-    ScriptEntry ResortAreaMart_UnusedEntry2
+    ScriptEntry ResortAreaMart_Dummy2
     ScriptEntryEnd
 
 ResortAreaMart_CashierF:
     PokeMartCommonWithGreeting
     End
 
-ResortAreaMart_UnusedEntry2:
+ResortAreaMart_Dummy2:
     End
 
     .balign 4, 0

--- a/res/field/scripts/scripts_unused_sunyshore_city_house_1.s
+++ b/res/field/scripts/scripts_unused_sunyshore_city_house_1.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry SunyshoreCityUnknownHouse1_Unused
+    ScriptEntry SunyshoreCityUnknownHouse1_Dummy1
     ScriptEntryEnd
 
-SunyshoreCityUnknownHouse1_Unused:
+SunyshoreCityUnknownHouse1_Dummy1:
     End

--- a/res/field/scripts/scripts_unused_sunyshore_city_house_2.s
+++ b/res/field/scripts/scripts_unused_sunyshore_city_house_2.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry SunyshoreCityUnknownHouse2_Unused
+    ScriptEntry SunyshoreCityUnknownHouse2_Dummy1
     ScriptEntryEnd
 
-SunyshoreCityUnknownHouse2_Unused:
+SunyshoreCityUnknownHouse2_Dummy1:
     End

--- a/res/field/scripts/scripts_unused_verity_lakefront_house.s
+++ b/res/field/scripts/scripts_unused_verity_lakefront_house.s
@@ -2,10 +2,10 @@
 #include "res/text/bank/unused_verity_lakefront_house.h"
 
 
-    ScriptEntry VerityLakefrontHouse_UnusedEntry1
+    ScriptEntry VerityLakefrontHouse_Dummy1
     ScriptEntryEnd
 
-VerityLakefrontHouse_UnusedEntry1:
+VerityLakefrontHouse_Dummy1:
     BufferPlayerName 0
     NPCMessage VerityLakefrontHouse1_Text_Dummy0
     End

--- a/res/field/scripts/scripts_valor_lakefront.s
+++ b/res/field/scripts/scripts_valor_lakefront.s
@@ -421,7 +421,7 @@ ValorLakefront_Movement_CynthiaLeave:
     WalkNormalNorth 9
     EndMovement
 
-ValorLakefront_UnusedMovement:
+ValorLakefront_Movement_Unused:
     Delay8
     WalkOnSpotNormalEast
     EndMovement
@@ -444,7 +444,7 @@ ValorLakefront_Movement_PlayerWatchRivalLeave:
     WalkOnSpotNormalNorth
     EndMovement
 
-ValorLakefront_UnusedMovement2:
+ValorLakefront_Movement_Unused2:
     Delay8 3
     WalkOnSpotNormalNorth
     EndMovement

--- a/res/field/scripts/scripts_veilstone_city.s
+++ b/res/field/scripts/scripts_veilstone_city.s
@@ -333,7 +333,7 @@ VeilstoneCity_Movement_CounterpartWatchCrasherWakeLeave:
     WalkOnSpotNormalSouth
     EndMovement
 
-VeilstoneCity_UnusedMovement:
+VeilstoneCity_Movement_Unused:
     Delay8
     WalkOnSpotNormalNorth
     EndMovement
@@ -792,30 +792,30 @@ VeilstoneCity_Movement_CounterpartWalkToGruntNorth:
     WalkOnSpotNormalEast
     EndMovement
 
-VeilstoneCity_UnusedMovement2:
+VeilstoneCity_Movement_Unused2:
     Delay4
     WalkOnSpotNormalWest
     EmoteExclamationMark
     Delay8
     EndMovement
 
-VeilstoneCity_UnusedMovement3:
+VeilstoneCity_Movement_Unused3:
     WalkNormalWest 4
     EndMovement
 
-VeilstoneCity_UnusedMovement4:
+VeilstoneCity_Movement_Unused4:
     WalkNormalSouth 2
     WalkNormalWest 2
     WalkNormalSouth 6
     EndMovement
 
-VeilstoneCity_UnusedMovement5:
+VeilstoneCity_Movement_Unused5:
     Delay8
     WalkOnSpotNormalNorth
     WalkOnSpotNormalWest
     EndMovement
 
-VeilstoneCity_UnusedMovement6:
+VeilstoneCity_Movement_Unused6:
     Delay8
     WalkOnSpotNormalSouth
     WalkOnSpotNormalWest
@@ -858,13 +858,13 @@ VeilstoneCity_Movement_PlayerWalkToGruntNorth:
     WalkOnSpotNormalEast
     EndMovement
 
-VeilstoneCity_UnusedMovement7:
+VeilstoneCity_Movement_Unused7:
     Delay8
     WalkOnSpotNormalSouth
     WalkOnSpotNormalWest
     EndMovement
 
-VeilstoneCity_UnusedMovement8:
+VeilstoneCity_Movement_Unused8:
     Delay8
     WalkOnSpotNormalNorth
     WalkOnSpotNormalWest
@@ -885,7 +885,7 @@ VeilstoneCity_Movement_PlayerFaceLooker:
     WalkOnSpotNormalWest
     EndMovement
 
-VeilstoneCity_UnusedMovement9:
+VeilstoneCity_Movement_Unused9:
     Delay8
     WalkOnSpotNormalWest
     EndMovement

--- a/res/field/scripts/scripts_veilstone_city_pokecenter_2f.s
+++ b/res/field/scripts/scripts_veilstone_city_pokecenter_2f.s
@@ -1,8 +1,8 @@
 #include "macros/scrcmd.inc"
 
 
-    ScriptEntry VeilstoneCityPokecenter2F_UnusedEntry1
+    ScriptEntry VeilstoneCityPokecenter2F_Dummy1
     ScriptEntryEnd
 
-VeilstoneCityPokecenter2F_UnusedEntry1:
+VeilstoneCityPokecenter2F_Dummy1:
     End

--- a/res/field/scripts/scripts_veilstone_store_b1f.s
+++ b/res/field/scripts/scripts_veilstone_store_b1f.s
@@ -18,7 +18,7 @@
     ScriptEntry VeilstoneStoreB1F_ProfRowan
     ScriptEntry VeilstoneStoreB1F_LavaCookieVendor
     ScriptEntry VeilstoneStoreB1F_PoffinVendor
-    ScriptEntry VeilstoneStoreB1F_Dummy
+    ScriptEntry VeilstoneStoreB1F_Dummy10
     ScriptEntry VeilstoneStoreB1F_BerryVendor
     ScriptEntry VeilstoneStoreB1F_Directory
     ScriptEntryEnd
@@ -406,7 +406,7 @@ VeilstoneStoreB1F_PoffinVendorMenu:
     ShowListMenu
     Return
 
-VeilstoneStoreB1F_Dummy:
+VeilstoneStoreB1F_Dummy10:
     End
 
 VeilstoneStoreB1F_IncrementDepartmentStoreRegularCounter:

--- a/res/field/scripts/scripts_victory_road_1f_room_2.s
+++ b/res/field/scripts/scripts_victory_road_1f_room_2.s
@@ -187,7 +187,7 @@ VictoryRoad1FRoom2_Movement_PlayerWalkOnSpotEast:
     WalkOnSpotNormalEast
     EndMovement
 
-VictoryRoad1FRoom2_UnusedMovement:
+VictoryRoad1FRoom2_Movement_Unused:
     WalkNormalNorth
     EndMovement
 

--- a/res/field/scripts/scripts_villa.s
+++ b/res/field/scripts/scripts_villa.s
@@ -1488,7 +1488,7 @@ Villa_Movement_SchoolKidMFacePlayer:
     WalkOnSpotNormalEast
     EndMovement
 
-Villa_UnusedMovement:
+Villa_Movement_Unused:
     WalkNormalSouth 3
     WalkNormalEast
     WalkOnSpotNormalSouth

--- a/res/field/scripts/scripts_wayward_cave_1f.s
+++ b/res/field/scripts/scripts_wayward_cave_1f.s
@@ -5,7 +5,7 @@
 
     ScriptEntry WaywardCave1F_OnTransition
     ScriptEntry WaywardCave1F_Mira
-    ScriptEntry WaywardCave1F_Unused
+    ScriptEntry WaywardCave1F_Dummy3
     ScriptEntry WaywardCave1F_CoordEvent_Exit
     ScriptEntryEnd
 
@@ -76,7 +76,7 @@ WaywardCave1F_IncreaseFollowerMiraTimesTalked:
     ReleaseAll
     End
 
-WaywardCave1F_Unused:
+WaywardCave1F_Dummy3:
     End
 
 WaywardCave1F_CoordEvent_Exit:
@@ -148,12 +148,12 @@ WaywardCave1F_Movement_PlayerWalkEastOnSpotWest:
     WalkOnSpotNormalWest
     EndMovement
 
-WaywardCave1F_UnusedMovement:
+WaywardCave1F_Movement_Unused:
     Delay8 5
     WalkNormalWest
     EndMovement
 
-WaywardCave1F_UnusedMovement2:
+WaywardCave1F_Movement_Unused2:
     Delay8 5
     WalkNormalNorth
     WalkOnSpotNormalWest


### PR DESCRIPTION
This PR attempts to standardize the names for unused script blocks/entries. The introduced standard is:
- `[Map]_Dummy[X]` for dummy script entries (an entry containing just `End` or also a dummy message) where X is the script id 
- `[Map]_[Description]_Unused` for unused script blocks/entries with a clear purpose (e.g. `CelesticTownNorthwestHouse_Vendor_Unused`)
- `[Map]_Unused[X]` for unused script blocks that are more just left over garbage where X is just an enumerator for the amount of unused script blocks
There are some cases where I didn't exactly follow this just because some script blocks/entries don't fully fall into just one of these categories, but I hope this at least sets a standard that is mostly easy to follow.