### PR TITLE
Rename unused daily trainers messages

### DIFF
--- a/res/field/scripts/scripts_pokemon_center_daily_trainers.s
+++ b/res/field/scripts/scripts_pokemon_center_daily_trainers.s
@@ -340,7 +340,7 @@ PokemonCenterDailyTrainers_GraceIntroMessageOreburgh:
     Return
 
 PokemonCenterDailyTrainers_GraceIntroMessagePastoria:
-    Message PokemonCenterDailyTrainers_Text_GracePastiora_Intro
+    Message PokemonCenterDailyTrainers_Text_GracePastoria_Intro
     Return
 
 PokemonCenterDailyTrainers_GraceIntroMessageSnowpoint:
@@ -485,7 +485,7 @@ PokemonCenterDailyTrainers_GraceBattleAcceptedMessageOreburgh:
     Return
 
 PokemonCenterDailyTrainers_GraceBattleAcceptedMessagePastoria:
-    Message PokemonCenterDailyTrainers_Text_GracePastiora_BattleAccepted
+    Message PokemonCenterDailyTrainers_Text_GracePastoria_BattleAccepted
     Return
 
 PokemonCenterDailyTrainers_GraceBattleAcceptedMessageSnowpoint:
@@ -551,7 +551,7 @@ PokemonCenterDailyTrainers_LeeBattleAcceptedHearthome:
     Return
 
 PokemonCenterDailyTrainers_LeeBattleAcceptedPastoria:
-    Message PokemonCenterDailyTrainers_Text_LeePastiora_BattleAccepted
+    Message PokemonCenterDailyTrainers_Text_LeePastoria_BattleAccepted
     Return
 
 PokemonCenterDailyTrainers_LeeBattleAcceptedCelestic:
@@ -623,7 +623,7 @@ PokemonCenterDailyTrainers_ArturoBattleAcceptedCanalave:
     Return
 
 PokemonCenterDailyTrainers_ArturoBattleAcceptedPastoria:
-    Message PokemonCenterDailyTrainers_Text_ArturoPastiora_BattleAccepted
+    Message PokemonCenterDailyTrainers_Text_ArturoPastoria_BattleAccepted
     Return
 
 PokemonCenterDailyTrainers_ArturoBattleAcceptedSunyshore:
@@ -642,7 +642,7 @@ PokemonCenterDailyTrainers_GraceBattleDeclinedOreburgh:
     Return
 
 PokemonCenterDailyTrainers_GraceBattleDeclinedPastoria:
-    Message PokemonCenterDailyTrainers_Text_GracePastiora_BattleDeclined
+    Message PokemonCenterDailyTrainers_Text_GracePastoria_BattleDeclined
     Return
 
 PokemonCenterDailyTrainers_GraceBattleDeclinedSnowpoint:
@@ -701,7 +701,7 @@ PokemonCenterDailyTrainers_LeeBattleDeclinedHearthome:
     Return
 
 PokemonCenterDailyTrainers_LeeBattleDeclinedPastoria:
-    Message PokemonCenterDailyTrainers_Text_LeePastiora_BattleDeclined
+    Message PokemonCenterDailyTrainers_Text_LeePastoria_BattleDeclined
     Return
 
 PokemonCenterDailyTrainers_LeeBattleDeclinedCelestic:
@@ -767,7 +767,7 @@ PokemonCenterDailyTrainers_ArturoBattleDeclinedCanalave:
     Return
 
 PokemonCenterDailyTrainers_ArturoBattleDeclinedPastoria:
-    Message PokemonCenterDailyTrainers_Text_ArturoPastiora_BattleDeclined
+    Message PokemonCenterDailyTrainers_Text_ArturoPastoria_BattleDeclined
     Return
 
 PokemonCenterDailyTrainers_ArturoBattleDeclinedSunyshore:
@@ -787,7 +787,7 @@ PokemonCenterDailyTrainers_GracePostBattleMessageOreburgh:
     Return
 
 PokemonCenterDailyTrainers_GracePostBattleMessagePastoria:
-    Message PokemonCenterDailyTrainers_Text_GracePastiora_PostBattle
+    Message PokemonCenterDailyTrainers_Text_GracePastoria_PostBattle
     Return
 
 PokemonCenterDailyTrainers_GracePostBattleMessageSnowpoint:
@@ -853,7 +853,7 @@ PokemonCenterDailyTrainers_LeePostBattleMessageHearthome:
     Return
 
 PokemonCenterDailyTrainers_LeePostBattleMessagePastoria:
-    Message PokemonCenterDailyTrainers_Text_LeePastiora_PostBattle
+    Message PokemonCenterDailyTrainers_Text_LeePastoria_PostBattle
     Return
 
 PokemonCenterDailyTrainers_LeePostBattleMessageCelestic:
@@ -925,7 +925,7 @@ PokemonCenterDailyTrainers_ArturoPostBattleMessageCanalave:
     Return
 
 PokemonCenterDailyTrainers_ArturoPostBattleMessagePastoria:
-    Message PokemonCenterDailyTrainers_Text_ArturoPastiora_PostBattle
+    Message PokemonCenterDailyTrainers_Text_ArturoPastoria_PostBattle
     Return
 
 PokemonCenterDailyTrainers_ArturoPostBattleMessageSunyshore:

