### PR TITLE
build: Update to meson-1.12.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Software
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y --no-install-recommends bison flex g++ gcc-arm-none-eabi git make ninja-build pkg-config python3 wget xz-utils
+          sudo apt-get install -y --no-install-recommends bison flex g++ gcc-arm-none-eabi git make ninja-build pkg-config python3 wget xz-utils libpng-dev
 
       - name: Checkout Repo
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,10 @@ ROM_REVISION ?= 1
 
 SUBPROJ_DIR := subprojects
 
-MESON_VER := 1.10.0
+MESON_VER := 1.12.0
 MESON_DIR := $(SUBPROJ_DIR)/meson-$(MESON_VER)
-MESON_SUB := $(MESON_DIR)/meson.py
 
-MESON ?= $(MESON_SUB)
+MESON ?= $(MESON_DIR)/meson.py
 NINJA ?= ninja
 GIT ?= git
 
@@ -119,12 +118,8 @@ distclean:
 
 purge: distclean
 	rm -rf $(SKREW_DIR)
-ifeq ($(MESON),$(MESON_SUB))
 	! test -f $(MESON) || $(MESON) subprojects purge --confirm
 	rm -rf $(MESON_DIR)
-else
-	$(MESON) subprojects purge --confirm
-endif
 
 update: meson skrewup
 	$(MESON) subprojects update || true
@@ -148,12 +143,9 @@ $(BUILD)/build.ninja: | $(BUILD) $(SKREW_EXE) meson
 $(BUILD):
 	mkdir -p -- $(BUILD)
 
-meson: ;
-ifeq ($(MESON),$(MESON_SUB))
-meson: $(MESON_SUB)
-endif
+meson: $(MESON)
 
