### PR TITLE
Follow-up fixes from #1215

### DIFF
--- a/res/words/meson.build
+++ b/res/words/meson.build
@@ -9,7 +9,8 @@ word_bank_object = custom_target(
         '-I', meson.global_source_root() / 'subprojects' / 'NitroSDK-4.2.30001' / 'include',
         '-c', '-o', '@OUTPUT@',
         '@INPUT@',
-    ]
+    ],
+    depends: text_banks,
 )
 
 word_bank = custom_target(
@@ -24,7 +25,7 @@ word_bank = custom_target(
     ],
     build_subdir: 'word_bank.narc.p'
 )
- 
+
 word_bank_narc = custom_target('word_bank.narc',
     output: [
         'word_bank.narc',

--- a/tools/nitroarc/src/common.h
+++ b/tools/nitroarc/src/common.h
@@ -60,7 +60,7 @@ struct options {
     const char *directory;    // -C, --directory=DIR
     const char *file;         // -f, --file=ARCHIVE
     const char *format;       // -F, --format=FORMAT
-    const char *single_file;  // -t  --file=FILE
+    const char *single_file;  // -O  --single-file=FILE
     const char *files_from;   // -T, --files-from=FILE
     const char *exclude_from; // -X, --exclude-from=FILE
     const char *exclude_pat;  //     --exclude=PATTERN

--- a/tools/nitroarc/src/main.c
+++ b/tools/nitroarc/src/main.c
@@ -115,7 +115,7 @@ static const option_cfg_t s_options[] = {
 
     [exclude]      = { "exclude",      NULL, 'E', 0, true  },
     [exclude_from] = { "exclude-from", NULL, 'X', 0, true  },
-    [single_file]  = { "single-file",  NULL, 'S', 0, true  },
+    [single_file]  = { "single-file",  NULL, 'O', 0, true  },
     [files_from]   = { "files-from",   NULL, 'T', 0, true  },
     [index]        = { "index",        NULL, 'I', 0, false },
     [no_recurse]   = { "no-recursion", NULL, 'R', 0, false },
@@ -218,11 +218,11 @@ static void exit_help(const char *name, int exit_status) {
     puts("Archive creation options:");
     puts("  -E, --exclude=PATTERN    exclude filenames matching PATTERN");
     puts("  -X, --exclude-from=FILE  read exclusion patterns from FILE");
-    puts("  -S, --single-file=FILE   specify FILE as the only member file");
     puts("  -T, --files-from=FILE    read ordered filenames from FILE");
     puts("  -I, --index              create a C-header index of member files");
     puts("  -N, --named              retain filenames in the archive");
     puts("  -R, --no-recursion       do not discover files in subdirectories");
+    puts("  -O, --single-file=FILE   specify FILE as the only member file");
     puts("  -S, --stripped           do not write the signed file-type header");
     puts("");
     puts("Tabulated data options:");


### PR DESCRIPTION
Patched some changes made to `nitroarc` while syncing them to upstream, then also noticed that there was a missing dependency on the text-banks for the word list, which is required for compilation (it needs the generated headers).