--- a/res/text/canalave_city_pokecenter_1f.json
+++ b/res/text/canalave_city_pokecenter_1f.json
@@ -39,28 +39,28 @@
       ]
     },
     {
-      "id": "CanalaveCityPokecenter1F_Text_LetsDoBattle",
+      "id": "CanalaveCityPokecenter1F_Text_ArturoIntro_Unused",
       "en_US": [
         "Come on, let’s show off our Pokémon!\n",
         "Let’s do battle, kiddo!"
       ]
     },
     {
-      "id": "CanalaveCityPokecenter1F_Text_RockInYourVeins",
+      "id": "CanalaveCityPokecenter1F_Text_ArturoBattleAccepted_Unused",
       "en_US": [
         "Your spirit’s vibes...\n",
         "You’ve got rock in your veins!\r"
       ]
     },
     {
-      "id": "CanalaveCityPokecenter1F_Text_MyGuitarLiesBroken",
+      "id": "CanalaveCityPokecenter1F_Text_ArturoBattleDeclined_Unused",
       "en_US": [
         "My guitar...\n",
         "It lies broken and weeping..."
       ]
     },
     {
-      "id": "CanalaveCityPokecenter1F_Text_PokemonAndRockNRoll",
+      "id": "CanalaveCityPokecenter1F_Text_ArturoPostBattle_Unused",
       "en_US": [
         "Pokémon and rock ’n’ roll are all\n",
         "anyone needs to survive in this world!"

--- a/res/text/celestic_town_pokecenter_1f.json
+++ b/res/text/celestic_town_pokecenter_1f.json
@@ -58,7 +58,7 @@
       ]
     },
     {
-      "id": "CelesticTownPokecenter1F_Text_WantToBattle",
+      "id": "CelesticTownPokecenter1F_Text_LeeIntro_Unused",
       "en_US": [
         "As a clown, I like to show off Pokémon\n",
         "that are a little out of the ordinary.\r",
@@ -66,21 +66,21 @@
       ]
     },
     {
-      "id": "CelesticTownPokecenter1F_Text_DoSomethingFantastical",
+      "id": "CelesticTownPokecenter1F_Text_LeeBattleAccepted_Unused",
       "en_US": [
         "OK, how shall we do this?\n",
         "Shall we do something fantastical?\r"
       ]
     },
     {
-      "id": "CelesticTownPokecenter1F_Text_ItMakesMeLonely",
+      "id": "CelesticTownPokecenter1F_Text_LeeBattleDeclined_Unused",
       "en_US": [
         "Oh, how shall I say this...?\n",
         "It makes me all lonely, I say..."
       ]
     },
     {
-      "id": "CelesticTownPokecenter1F_Text_UselessTriviaCoulrophobia",
+      "id": "CelesticTownPokecenter1F_Text_LeePostBattle_Unused",
       "en_US": [
         "Here’s a piece of useless trivia.\n",
         "Fear of clowns is also known as\f",

--- a/res/text/eterna_city_pokecenter_1f.json
+++ b/res/text/eterna_city_pokecenter_1f.json
@@ -78,7 +78,7 @@
       ]
     },
     {
-      "id": "EternaCityPokecenter1F_Text_WereLookingForATrainerWhosTravelingWithAtLeastTwoPokemon",
+      "id": "EternaCityPokecenter1F_Text_OliNotEnoughPokemon_Unused",
       "en_US": [
         "Two Pokémon!\n",
         "That’s what we need.\r",
@@ -87,28 +87,28 @@
       ]
     },
     {
-      "id": "EternaCityPokecenter1F_Text_OhWouldYouLikeToBattleAgainstTheBothOfUs",
+      "id": "EternaCityPokecenter1F_Text_OliIntro_Unused",
       "en_US": [
         "Oh! Would you like to battle against the\n",
         "both of us?"
       ]
     },
     {
-      "id": "EternaCityPokecenter1F_Text_YoureLiveOnCameraButTryToActNaturalOK",
+      "id": "EternaCityPokecenter1F_Text_OliBattleAccepted_Unused",
       "en_US": [
         "You’re live on camera, but try to act\n",
         "natural, OK?\r"
       ]
     },
     {
-      "id": "EternaCityPokecenter1F_Text_OKThatsHowItIsHuh",
+      "id": "EternaCityPokecenter1F_Text_OliBattleDeclined_Unused",
       "en_US": [
         "OK, that’s how it is, huh.\n",
         "Can’t do anything about that."
       ]
     },
     {
-      "id": "EternaCityPokecenter1F_Text_WheeWasntThatBattleSmokingHot",
+      "id": "EternaCityPokecenter1F_Text_OliPostBattle_Unused",
       "en_US": [
         "Whee!\n",
         "Wasn’t that battle smoking hot?\r",
@@ -117,7 +117,7 @@
       ]
     },
     {
-      "id": "EternaCityPokecenter1F_Text_OhDearYouOnlyHaveOnePokemonWithYou",
+      "id": "EternaCityPokecenter1F_Text_RoxyNotEnoughPokemon_Unused",
       "en_US": [
         "Oh, dear!\n",
         "You only have one Pokémon with you?\r",
@@ -126,28 +126,28 @@
       ]
     },
     {
-      "id": "EternaCityPokecenter1F_Text_GiggleCouldYouWinAgainstBothOfUs",
+      "id": "EternaCityPokecenter1F_Text_RoxyIntro_Unused",
       "en_US": [
         "Giggle!\n",
         "Could you win against both of us?\n"
       ]
     },
     {
-      "id": "EternaCityPokecenter1F_Text_WellThoroughlyCheckOutYourAbilitiesAsATrainer",
+      "id": "EternaCityPokecenter1F_Text_RoxyBattleAccepted_Unused",
       "en_US": [
         "We’ll thoroughly check out your\n",
         "abilities as a Trainer!\r"
       ]
     },
     {
-      "id": "EternaCityPokecenter1F_Text_OhYouHaventHealedYourPokemonMaybe",
+      "id": "EternaCityPokecenter1F_Text_RoxyBattleDeclined_Unused",
       "en_US": [
         "Oh? You haven’t healed your Pokémon,\n",
         "maybe?"
       ]
     },
     {
-      "id": "EternaCityPokecenter1F_Text_ThatWasAGoodMatch",
+      "id": "EternaCityPokecenter1F_Text_RoxyPostBattle_Unused",
       "en_US": [
         "That was a good match.\r",
         "It adds flair and drama when many\n",

--- a/res/text/fight_area_pokecenter_1f.json
+++ b/res/text/fight_area_pokecenter_1f.json
@@ -28,7 +28,7 @@
       ]
     },
     {
-      "id": "FightAreaPokecenter1F_Text_WeNeedBattle",
+      "id": "FightAreaPokecenter1F_Text_KinseyIntro_Unused",
       "en_US": [
         "We’re doing a feature on tough Trainers\n",
         "in the Battle Zone.\r",
@@ -37,18 +37,18 @@
       ]
     },
     {
-      "id": "FightAreaPokecenter1F_Text_ReporterKinseysLiveInterview",
+      "id": "FightAreaPokecenter1F_Text_KinseyBattleAccepted_Unused",
       "en_US": "Reporter Kinsey’s live interview!\r"
     },
     {
-      "id": "FightAreaPokecenter1F_Text_DontBeShy",
+      "id": "FightAreaPokecenter1F_Text_KinseyBattleDeclined_Unused",
       "en_US": [
         "You don’t have to be shy.\n",
         "We can obscure your face if we have to."
       ]
     },
     {
-      "id": "FightAreaPokecenter1F_Text_IGoAfterInverviews",
+      "id": "FightAreaPokecenter1F_Text_KinseyPostBattle_Unused",
       "en_US": [
         "I go after interviews like my favorite\n",
         "Pokémon move--I tackle them!\r",
@@ -57,28 +57,28 @@
       ]
     },
     {
-      "id": "FightAreaPokecenter1F_Text_WillYouLetUsBattle",
+      "id": "FightAreaPokecenter1F_Text_TevinIntro_Unused",
       "en_US": [
         "Expert Trainer spotted!\n",
         "Will you let us battle with you?"
       ]
     },
     {
-      "id": "FightAreaPokecenter1F_Text_YouGuysAreGreat",
+      "id": "FightAreaPokecenter1F_Text_TevinBattleAccepted_Unused",
       "en_US": [
         "Great! Great!\n",
         "You guys are great!\r"
       ]
     },
     {
-      "id": "FightAreaPokecenter1F_Text_HowGoodAreYou",
+      "id": "FightAreaPokecenter1F_Text_TevinBattleDeclined_Unused",
       "en_US": [
         "Want to see how good you are before\n",
         "you go off to the Battle Frontier?"
       ]
     },
     {
-      "id": "FightAreaPokecenter1F_Text_CombinationWillTearUp",
+      "id": "FightAreaPokecenter1F_Text_TevinPostBattle_Unused",
       "en_US": [
         "The combination of you and your Pokémon\n",
         "will tear up the Battle Tower!"

--- a/res/text/floaroma_town_pokecenter_1f.json
+++ b/res/text/floaroma_town_pokecenter_1f.json
@@ -38,7 +38,7 @@
       ]
     },
     {
-      "id": "FloaromaTownPokecenter1F_Text_PoPoPokemonIWantToBecomeMoreLikeAPikachu",
+      "id": "FloaromaTownPokecenter1F_Text_ArielIntro_Unused",
       "en_US": [
         "Po-Po-Pokémon!\r",
         "I want to become more like a PIKACHU!\n",
@@ -46,15 +46,15 @@
       ]
     },
     {
-      "id": "FloaromaTownPokecenter1F_Text_PiPikachu",
+      "id": "FloaromaTownPokecenter1F_Text_ArielBattleAccepted_Unused",
       "en_US": "Pi-Pikachu!\r"
     },
     {
-      "id": "FloaromaTownPokecenter1F_Text_PiPikachu2",
+      "id": "FloaromaTownPokecenter1F_Text_ArielBattleDeclined_Unused",
       "en_US": "Pi-Pikachu!"
     },
     {
-      "id": "FloaromaTownPokecenter1F_Text_ICanMakeStaticElectricityButImNotVeryMuchLikeAPokemonYet",
+      "id": "FloaromaTownPokecenter1F_Text_ArielPostBattle_Unused",
       "en_US": [
         "I can make static electricity, but I’m\n",
         "not very much like a Pokémon yet.\r",

--- a/res/text/hearthome_city_pokecenter_1f.json
+++ b/res/text/hearthome_city_pokecenter_1f.json
@@ -45,25 +45,25 @@
       ]
     },
     {
-      "id": "HearthomeCityPokecenter1F_Text_CanYouParticipateInAPieceOnTrainers",
+      "id": "HearthomeCityPokecenter1F_Text_KinseyIntro_Unused",
       "en_US": [
         "We’re doing a news piece on Trainers.\n",
         "Can we get you to participate?"
       ]
     },
     {
-      "id": "HearthomeCityPokecenter1F_Text_ReporterKinseysLiveInterview",
+      "id": "HearthomeCityPokecenter1F_Text_KinseyBattleAccepted_Unused",
       "en_US": "Reporter Kinsey’s live interview!\r"
     },
     {
-      "id": "HearthomeCityPokecenter1F_Text_DoYouReplyNoFirstThing",
+      "id": "HearthomeCityPokecenter1F_Text_KinseyBattleDeclined_Unused",
       "en_US": [
         "...Are you one of those contrary\n",
         "people who reply “No” first thing?"
       ]
     },
     {
-      "id": "HearthomeCityPokecenter1F_Text_WereInvestigatingWhyTrainersChoosePokemon",
+      "id": "HearthomeCityPokecenter1F_Text_KinseyPostBattle_Unused",
       "en_US": [
         "Why Trainers choose certain kinds of\n",
         "Pokémon and their feelings about it...\r",
@@ -71,7 +71,7 @@
       ]
     },
     {
-      "id": "HearthomeCityPokecenter1F_Text_IFeltAFlashOfInspiration",
+      "id": "HearthomeCityPokecenter1F_Text_TevinIntro_Unused",
       "en_US": [
         "I felt a flash of inspiration when I laid\n",
         "eyes on you.\r",
@@ -80,14 +80,14 @@
       ]
     },
     {
-      "id": "HearthomeCityPokecenter1F_Text_INeedToGetInTightYouDontMindDoYou",
+      "id": "HearthomeCityPokecenter1F_Text_TevinBattleAccepted_Unused",
       "en_US": [
         "For close-ups, I need to get in tight.\n",
         "You don’t mind, do you?\r"
       ]
     },
     {
-      "id": "HearthomeCityPokecenter1F_Text_ThatsADowner",
+      "id": "HearthomeCityPokecenter1F_Text_TevinBattleDEclined_Unused",
       "en_US": [
         "That’s a downer...\r",
         "I thought I’d found a Trainer and\n",
@@ -95,7 +95,7 @@
       ]
     },
     {
-      "id": "HearthomeCityPokecenter1F_Text_DidYouComeToCompeteInContests",
+      "id": "HearthomeCityPokecenter1F_Text_TevinPostBattle_Unused",
       "en_US": [
         "So, did you come to Hearthome to\n",
         "compete in Contests?"

--- a/res/text/jubilife_city_pokecenter_1f.json
+++ b/res/text/jubilife_city_pokecenter_1f.json
@@ -33,7 +33,7 @@
       ]
     },
     {
-      "id": "JubilifeCityPokecenter1F_Text_HiCanWeFeatureYouInANewsPieceWereDoing",
+      "id": "JubilifeCityPokecenter1F_Text_KinseyIntro_Unused",
       "en_US": [
         "Hi, can we feature you in a news piece\n",
         "we’re doing?\r",
@@ -42,18 +42,18 @@
       ]
     },
     {
-      "id": "JubilifeCityPokecenter1F_Text_ReporterKinseysLiveInterview",
+      "id": "JubilifeCityPokecenter1F_Text_KinseyBattleAccepted_Unused",
       "en_US": "Reporter Kinsey’s live interview!\r"
     },
     {
-      "id": "JubilifeCityPokecenter1F_Text_UnbelievablePressCoverageDenied",
+      "id": "JubilifeCityPokecenter1F_Text_KinseyBattleDeclined_Unused",
       "en_US": [
         "Unbelievable! Press coverage denied!\n",
         "I find you intriguing, too..."
       ]
     },
     {
-      "id": "JubilifeCityPokecenter1F_Text_ToGetPeopleToOpenUpWeApproachThemHonestly",
+      "id": "JubilifeCityPokecenter1F_Text_KinseyPostBattle_Unused",
       "en_US": [
         "To get people to open up, we approach\n",
         "them honestly with no hidden tricks.\r",
@@ -62,21 +62,21 @@
       ]
     },
     {
-      "id": "JubilifeCityPokecenter1F_Text_IsItOKToGoForTheScoop",
+      "id": "JubilifeCityPokecenter1F_Text_TevinIntro_Unused",
       "en_US": [
         "I’ve spotted a charismatic Trainer!\n",
         "Is it OK to go for the scoop?"
       ]
     },
     {
-      "id": "JubilifeCityPokecenter1F_Text_AsAProfessionalCameramanIAlwaysGoForTheBestShot",
+      "id": "JubilifeCityPokecenter1F_Text_TevinBattleAccepted_Unused",
       "en_US": [
         "As a professional cameraman, I always\n",
         "go for the best shot!\r"
       ]
     },
     {
-      "id": "JubilifeCityPokecenter1F_Text_ThatsADowner",
+      "id": "JubilifeCityPokecenter1F_Text_TevinBattleDeclined_Unused",
       "en_US": [
         "That’s a downer...\r",
         "I thought I’d found a Trainer and\n",
@@ -84,7 +84,7 @@
       ]
     },
     {
-      "id": "JubilifeCityPokecenter1F_Text_TheLivelyExpressionsOnYouAndYourPokemonsFaces",
+      "id": "JubilifeCityPokecenter1F_Text_TevinPostBattle_Unused",
       "en_US": [
         "The lively expressions on you and your\n",
         "Pokémon’s faces...\r",
@@ -92,7 +92,7 @@
       ]
     },
     {
-      "id": "JubilifeCityPokecenter1F_Text_AreWeAllReadyToHaveSomeFun",
+      "id": "JubilifeCityPokecenter1F_Text_LeeIntro_Unused",
       "en_US": [
         "Are we all ready to have some fun?\n",
         "I sure am! Aren’t you having fun?!\f",
@@ -100,21 +100,21 @@
       ]
     },
     {
-      "id": "JubilifeCityPokecenter1F_Text_OKHowShallWeDoThis",
+      "id": "JubilifeCityPokecenter1F_Text_LeeBattleAccepted_Unused",
       "en_US": [
         "OK, how shall we do this?\n",
         "Shall we do something fantastical?\r"
       ]
     },
     {
-      "id": "JubilifeCityPokecenter1F_Text_OhHowShallISayThis",
+      "id": "JubilifeCityPokecenter1F_Text_LeeBattleDeclined_Unused",
       "en_US": [
         "Oh, how shall I say this...?\n",
         "It makes me all lonely, I say..."
       ]
     },
     {
-      "id": "JubilifeCityPokecenter1F_Text_AClownsMakeupIsAFaceThatsCryingWhileLaughing",
+      "id": "JubilifeCityPokecenter1F_Text_LeePostBattle_Unused",
       "en_US": [
         "A clown’s makeup is a face that’s\n",
         "crying while laughing. Mwahahah!\r",

--- a/res/text/oreburgh_city_pokecenter_1f.json
+++ b/res/text/oreburgh_city_pokecenter_1f.json
@@ -108,7 +108,7 @@
       ]
     },
     {
-      "id": "OreburghCityPokecenter1F_Text_HiImGraceTheIdolSoShallWeBattle",
+      "id": "OreburghCityPokecenter1F_Text_GraceIntro_Unused",
       "en_US": [
         "Hi, I’m Grace, the Idol! I’m just back\n",
         "from a show in Oreburgh Mine!\r",
@@ -116,21 +116,21 @@
       ]
     },
     {
-      "id": "OreburghCityPokecenter1F_Text_IllLetYouJoinMyFanClubIfYouCanBeatMe",
+      "id": "OreburghCityPokecenter1F_Text_GraceBattleAccepted_Unused",
       "en_US": [
         "I’ll let you join my fan club if you can\n",
         "beat me!\r"
       ]
     },
     {
-      "id": "OreburghCityPokecenter1F_Text_YouWontAcceptMyChallengeButImAnIdol",
+      "id": "OreburghCityPokecenter1F_Text_GraceBattleDeclined_Unused",
       "en_US": [
         "You won’t accept my challenge?!\n",
         "But I’m an Idol..."
       ]
     },
     {
-      "id": "OreburghCityPokecenter1F_Text_WellThatsMeAndMyPokemon",
+      "id": "OreburghCityPokecenter1F_Text_GracePostBattle_Unused",
       "en_US": [
         "Well, that’s me and my Pokémon!\n",
         "I hope you’ll support us!\r",

--- a/res/text/pastoria_city_pokecenter_1f.json
+++ b/res/text/pastoria_city_pokecenter_1f.json
@@ -22,28 +22,28 @@
       ]
     },
     {
-      "id": "PastoriaCityPokecenter1F_Text_AskBattleWithMe",
+      "id": "PastoriaCityPokecenter1F_Text_GraceIntro_Unused",
       "en_US": [
         "Would you like to battle with me?\n",
         "As a memento of your visit to Pastoria?"
       ]
     },
     {
-      "id": "PastoriaCityPokecenter1F_Text_JoinMyFanClub",
+      "id": "PastoriaCityPokecenter1F_Text_GraceBattleAccepted_Unused",
       "en_US": [
         "I’ll let you join my fan club if you can\n",
         "beat me!\r"
       ]
     },
     {
-      "id": "PastoriaCityPokecenter1F_Text_ImGoingToCry",
+      "id": "PastoriaCityPokecenter1F_Text_GraceBattleDeclined_Unused",
       "en_US": [
         "You’re not interested in Idols?\n",
         "...I think I’m going to cry."
       ]
     },
     {
-      "id": "PastoriaCityPokecenter1F_Text_SupportUs",
+      "id": "PastoriaCityPokecenter1F_Text_GracePostBattle_Unused",
       "en_US": [
         "Well, that’s me and my Pokémon!\n",
         "I hope you’ll support us!\r",
@@ -52,56 +52,56 @@
       ]
     },
     {
-      "id": "PastoriaCityPokecenter1F_Text_BattleWillBeFun",
+      "id": "PastoriaCityPokecenter1F_Text_LeeIntro_Unused",
       "en_US": [
         "Are we all ready to have some fun?\n",
         "Our battle will be fun! OK?!"
       ]
     },
     {
-      "id": "PastoriaCityPokecenter1F_Text_ShallWeDoThis",
+      "id": "PastoriaCityPokecenter1F_Text_LeeBattleAccepted_Unused",
       "en_US": [
         "OK, how shall we do this?\n",
         "Shall we do something fantastical?\r"
       ]
     },
     {
-      "id": "PastoriaCityPokecenter1F_Text_ItMakesMeLonely",
+      "id": "PastoriaCityPokecenter1F_Text_LeeBattleDeclined_Unused",
       "en_US": [
         "Oh, how shall I say this...?\n",
         "It makes me all lonely, I say..."
       ]
     },
     {
-      "id": "PastoriaCityPokecenter1F_Text_WhichTownNext",
+      "id": "PastoriaCityPokecenter1F_Text_LeePostBattle_Unused",
       "en_US": [
         "Well, let’s see!\n",
         "Which town will we go to next?"
       ]
     },
     {
-      "id": "PastoriaCityPokecenter1F_Text_LetsDoBattle",
+      "id": "PastoriaCityPokecenter1F_Text_ArturoIntro_Unused",
       "en_US": [
         "Come on, let’s show off our Pokémon!\n",
         "Let’s do battle, kiddo!"
       ]
     },
     {
-      "id": "PastoriaCityPokecenter1F_Text_RockInYourVeins",
+      "id": "PastoriaCityPokecenter1F_Text_ArturoBattleAccepted_Unused",
       "en_US": [
         "Your spirit’s vibes...\n",
         "You’ve got rock in your veins!\r"
       ]
     },
     {
-      "id": "PastoriaCityPokecenter1F_Text_MyGuitarLiesBroken",
+      "id": "PastoriaCityPokecenter1F_Text_ArturoBattleDeclined_Unused",
       "en_US": [
         "My guitar...\n",
         "It lies broken and weeping..."
       ]
     },
     {
-      "id": "PastoriaCityPokecenter1F_Text_RockIsAboutSpirit",
+      "id": "PastoriaCityPokecenter1F_Text_ArturoPostBattle_Unused",
       "en_US": [
         "Rock is about your spirit!\n",
         "Battling is about spirit, too!\f",

--- a/res/text/pokemon_center_daily_trainers.json
+++ b/res/text/pokemon_center_daily_trainers.json
@@ -289,28 +289,28 @@
       ]
     },
     {
-      "id": "PokemonCenterDailyTrainers_Text_GracePastiora_Intro",
+      "id": "PokemonCenterDailyTrainers_Text_GracePastoria_Intro",
       "en_US": [
         "Would you like to battle with me?\n",
         "As a memento of your visit to Pastoria?"
       ]
     },
     {
-      "id": "PokemonCenterDailyTrainers_Text_GracePastiora_BattleAccepted",
+      "id": "PokemonCenterDailyTrainers_Text_GracePastoria_BattleAccepted",
       "en_US": [
         "I’ll let you join my fan club if you can\n",
         "beat me!\r"
       ]
     },
     {
-      "id": "PokemonCenterDailyTrainers_Text_GracePastiora_BattleDeclined",
+      "id": "PokemonCenterDailyTrainers_Text_GracePastoria_BattleDeclined",
       "en_US": [
         "You’re not interested in Idols?\n",
         "...I think I’m going to cry."
       ]
     },
     {
-      "id": "PokemonCenterDailyTrainers_Text_GracePastiora_PostBattle",
+      "id": "PokemonCenterDailyTrainers_Text_GracePastoria_PostBattle",
       "en_US": [
         "Well, that’s me and my Pokémon!\n",
         "I hope you’ll support us!\r",
@@ -326,21 +326,21 @@
       ]
     },
     {
-      "id": "PokemonCenterDailyTrainers_Text_LeePastiora_BattleAccepted",
+      "id": "PokemonCenterDailyTrainers_Text_LeePastoria_BattleAccepted",
       "en_US": [
         "OK, how shall we do this?\n",
         "Shall we do something fantastical?\r"
       ]
     },
     {
-      "id": "PokemonCenterDailyTrainers_Text_LeePastiora_BattleDeclined",
+      "id": "PokemonCenterDailyTrainers_Text_LeePastoria_BattleDeclined",
       "en_US": [
         "Oh, how shall I say this...?\n",
         "It makes me all lonely, I say..."
       ]
     },
     {
-      "id": "PokemonCenterDailyTrainers_Text_LeePastiora_PostBattle",
+      "id": "PokemonCenterDailyTrainers_Text_LeePastoria_PostBattle",
       "en_US": [
         "Well, let’s see!\n",
         "Which town will we go to next?"
@@ -354,21 +354,21 @@
       ]
     },
     {
-      "id": "PokemonCenterDailyTrainers_Text_ArturoPastiora_BattleAccepted",
+      "id": "PokemonCenterDailyTrainers_Text_ArturoPastoria_BattleAccepted",
       "en_US": [
         "Your spirit’s vibes...\n",
         "You’ve got rock in your veins!\r"
       ]
     },
     {
-      "id": "PokemonCenterDailyTrainers_Text_ArturoPastiora_BattleDeclined",
+      "id": "PokemonCenterDailyTrainers_Text_ArturoPastoria_BattleDeclined",
       "en_US": [
         "My guitar...\n",
         "It lies broken and weeping..."
       ]
     },
     {
-      "id": "PokemonCenterDailyTrainers_Text_ArturoPastiora_PostBattle",
+      "id": "PokemonCenterDailyTrainers_Text_ArturoPastoria_PostBattle",
       "en_US": [
         "Rock is about your spirit!\n",
         "Battling is about spirit, too!\f",

--- a/res/text/resort_area_pokecenter_1f.json
+++ b/res/text/resort_area_pokecenter_1f.json
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "id": "ResortAreaPokecenter1F_Text_WillYouBattleMe",
+      "id": "ResortAreaPokecenter1F_Text_ArielIntro_Unused",
       "en_US": [
         "Po-Po-Pokémon!\r",
         "I want to become more like a PIKACHU!\n",
@@ -28,15 +28,15 @@
       ]
     },
     {
-      "id": "ResortAreaPokecenter1F_Text_PiPikachu",
+      "id": "ResortAreaPokecenter1F_Text_ArielBattleAccepted_Unused",
       "en_US": "Pi-Pikachu!\r"
     },
     {
-      "id": "ResortAreaPokecenter1F_Text_PiPikachu2",
+      "id": "ResortAreaPokecenter1F_Text_ArielBattleDeclined_Unused",
       "en_US": "Pi-Pikachu!"
     },
     {
-      "id": "ResortAreaPokecenter1F_Text_HadTeamPampered",
+      "id": "ResortAreaPokecenter1F_Text_ArielPostBattle_Unused",
       "en_US": [
         "But I just had my team pampered at the\n",
         "Ribbon Syndicate!\r",

--- a/res/text/snowpoint_city_pokecenter_1f.json
+++ b/res/text/snowpoint_city_pokecenter_1f.json
@@ -50,7 +50,7 @@
       "en_US": "PSYDUCK: Gaga guwawa!"
     },
     {
-      "id": "SnowpointCityPokecenter1F_Text_BattleAsThankYou",
+      "id": "SnowpointCityPokecenter1F_Text_GraceIntro_Unused",
       "en_US": [
         "Thank you for coming to Grace’s live\n",
         "show in Snowpoint!\r",
@@ -59,21 +59,21 @@
       ]
     },
     {
-      "id": "SnowpointCityPokecenter1F_Text_JoinMyFanClub",
+      "id": "SnowpointCityPokecenter1F_Text_GraceBattleAccepted_Unused",
       "en_US": [
         "I’ll let you join my fan club if you can\n",
         "beat me!\r"
       ]
     },
     {
-      "id": "SnowpointCityPokecenter1F_Text_MySongIsNicer",
+      "id": "SnowpointCityPokecenter1F_Text_GraceBattleDeclined_Unused",
       "en_US": [
         "But my song!\n",
         "It’s nicer than that Crasher Wake’s!"
       ]
     },
     {
-      "id": "SnowpointCityPokecenter1F_Text_MyDreamIsTopIdol",
+      "id": "SnowpointCityPokecenter1F_Text_GracePostBattle_Unused",
       "en_US": [
         "My dream is to be the top Idol!\r",
         "To win everyone’s heart, I’ll sing my\n",

--- a/res/text/solaceon_town_pokecenter_1f.json
+++ b/res/text/solaceon_town_pokecenter_1f.json
@@ -29,7 +29,7 @@
       ]
     },
     {
-      "id": "SolaceonTownPokecenter1F_Text_WillYouBattleMe",
+      "id": "SolaceonTownPokecenter1F_Text_ArielIntro_Unused",
       "en_US": [
         "Pikachu!\r",
         "I want to become more like a PIKACHU!\n",
@@ -37,15 +37,15 @@
       ]
     },
     {
-      "id": "SolaceonTownPokecenter1F_Text_PiPikachu",
+      "id": "SolaceonTownPokecenter1F_Text_ArielBattleAccepted_Unused",
       "en_US": "Pi-Pikachu!\r"
     },
     {
-      "id": "SolaceonTownPokecenter1F_Text_PiPikachu2",
+      "id": "SolaceonTownPokecenter1F_Text_ArielBattleDeclined_Unused",
       "en_US": "Pi-Pikachu!"
     },
     {
-      "id": "SolaceonTownPokecenter1F_Text_INeedToGetMoreIntoCharacter",
+      "id": "SolaceonTownPokecenter1F_Text_ArielPostBattle_Unused",
       "en_US": [
         "I need to find a way to get more into\n",
         "the character of a Pokémon...\r",

--- a/res/text/sunyshore_city_pokecenter_1f.json
+++ b/res/text/sunyshore_city_pokecenter_1f.json
@@ -42,28 +42,28 @@
       ]
     },
     {
-      "id": "SunyshoreCityPokecenter1F_Text_DoWeBattle",
+      "id": "SunyshoreCityPokecenter1F_Text_ArturoIntro_Unused",
       "en_US": [
         "Do you want to hear me play my guitar?\n",
         "Or do we battle?"
       ]
     },
     {
-      "id": "SunyshoreCityPokecenter1F_Text_RockInYourVeins",
+      "id": "SunyshoreCityPokecenter1F_Text_ArturoBattleAccepted_Unused",
       "en_US": [
         "Your spirit’s vibes...\n",
         "You’ve got rock in your veins!\r"
       ]
     },
     {
-      "id": "SunyshoreCityPokecenter1F_Text_MyGuitarLiesBroken",
+      "id": "SunyshoreCityPokecenter1F_Text_ArturoBattleDeclined_Unused",
       "en_US": [
         "My guitar...\n",
         "It lies broken and weeping..."
       ]
     },
     {
-      "id": "SunyshoreCityPokecenter1F_Text_PerfectWorld",
+      "id": "SunyshoreCityPokecenter1F_Text_ArturoPostBattle_Unused",
       "en_US": [
         "For Trainers, Pokémon!\r",
         "For my girl, sweet kisses!\r",

--- a/res/text/veilstone_city_pokecenter_1f.json
+++ b/res/text/veilstone_city_pokecenter_1f.json
@@ -19,70 +19,70 @@
       ]
     },
     {
-      "id": "VeilstoneCityPokecenter1F_Text_IfYouHadTwoPokemon",
+      "id": "VeilstoneCityPokecenter1F_Text_OliNotEnoughPokemon_Unused",
       "en_US": [
         "Two Pokémon! If you had two Pokémon,\n",
         "we’d get a great shot here."
       ]
     },
     {
-      "id": "VeilstoneCityPokecenter1F_Text_YoureReadyForBattle",
+      "id": "VeilstoneCityPokecenter1F_Text_OliIntro_Unused",
       "en_US": [
         "Oh! You’re ready for a battle\n",
         "with us?"
       ]
     },
     {
-      "id": "VeilstoneCityPokecenter1F_Text_TryToActNatural",
+      "id": "VeilstoneCityPokecenter1F_Text_OliBattleAccepted_Unused",
       "en_US": [
         "You’re live on camera, but try to act\n",
         "natural, OK?\r"
       ]
     },
     {
-      "id": "VeilstoneCityPokecenter1F_Text_ThatsHowItIs",
+      "id": "VeilstoneCityPokecenter1F_Text_OliBattleDeclined_Unused",
       "en_US": [
         "OK, that’s how it is, huh.\n",
         "Can’t do anything about that."
       ]
     },
     {
-      "id": "VeilstoneCityPokecenter1F_Text_IdLikeToBroadcast",
+      "id": "VeilstoneCityPokecenter1F_Text_OliPostBattle_Unused",
       "en_US": [
         "I’d like to take that footage and\n",
         "broadcast it worldwide."
       ]
     },
     {
-      "id": "VeilstoneCityPokecenter1F_Text_WeWantTwoPokemon",
+      "id": "VeilstoneCityPokecenter1F_Text_RoxyNotEnoughPokemon_Unused",
       "en_US": [
         "Oh, no. What we really want to see\n",
         "is you battling using two Pokémon!"
       ]
     },
     {
-      "id": "VeilstoneCityPokecenter1F_Text_WillYouBattleUs",
+      "id": "VeilstoneCityPokecenter1F_Text_RoxyIntro_Unused",
       "en_US": [
         "Giggle!\n",
         "Will you have a battle with us?"
       ]
     },
     {
-      "id": "VeilstoneCityPokecenter1F_Text_WellCheckYourAbilities",
+      "id": "VeilstoneCityPokecenter1F_Text_RoxyBattleAccepted_Unused",
       "en_US": [
         "We’ll thoroughly check out your\n",
         "abilities as a Trainer!\r"
       ]
     },
     {
-      "id": "VeilstoneCityPokecenter1F_Text_OhTooBad",
+      "id": "VeilstoneCityPokecenter1F_Text_RoxyBattleDeclined_Unused",
       "en_US": [
         "Oh, too bad!\n",
         "I wanted to check out your Pokémon!"
       ]
     },
     {
-      "id": "VeilstoneCityPokecenter1F_Text_WeMadeASpectacle",
+      "id": "VeilstoneCityPokecenter1F_Text_RoxyPostBattle_Unused",
       "en_US": [
         "I lost but I’m totally thrilled!\n",
         "We made a wonderful spectacle!"


### PR DESCRIPTION
All the messages for daily trainers are stored in `pokemon_center_daily_trainers.json`, but each pokecenter map also has unused of these copies. This PR renames those messages to reflect what daily trainer message it is and that it is unused.