-$(MESON_SUB):
+$(MESON):
 	$(GIT) clone --depth=1 -b $(MESON_VER) https://github.com/mesonbuild/meson $(@D)
 
 skrew: $(SKREW_EXE)

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('pokeplatinum', ['c', 'cpp', 'nasm'],
     version: '1.0',
-    meson_version: '>=1.10.0',
+    meson_version: '>=1.12.0',
     default_options : [
         'buildtype=plain',
         'warning_level=0'

--- a/res/battle/scripts/common_anims/meson.build
+++ b/res/battle/scripts/common_anims/meson.build
@@ -65,9 +65,16 @@ anim_subscripts_narc = custom_target(anim_subscripts_narc_name,
         anim_subscripts_narc_name,
         anim_subscripts_naix_name,
     ],
-    input: battle_anim_script_bin_gen.process(
+    input: script_bin_gen.process(
         anim_subscript_files,
-        extra_args: [ '--out-dir', anim_subscripts_private_dir, ]
+        extra_args: [ '--out-dir', anim_subscripts_private_dir, ],
+        depends: [
+            battle_particles_narc,
+            anim_ncer_narc_files,
+            anim_nanr_narc_files,
+            anim_ncgr_narc_files,
+            anim_nclr_narc_files,
+        ],
     ),
     command: [
         nitroarc_exe,

--- a/res/battle/scripts/meson.build
+++ b/res/battle/scripts/meson.build
@@ -19,7 +19,8 @@ be_seq_narc = custom_target(be_seq_target_name,
     output: be_seq_target_name,
     input: script_bin_gen.process(
         effect_script_files,
-        extra_args: ['--out-dir', be_seq_private_dir]
+        extra_args: ['--out-dir', be_seq_private_dir],
+        depends: [text_banks],
     ),
     command: [
         nitroarc_exe,
@@ -36,7 +37,8 @@ sub_seq_narc = custom_target(sub_seq_narc_name,
     ],
     input: script_bin_gen.process(
         subscript_files,
-        extra_args: ['--out-dir', sub_seq_private_dir]
+        extra_args: ['--out-dir', sub_seq_private_dir],
+        depends: [text_banks],
     ),
     command: [
         nitroarc_exe,
@@ -56,6 +58,7 @@ waza_seq_narc = custom_target(waza_seq_target_name,
             '--out-dir', waza_seq_private_dir,
             '--parent-dir',
         ],
+        depends: [text_banks],
         preserve_path_from: move_script_srcdir,
     ),
     command: [

--- a/res/field/frontier_scripts/meson.build
+++ b/res/field/frontier_scripts/meson.build
@@ -1,32 +1,4 @@
 relative_build_dir = fs.relative_to(meson.current_build_dir(), meson.project_build_root())
-#
-# NOTE: This is a functional copy of script_bin_gen, which is separated from the
-# base generator due to an additional dependency on headers generated for
-# events IDs. Meson unfortunately does not have a clean way to copy an existing
-# object and tweak a single property.
-# WARN: If you update this generator, you should also consider updating its parent
-# in res/meson.build
-frontier_script_bin_gen = generator(make_script_bin_sh,
-    arguments: [
-        '-i', relative_source_root / 'include',
-        '-i', relative_source_root / 'asm',
-        '-i', '.',
-        '--depfile', '@DEPFILE@',
-        '--enumproc', enumproc_exe.full_path(),
-        '--assembler', arm_none_eabi_gcc_exe.full_path(),
-        '--objcopy', arm_none_eabi_objcopy_exe.full_path(),
-        '@EXTRA_ARGS@',
-        '@INPUT@',
-    ],
-    depends: [
-        enumproc_exe,
-        c_consts_generators,
-        frontier_particles_narc[1],
-        text_banks,
-    ],
-    output: '@BASENAME@',
-    depfile: '@BASENAME@.d',
-)
 
 fr_script_target_name = 'fr_script.narc'
 fr_script_private_dir = relative_build_dir / fr_script_target_name + '.p'
@@ -37,23 +9,28 @@ fr_script_narc = custom_target('fr_script.narc',
         'fr_script.naix',
     ],
     input: [
-        frontier_script_bin_gen.process(files(
-            'frontier_scripts_battle_castle.s',
-            'frontier_scripts_battle_factory.s',
-            'frontier_scripts_battle_hall.s',
-            'frontier_scripts_battle_arcade.s',
-        ), extra_args: ['--out-dir', fr_script_private_dir]),
+        script_bin_gen.process(
+            files(
+                'frontier_scripts_battle_castle.s',
+                'frontier_scripts_battle_factory.s',
+                'frontier_scripts_battle_hall.s',
+                'frontier_scripts_battle_arcade.s',
+                'frontier_scripts_battle_tower_corridor.s',
+                'frontier_scripts_battle_tower_corridor_multi.s',
+                'frontier_scripts_battle_tower_battle_room.s',
+                'frontier_scripts_battle_tower_multi_battle_room.s',
+                'frontier_scripts_unknown_10.s',
+            ),
+            extra_args: ['--out-dir', fr_script_private_dir],
+            depends: [
+                frontier_particles_narc,
+                text_banks,
+            ],
+        ),
         copy_gen.process(files(
             'frontier_scripts_unused_04.bin',
             'frontier_scripts_unused_05.bin',
         )),
-        script_bin_gen.process(files(
-            'frontier_scripts_battle_tower_corridor.s',
-            'frontier_scripts_battle_tower_corridor_multi.s',
-            'frontier_scripts_battle_tower_battle_room.s',
-            'frontier_scripts_battle_tower_multi_battle_room.s',
-            'frontier_scripts_unknown_10.s',
-        ), extra_args: ['--out-dir', fr_script_private_dir]),
     ],
     command: [
         nitroarc_exe,

--- a/res/field/scripts/meson.build
+++ b/res/field/scripts/meson.build
@@ -1,34 +1,5 @@
 relative_build_dir = fs.relative_to(meson.current_build_dir(), meson.project_build_root())
 
-# NOTE: This is a functional copy of script_bin_gen, which is separated from the
-# base generator due to an additional dependency on headers generated for
-# events IDs. Meson unfortunately does not have a clean way to copy an existing
-# object and tweak a single property.
-# WARN: If you update this generator, you should also consider updating its parent
-# in res/meson.build
-field_script_bin_gen = generator(make_script_bin_sh,
-    arguments: [
-        '-i', relative_source_root / 'include',
-        '-i', relative_source_root / 'asm',
-        '-i', '.',
-        '--depfile', '@DEPFILE@',
-        '--enumproc', enumproc_exe.full_path(),
-        '--assembler', arm_none_eabi_gcc_exe.full_path(),
-        '--objcopy', arm_none_eabi_objcopy_exe.full_path(),
-        '@EXTRA_ARGS@',
-        '@INPUT@',
-    ],
-    depends: [
-        enumproc_exe,
-        text_banks,
-        c_consts_generators,
-        h_headers,
-        events_headers,
-    ],
-    output: '@BASENAME@',
-    depfile: '@BASENAME@.d',
-)
-
 scr_seq_target_name = 'scr_seq.narc'
 scr_seq_private_dir = relative_build_dir / scr_seq_target_name + '.p'
 
@@ -1164,9 +1135,13 @@ scr_seq_narc = custom_target('scr_seq.narc',
         'scr_seq.narc',
         'scr_seq.naix',
     ],
-    input: field_script_bin_gen.process(
+    input: script_bin_gen.process(
         scr_seq_files,
-        extra_args: ['--out-dir', scr_seq_private_dir]
+        extra_args: ['--out-dir', scr_seq_private_dir],
+        depends: [
+            events_headers,
+            text_banks,
+        ],
     ),
     command: [
         nitroarc_exe,

--- a/res/meson.build
+++ b/res/meson.build
@@ -93,17 +93,6 @@ npctrade_text_banks = npctrade_data[1]
 
 relative_source_root = fs.relative_to(meson.project_source_root(), meson.project_build_root())
 
-### DECOMPILED DATA DIRECTORIES ###
-# These subpaths are listed because the result of some build-rule inside them
-# is a dependency of some later build-rule.
-subdir('pokemon')
-subdir('trainers')
-subdir('items')
-subdir('graphics')
-subdir('moves')
-subdir('town_map')
-subdir('text')
-
 # Common generator for "scripting" files, i.e. field and battle scripts
 # NOTE: The members of the `depends` clause below will always be modified by the
 # postconf script to be order-only dependencies. This means that this generator
@@ -111,8 +100,6 @@ subdir('text')
 # *breaks* the dependency-chain if any of these files are edited. However, because
 # this generator produces a depfile, the build back-end will still see the correct
 # granular headers on which each input source file depends.
-# WARN: If you update this generator, you should also consider updating its child
-# in res/field/scripts/meson.build
 script_bin_gen = generator(make_script_bin_sh,
     arguments: [
         '-i', relative_source_root / 'include',
@@ -127,13 +114,23 @@ script_bin_gen = generator(make_script_bin_sh,
     ],
     depends: [
         enumproc_exe,
-        text_banks,
         c_consts_generators,
         h_headers,
     ],
     output: '@BASENAME@',
     depfile: '@BASENAME@.d',
 )
+
+### DECOMPILED DATA DIRECTORIES ###
+# These subpaths are listed because the result of some build-rule inside them
+# is a dependency of some later build-rule.
+subdir('pokemon')
+subdir('trainers')
+subdir('items')
+subdir('graphics')
+subdir('moves')
+subdir('town_map')
+subdir('text')
 
 subdir('battle')
 subdir('field')

--- a/res/moves/meson.build
+++ b/res/moves/meson.build
@@ -46,45 +46,24 @@ foreach move : move_consts
     endif
 endforeach
 
-# This generator is shared by both move-specific animations (in this directory)
-# and common animations (in the `battle/scripts/common_anims` directory).
-battle_anim_script_bin_gen = generator(make_script_bin_sh,
-    arguments: [
-        '-i', relative_source_root / 'include',
-        '-i', relative_source_root / 'asm',
-        '-i', '.',
-        '--depfile', '@DEPFILE@',
-        '--enumproc', enumproc_exe.full_path(),
-        '--assembler', arm_none_eabi_gcc_exe.full_path(),
-        '--objcopy', arm_none_eabi_objcopy_exe.full_path(),
-        '@EXTRA_ARGS@',
-        '@INPUT@',
-    ],
-    depends: [
-        enumproc_exe,
-        c_consts_generators,
-        h_headers,
-        battle_particles_narc[1],
-        anim_ncer_narc_files[1],
-        anim_nanr_narc_files[1],
-        anim_ncgr_narc_files[1],
-        anim_nclr_narc_files[1],
-    ],
-    output: '@BASENAME@',
-    depfile: '@BASENAME@.d',
-)
-
 relative_build_dir = fs.relative_to(meson.current_build_dir(), meson.project_build_root())
 
 anim_scripts_narc = custom_target('anim_scripts.narc',
     output: 'anim_scripts.narc',
-    input: battle_anim_script_bin_gen.process(
+    input: script_bin_gen.process(
         anim_script_srcs,
         extra_args: [
             '--out-dir', relative_build_dir / 'anim_scripts.narc.p',
             '--parent-dir',
         ],
         preserve_path_from: meson.current_source_dir(),
+        depends: [
+            battle_particles_narc,
+            anim_ncer_narc_files,
+            anim_nanr_narc_files,
+            anim_ncgr_narc_files,
+            anim_nclr_narc_files,
+        ],
     ),
     command: [
         nitroarc_exe,

--- a/subprojects/NitroSDK.wrap
+++ b/subprojects/NitroSDK.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/ntrtwl/NitroSDK.git
-revision = 996ce8522ce48a9852193ec572847cfe0219f29c
+revision = 4dcf3a45e54ed36d72700331084880e2be9a627c
 depth = 1
 directory = NitroSDK-4.2.30001
 

--- a/tools/dataproc/src/speciesproc.c
+++ b/tools/dataproc/src/speciesproc.c
@@ -721,7 +721,7 @@ static u32 get_height_decimeters(datanode_t dexdata) {
         datanode_t height_m = dp_objmemb(dexdata, "height_meters");
         datanode_t height_i = dp_objmemb(dexdata, "height_inches");
 
-        dp_error(&dexdata, "conflicting unit-systems given for species height; remove one before rebuilding");
+        dp_warn(&dexdata, "conflicting unit-systems given for species height; metric units will be used");
         dp_note(&height_m, "metric units defined here");
         dp_note(&height_i, "imperial units defined here");
     }
@@ -739,7 +739,7 @@ static u32 get_weight_hectograms(datanode_t dexdata, enum Species species) {
         datanode_t weight_m = dp_objmemb(dexdata, "weight_kilograms");
         datanode_t weight_i = dp_objmemb(dexdata, "weight_pounds");
 
-        dp_error(&dexdata, "conflicting unit-systems given for species weight; remove one before rebuilding");
+        dp_warn(&dexdata, "conflicting unit-systems given for species weight; metric units will be used");
         dp_note(&weight_m, "metric units defined here");
         dp_note(&weight_i, "imperial units defined here");
     }
@@ -905,7 +905,7 @@ static void emit_tutorables(datafile_t *df, size_t i) {
         }
 
         if (found) tutorset[idx / 8] |= (u8)(1 << (idx % 8));
-        else dp_error(&move, "'%s' is not available from any move tutors", move_s);
+        else dp_warn(&move, "'%s' is not available from any move tutors and will be skipped", move_s);
     }
 
     for (size_t i = 0; i < tutorset_size; i++) fprintf(*f_tutor_sets, "0x%02X, ", tutorset[i]);


### PR DESCRIPTION
## Update to `meson` 1.12.0

Downstream repositories must run `make update` after pulling this change-set, as it requires a change to the SDK's build: ntrtwl/NitroSDK@4dcf3a45e54ed36d72700331084880e2be9a627c

This update also includes a bug-fix: the name for a `depfile` now respects `preserve_path_from`, where it previously did not: mesonbuild/meson#15762

### New Feature: `depends` clauses in the script compilers

As of 1.12.0, Meson allows specifying additional dependencies for `generator`s during their `.process` methods. This allows us to get rid of some custom `generator`s that we created which were essentially copies of other `generator`s, but with additional dependencies attached to them during instantiation.

There is now exactly one script-compiler: `script_bin_gen`. Due to the placement of byte-code scripts used for animations (for moves and Pokemon in-battle), it cannot depend on `text_banks` itself. Instead, this dependency is added only to the compilers which need it.

Additionally, the various custom script-compilers are now defunct, so they have been removed in favor of using the primary compiler and specifying their additional dependencies as-needed.

### New Feature: True warnings in `dataproc`

As of 1.12.0, Meson will now write all output made to `stderr` by executed processes, rather than only surfacing it when the process terminates with a non-zero exit code.

This lets us properly surface warnings in `dataproc` implementations. To illustrate, I made the following changes to `res/pokemon/bulbasaur/data.json`:

```diff
diff --git a/res/pokemon/bulbasaur/data.json b/res/pokemon/bulbasaur/data.json
index 0242d8e605..e392f839e7 100644
--- a/res/pokemon/bulbasaur/data.json
+++ b/res/pokemon/bulbasaur/data.json
@@ -85,7 +85,8 @@
             "MOVE_SNORE",
             "MOVE_SYNTHESIS",
             "MOVE_SEED_BOMB",
-            "MOVE_KNOCK_OFF"
+            "MOVE_KNOCK_OFF",
+            "MOVE_GIGA_DRAIN"
         ],
         "egg_moves": [
             "MOVE_LIGHT_SCREEN",
@@ -116,7 +117,9 @@
         "type": "FOOTPRINT_TYPE_CUTE"
     },
     "pokedex_data": {
+        "height_meters": 0.7,
         "height_inches": 28,
+        "weight_kilograms": 6.9,
         "weight_pounds": 15.2,
         "body_shape": "SHAPE_QUADRUPED",
         "trainer_scale_f": 272,
```

This causes the build to emit the following output and produce a match, as expected:

```
> make
subprojects/meson-1.12.0/meson.py configure build -Dgdb_debugging=false -Dlogging_enabled=false
ninja -C build pokeplatinum.us.nds
ninja: Entering directory `build'
[  7% 3/41] Generating res/pokemon/species_data with a custom command (wrapped by meson to set env)
/home/rachel/code/git/pokeplatinum/meson-1.12.0/res/pokemon/bulbasaur/data.json:119:21: warning: .pokedex_data: conflicting unit-systems given for species height; metric units will be used
  119 |     "pokedex_data": {
      |                     ^
/home/rachel/code/git/pokeplatinum/meson-1.12.0/res/pokemon/bulbasaur/data.json:120:26: note: .pokedex_data.height_meters: metric units defined here
  120 |         "height_meters": 0.7,
      |                          ^^^
/home/rachel/code/git/pokeplatinum/meson-1.12.0/res/pokemon/bulbasaur/data.json:121:26: note: .pokedex_data.height_inches: imperial units defined here
  121 |         "height_inches": 28,
      |                          ^^
/home/rachel/code/git/pokeplatinum/meson-1.12.0/res/pokemon/bulbasaur/data.json:119:21: warning: .pokedex_data: conflicting unit-systems given for species weight; metric units will be used
  119 |     "pokedex_data": {
      |                     ^
/home/rachel/code/git/pokeplatinum/meson-1.12.0/res/pokemon/bulbasaur/data.json:122:29: note: .pokedex_data.weight_kilograms: metric units defined here
  122 |         "weight_kilograms": 6.9,
      |                             ^^^
/home/rachel/code/git/pokeplatinum/meson-1.12.0/res/pokemon/bulbasaur/data.json:123:26: note: .pokedex_data.weight_pounds: imperial units defined here
  123 |         "weight_pounds": 15.2,
      |                          ^^^^
/home/rachel/code/git/pokeplatinum/meson-1.12.0/res/pokemon/bulbasaur/data.json:89:13: warning: .learnset.by_tutor[6]: 'MOVE_GIGA_DRAIN' is not available from any move tutors and will be skipped
   89 |             "MOVE_GIGA_DRAIN"
      |             ^^^^^^^^^^^^^^^^^

[100% 41/41] Generating pokeplatinum.us.nds with a custom command
subprojects/meson-1.12.0/meson.py test -C build
ninja: Entering directory `/home/rachel/code/git/pokeplatinum/meson-1.12.0/build'
ninja: no work to do.
1/4 pokeplatinum:SBIN Checksums - Shared              OK              0.03s
2/4 pokeplatinum:SBIN Checksums - For Revision        OK              0.02s
3/4 pokeplatinum:Filesystem Checksums                 OK              0.07s
4/4 pokeplatinum:ROM Checksum                         OK              0.09s

Ok:                4
Fail:              0

Full log written to /home/rachel/code/git/pokeplatinum/meson-1.12.0/build/meson-logs/testlog.txt
```