### PR TITLE
meson: Remove 'res' from public includes

### DIFF
--- a/include/applications/title_screen.h
+++ b/include/applications/title_screen.h
@@ -1,0 +1,8 @@
+#ifndef POKEPLATINUM_APPLICATIONS_TITLE_SCREEN_H
+#define POKEPLATINUM_APPLICATIONS_TITLE_SCREEN_H
+
+#include "overlay_manager.h"
+
+extern const ApplicationManagerTemplate gTitleScreenAppTemplate;
+
+#endif // POKEPLATINUM_APPLICATIONS_TITLE_SCREEN_H

--- a/include/game_opening/const_ov77_021D742C.h
+++ b/include/game_opening/const_ov77_021D742C.h
@@ -1,8 +1,0 @@
-#ifndef POKEPLATINUM_CONST_OV77_021D742C_H
-#define POKEPLATINUM_CONST_OV77_021D742C_H
-
-#include "overlay_manager.h"
-
-extern const ApplicationManagerTemplate gTitleScreenAppTemplate;
-
-#endif // POKEPLATINUM_CONST_OV77_021D742C_H

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ fs = import('fs')
 ############################################################
 ###                    INCLUDE PATHS                     ###
 ############################################################
-public_includes = include_directories('include', 'asm', 'res')
+public_includes = include_directories('include', 'asm')
 toplevel_includes = include_directories('.')
 
 

--- a/src/applications/title_screen.c
+++ b/src/applications/title_screen.c
@@ -1,4 +1,4 @@
-#include "text/bank/title_screen.h"
+#include "applications/title_screen.h"
 
 #include <nitro/gx/g3.h>
 #include <nitro/types.h>
@@ -6,8 +6,6 @@
 #include "constants/graphics.h"
 #include "constants/heap.h"
 #include "constants/species.h"
-
-#include "game_opening/const_ov77_021D742C.h"
 
 #include "bg_window.h"
 #include "brightness_controller.h"
@@ -34,6 +32,7 @@
 #include "unk_0202419C.h"
 
 #include "res/graphics/title_screen/titledemo.naix"
+#include "res/text/bank/title_screen.h"
 
 FS_EXTERN_OVERLAY(game_opening);
 FS_EXTERN_OVERLAY(main_menu);

--- a/src/battle/healthbox.c
+++ b/src/battle/healthbox.c
@@ -10,7 +10,6 @@
 #include "constants/string.h"
 
 #include "battle/battle_system.h"
-#include "graphics/battle/sprites.naix"
 
 #include "assert.h"
 #include "bg_window.h"
@@ -31,6 +30,7 @@
 #include "text.h"
 #include "unk_0208C098.h"
 
+#include "res/graphics/battle/sprites.naix"
 #include "res/text/bank/battle_strings.h"
 
 #define HEALTHBOX_SCROLL_SPEED      24

--- a/src/cutscenes/end_credits/strings.c
+++ b/src/cutscenes/end_credits/strings.c
@@ -5,8 +5,6 @@
 
 #include "constants/graphics.h"
 
-#include "text/bank/end_credits.h"
-
 #include "bg_window.h"
 #include "font.h"
 #include "heap.h"
@@ -15,6 +13,8 @@
 #include "sys_task.h"
 #include "sys_task_manager.h"
 #include "text.h"
+
+#include "res/text/bank/end_credits.h"
 
 enum EndCreditsStringsState {
     END_CREDITS_STRINGS_STATE_PRINTING = 0,

--- a/src/field_system.c
+++ b/src/field_system.c
@@ -9,8 +9,8 @@
 #include "generated/signpost_commands.h"
 
 #include "applications/poketch/poketch_system.h"
+#include "applications/title_screen.h"
 #include "field/field_system_sub2_t.h"
-#include "game_opening/const_ov77_021D742C.h"
 #include "overlay005/field_control.h"
 #include "overlay005/fieldmap.h"
 #include "overlay005/map_name_popup.h"

--- a/src/main_menu/gba_migrator.c
+++ b/src/main_menu/gba_migrator.c
@@ -11,7 +11,7 @@
 #include "constants/pokemon.h"
 #include "constants/species.h"
 
-#include "game_opening/const_ov77_021D742C.h"
+#include "applications/title_screen.h"
 #include "main_menu/gba_convert_string.h"
 #include "main_menu/gba_player.h"
 #include "main_menu/gba_pokemon.h"

--- a/src/main_menu/main_menu.c
+++ b/src/main_menu/main_menu.c
@@ -8,7 +8,7 @@
 #include "generated/genders.h"
 #include "generated/text_banks.h"
 
-#include "game_opening/const_ov77_021D742C.h"
+#include "applications/title_screen.h"
 #include "main_menu/application_template.h"
 #include "main_menu/distribution_cartridge.h"
 #include "main_menu/main_menu_util.h"

--- a/src/main_menu/mystery_gift_app.c
+++ b/src/main_menu/mystery_gift_app.c
@@ -9,7 +9,7 @@
 #include "constants/string.h"
 #include "generated/text_banks.h"
 
-#include "game_opening/const_ov77_021D742C.h"
+#include "applications/title_screen.h"
 #include "main_menu/distribution_cartridge.h"
 #include "main_menu/main_menu_util.h"
 #include "main_menu/ov97_0222D04C.h"

--- a/src/main_menu/ranger_link.c
+++ b/src/main_menu/ranger_link.c
@@ -6,7 +6,7 @@
 #include "constants/graphics.h"
 #include "constants/versions.h"
 
-#include "game_opening/const_ov77_021D742C.h"
+#include "applications/title_screen.h"
 #include "main_menu/main_menu_util.h"
 #include "main_menu/ov97_02232DC8.h"
 #include "main_menu/ov97_02233408.h"

--- a/src/overlay098/ov98_02246C20.c
+++ b/src/overlay098/ov98_02246C20.c
@@ -6,7 +6,7 @@
 
 #include "struct_defs/struct_02089438.h"
 
-#include "game_opening/const_ov77_021D742C.h"
+#include "applications/title_screen.h"
 #include "gts_application/networking.h"
 #include "overlay065/ov65_0222DCE0.h"
 #include "overlay098/ov98_022471C8.h"

--- a/src/overlay104/frontier_scenes.c
+++ b/src/overlay104/frontier_scenes.c
@@ -5,7 +5,6 @@
 #include "constants/battle_frontier.h"
 #include "generated/text_banks.h"
 
-#include "graphics/frontier/backgrounds/frontier_backgrounds.naix"
 #include "overlay104/ov104_0223D9E4.h"
 #include "overlay104/wfc_facility_selector_helpers.h"
 
@@ -14,6 +13,7 @@
 #include "heap.h"
 
 #include "res/field/frontier_scripts/fr_script.naix"
+#include "res/graphics/frontier/backgrounds/frontier_backgrounds.naix"
 #include "res/sound/pl_sound_data.naix"
 
 typedef void (*FrontierSceneSetupDestroyFunc)(FrontierGraphics *, void **);


### PR DESCRIPTION
This functionally enforces the use of `res` as the leading-prefix for any generated asset-files.