### PR TITLE
Clean up var pointer retrieval in script commands

### DIFF
--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -3251,7 +3251,7 @@ static BOOL ScrCmd_1D7(ScriptContext *ctx)
 
 static BOOL ScrCmd_CheckCanCookPoffin(ScriptContext *ctx)
 {
-    u16 *destVar = FieldSystem_GetVarPointer(ctx->fieldSystem, ScriptContext_ReadHalfWord(ctx));
+    u16 *destVar = ScriptContext_GetVarPointer(ctx);
 
     if (!Bag_HasItemsInPocket(SaveData_GetBag(ctx->fieldSystem->saveData), POCKET_BERRIES)) {
         *destVar = 1;
@@ -3384,9 +3384,7 @@ static BOOL ScrCmd_TryStartGTSApp(ScriptContext *ctx)
 
 static BOOL ScrCmd_0B3(ScriptContext *ctx)
 {
-    u16 v0 = ScriptContext_ReadHalfWord(ctx);
-
-    sub_0207DDE0(ctx->task, FieldSystem_GetVarPointer(ctx->fieldSystem, v0));
+    sub_0207DDE0(ctx->task, ScriptContext_GetVarPointer(ctx));
     return TRUE;
 }
 
@@ -5517,9 +5515,7 @@ static BOOL ScrCmd_GetDayOfWeek(ScriptContext *ctx)
 
 static BOOL ScrCmd_OpenBattleRegulationMenu(ScriptContext *ctx)
 {
-    u16 destVar = ScriptContext_ReadHalfWord(ctx);
-
-    OpenBattleRegulationMenu(ctx->task, FieldSystem_GetVarPointer(ctx->fieldSystem, destVar));
+    OpenBattleRegulationMenu(ctx->task, ScriptContext_GetVarPointer(ctx));
     return TRUE;
 }
 
@@ -5878,7 +5874,7 @@ static BOOL ScrCmd_FlickerObject(ScriptContext *ctx)
 
 static BOOL ScrCmd_CheckHasAllLegendaryTitansInParty(ScriptContext *ctx)
 {
-    u16 *destVar = FieldSystem_GetVarPointer(ctx->fieldSystem, ScriptContext_ReadHalfWord(ctx));
+    u16 *destVar = ScriptContext_GetVarPointer(ctx);
 
     *destVar = HasAllLegendaryTitansInParty(ctx->fieldSystem->saveData);
     return FALSE;
@@ -6871,8 +6867,7 @@ static BOOL ScrCmd_2F6(ScriptContext *ctx)
 
 static BOOL ScrCmd_2F7(ScriptContext *ctx)
 {
-    u16 v0 = ScriptContext_ReadHalfWord(ctx);
-    u16 *v1 = FieldSystem_GetVarPointer(ctx->fieldSystem, v0);
+    u16 *v1 = ScriptContext_GetVarPointer(ctx);
 
     if (WiFiList_HasValidLogin(ctx->fieldSystem->saveData)) {
         sub_0205749C(ctx->task, *v1);


### PR DESCRIPTION
Some script commands used `ScriptContext_ReadHalfWord` followed by `FieldSystem_GetVarPointer` when they could have been using `ScriptContext_GetVarPointer` directly while still matching (since it's an `inline`). There are still a few usages of this pattern for cases where the variable id needs to be stored for use in future commands or where using `ScriptContext_GetVarPointer` would have reordered function calls.